### PR TITLE
Fix - Use the pageInfo in TootStream when first setting up the stream

### DIFF
--- a/Sources/TootSDK/TootStream.swift
+++ b/Sources/TootSDK/TootStream.swift
@@ -127,6 +127,7 @@ extension TootDataStream {
         }
         
         let newHolder = TootEndpointStream(stream)
+        newHolder.pageInfo = pageInfo
         
         switch stream {
         case .timeLineHome:


### PR DESCRIPTION
This is a 1-liner fix; we have just never been using the PageInfo provided, to TootStream 🤦 

This addresses #92 