### PR TITLE
Updated Stream paging + add local/federated calls

### DIFF
--- a/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
+++ b/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		553CFB402952C26000F3EB69 /* AccountItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553CFB3F2952C26000F3EB69 /* AccountItemView.swift */; };
 		55539B222984CA6F00B2029D /* Array+RemoteEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55539B212984CA6F00B2029D /* Array+RemoteEmoji.swift */; };
 		557DD954297DF58E003C964C /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557DD953297DF58E003C964C /* FeedViewModel.swift */; };
+		559A90F2299CDD6300959E12 /* FeedSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559A90F1299CDD6300959E12 /* FeedSelectionView.swift */; };
 		55ACC1E02917618F0046363F /* TootSDK_DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55ACC1DF2917618F0046363F /* TootSDK_DemoApp.swift */; };
 		55ACC1E4291761910046363F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55ACC1E3291761910046363F /* Assets.xcassets */; };
 		55ACC1E7291761910046363F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55ACC1E6291761910046363F /* Preview Assets.xcassets */; };
@@ -44,6 +45,7 @@
 		553CFB3F2952C26000F3EB69 /* AccountItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountItemView.swift; sourceTree = "<group>"; };
 		55539B212984CA6F00B2029D /* Array+RemoteEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+RemoteEmoji.swift"; sourceTree = "<group>"; };
 		557DD953297DF58E003C964C /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
+		559A90F1299CDD6300959E12 /* FeedSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSelectionView.swift; sourceTree = "<group>"; };
 		55ACC1DC2917618F0046363F /* SwiftUI-Toot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftUI-Toot.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55ACC1DF2917618F0046363F /* TootSDK_DemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TootSDK_DemoApp.swift; sourceTree = "<group>"; };
 		55ACC1E3291761910046363F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 			children = (
 				55B8B1732917627D00339479 /* FeedView.swift */,
 				557DD953297DF58E003C964C /* FeedViewModel.swift */,
+				559A90F1299CDD6300959E12 /* FeedSelectionView.swift */,
 			);
 			path = Feed;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 				55B8B1742917627D00339479 /* FeedView.swift in Sources */,
 				553CFB3B2952BD0200F3EB69 /* ButtonView.swift in Sources */,
 				550CF66E2931F9A000D07EA0 /* UserAccountView.swift in Sources */,
+				559A90F2299CDD6300959E12 /* FeedSelectionView.swift in Sources */,
 				55B8B1722917620C00339479 /* MakePostView.swift in Sources */,
 				55539B222984CA6F00B2029D /* Array+RemoteEmoji.swift in Sources */,
 				553CFB402952C26000F3EB69 /* AccountItemView.swift in Sources */,

--- a/Examples/swiftui-toot/TootSDK-Demo/TootSDK_DemoApp.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/TootSDK_DemoApp.swift
@@ -22,7 +22,7 @@ struct TootSDK_DemoApp: App {
                         Label("Make Post", systemImage: "plus.message")
                     }
                 
-                FeedView()
+                FeedSelectionView()
                     .tabItem {
                         Label("Browse Feed", systemImage: "list.bullet.rectangle")
                     }

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
@@ -1,0 +1,43 @@
+//
+//  FeedSelectionView.swift
+//  SwiftUI-Toot
+//
+//  Created by dave on 15/02/23.
+//
+
+import SwiftUI
+
+enum SelectionOptions: String, CaseIterable {
+    case home
+    case local
+    case federated
+}
+
+struct FeedSelectionView: View {
+    
+    @State private var selection: SelectionOptions = .home
+    
+    @StateObject var timeLineHomeViewModel = FeedViewModel(streamType: .timeLineHome)
+    @StateObject var timeLineLocalViewModel = FeedViewModel(streamType: .timeLineLocal)
+    @StateObject var timeLineFederatedViewModel = FeedViewModel(streamType: .timeLineFederated)
+    
+    var body: some View {
+        VStack {
+            Picker("Select your feed", selection: $selection) {
+                ForEach(SelectionOptions.allCases, id: \.self) {
+                    Text($0.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            
+            switch selection {
+            case .home:
+                FeedView(viewModel: timeLineHomeViewModel)
+            case .local:
+                FeedView(viewModel: timeLineLocalViewModel)
+            case .federated:
+                FeedView(viewModel: timeLineFederatedViewModel)
+            }
+        }
+    }
+}

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedView.swift
@@ -10,11 +10,11 @@ import TootSDK
 
 struct FeedView: View {
     @EnvironmentObject var tootManager: TootManager
-    @StateObject var viewModel = FeedViewModel()
+    @ObservedObject var viewModel: FeedViewModel
     
     @State var name: String = ""
     @State var path: NavigationPath = NavigationPath()
-    
+            
     var body: some View {
         NavigationStack(path: $path) {
             List(viewModel.feedPosts, id: \.self) { feedPost in
@@ -36,7 +36,7 @@ struct FeedView: View {
         }
         .task {
             await viewModel.setManager(tootManager)
-            try? await viewModel.refresh()
+            try? await viewModel.refreshIfNoPosts()
         }
         .refreshable {
             try? await viewModel.refresh()
@@ -56,6 +56,6 @@ struct FeedView: View {
 
 struct FeedView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView()
+        FeedView(viewModel: FeedViewModel(streamType: .timeLineHome))
     }
 }

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -23,9 +23,42 @@ public extension TootClient {
         return PagedResult(result: decoded, info: info)
     }
     
+    /// Retrieves the user's home timeline
+    /// - Parameters:
+    ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
+    ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    /// - Returns: a PagedResult containing the posts retrieved
     func getHomeTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "timelines", "home"])
+            $0.method = .get
+            $0.query = getQueryParams(pageInfo, limit: limit)
+        }
+        return try await getPosts(req, pageInfo, limit)
+    }
+    
+    /// Retrieves the user's local timeline
+    /// - Parameters:
+    ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
+    ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    /// - Returns: a PagedResult containing the posts retrieved
+    func getLocalTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "timelines", "public"])
+            $0.method = .get
+            $0.query = getQueryParams(pageInfo, limit: limit) + [URLQueryItem(name: "local", value: "true")]
+        }
+        return try await getPosts(req, pageInfo, limit)
+    }
+    
+    /// Retrieves the user's federated timeline
+    /// - Parameters:
+    ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
+    ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    /// - Returns: a PagedResult containing the posts retrieved
+    func getFederatedTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "timelines", "public"])
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }

--- a/Sources/TootSDK/TootStream.swift
+++ b/Sources/TootSDK/TootStream.swift
@@ -117,10 +117,11 @@ public actor TootDataStream {
 // MARK: - Stream creation
 
 extension TootDataStream {
+    
     /// Provides an async stream of updates for the given stream
     /// - Parameter stream: the stream type to update
     /// - Returns: async stream of values
-    public func stream(_ stream: PostTootStreams, _ pageInfo: PagedInfo? = nil) throws -> AsyncStream<[Post]> {
+    public func stream(_ stream: PostTootStreams, _ pageInfo: PagedInfo? = nil) throws -> AsyncStream<[Post]> { // swiftlint:disable:this cyclomatic_complexity function_body_length
         if let streamHolder = cachedStreams[stream] as? TootEndpointStream<PostTootStreams> {
             return streamHolder.stream
         }
@@ -132,7 +133,7 @@ extension TootDataStream {
             newHolder.refresh = {[weak self, weak newHolder] in
                 if let items = try await self?.client.getHomeTimeline(newHolder?.pageInfo) {
                     newHolder?.internalContinuation?.yield(items.result)
-                    
+                                        
                     // Update PagedInfo
                     let minId = items.result.first?.id
                     newHolder?.pageInfo = PagedInfo(minId: minId)


### PR DESCRIPTION
This PR:

* Fixes our streaming function so that it updates the PageInfo object with the latest results from the API. This means each successive refresh will retrieve only new data.

* Adds Local and Federated timelines GET calls

* Updates the SwiftUI demo app so that it has a segmented picker to switch between home/local/federated timelines