### PR TITLE
Add support for hashtag timelines and only_media timeline filter

### DIFF
--- a/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
@@ -18,8 +18,8 @@ struct FeedSelectionView: View {
     @State private var selection: SelectionOptions = .home
     
     @StateObject var timeLineHomeViewModel = FeedViewModel(streamType: .timeLineHome)
-    @StateObject var timeLineLocalViewModel = FeedViewModel(streamType: .timeLineLocal)
-    @StateObject var timeLineFederatedViewModel = FeedViewModel(streamType: .timeLineFederated)
+    @StateObject var timeLineLocalViewModel = FeedViewModel(streamType: .timeLineLocal(onlyMedia: nil))
+    @StateObject var timeLineFederatedViewModel = FeedViewModel(streamType: .timeLineFederated(onlyMedia: nil))
     
     var body: some View {
         VStack {

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/Feed/FeedSelectionView.swift
@@ -18,8 +18,8 @@ struct FeedSelectionView: View {
     @State private var selection: SelectionOptions = .home
     
     @StateObject var timeLineHomeViewModel = FeedViewModel(streamType: .timeLineHome)
-    @StateObject var timeLineLocalViewModel = FeedViewModel(streamType: .timeLineLocal(onlyMedia: nil))
-    @StateObject var timeLineFederatedViewModel = FeedViewModel(streamType: .timeLineFederated(onlyMedia: nil))
+    @StateObject var timeLineLocalViewModel = FeedViewModel(streamType: .timeLineLocal())
+    @StateObject var timeLineFederatedViewModel = FeedViewModel(streamType: .timeLineFederated())
     
     var body: some View {
         VStack {

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/SearchView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/SearchView.swift
@@ -31,7 +31,7 @@ struct SearchView: View {
                     Section("Hashtags") {
                         ForEach(searchResults.hashtags, id: \.name) { hashtag in
                             NavigationLink {
-                                FeedView(viewModel: FeedViewModel(streamType: .timeLineHashtag(tag: hashtag.name, anyTags: nil, allTags: nil, noneTags: nil, onlyMedia: nil, locality: nil)))
+                                FeedView(viewModel: FeedViewModel(streamType: .timeLineHashtag(tag: hashtag.name)))
                             } label: {
                                 Text(hashtag.name)
                             }

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/SearchView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/SearchView.swift
@@ -30,7 +30,11 @@ struct SearchView: View {
                     }
                     Section("Hashtags") {
                         ForEach(searchResults.hashtags, id: \.name) { hashtag in
-                            Text(hashtag.name)
+                            NavigationLink {
+                                FeedView(viewModel: FeedViewModel(streamType: .timeLineHashtag(tag: hashtag.name, anyTags: nil, allTags: nil, noneTags: nil, onlyMedia: nil, locality: nil)))
+                            } label: {
+                                Text(hashtag.name)
+                            }
                         }
                     }
                 }
@@ -44,7 +48,7 @@ struct SearchView: View {
             }
         }
     }
-
+    
     private func performSearch() async {
         guard let client = tootManager.currentClient else { return }
         do {

--- a/Sources/TootSDK/HTTP/TimelineLocality.swift
+++ b/Sources/TootSDK/HTTP/TimelineLocality.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//
+//  Created by Dale Price on 3/1/23.
+//
+
+import Foundation
+
+/// Specifies whether a timeline request should be restricted to local or remote statuses
+public enum TimelineLocality: Codable, Sendable {
+    /// Return only local statuses
+    case local
+    
+    /// Return only remote statuses
+    case remote
+}

--- a/Sources/TootSDK/HTTP/TimelineLocality.swift
+++ b/Sources/TootSDK/HTTP/TimelineLocality.swift
@@ -13,4 +13,7 @@ public enum TimelineLocality: Codable, Sendable {
     
     /// Return only remote statuses
     case remote
+    
+    /// Return local and remote statuses (do not filter by origin)
+    case all
 }

--- a/Sources/TootSDK/TootClient/TootClient+Request.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Request.swift
@@ -16,7 +16,7 @@ extension TootClient {
         return url
     }
     
-    internal func getQueryParams(_ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil) -> [URLQueryItem] {
+    internal func getQueryParams(_ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil) -> [URLQueryItem] {
         var queryParameters = [URLQueryItem]()
         
         if let maxId = pageInfo?.maxId {
@@ -37,6 +37,16 @@ extension TootClient {
 
         if let offset = offset {
             queryParameters.append(.init(name: "offset", value: String(offset)))
+        }
+        
+        if onlyMedia == true {
+            queryParameters.append(.init(name: "only_media", value: "true"))
+        }
+        
+        if locality == .local {
+            queryParameters.append(.init(name: "local", value: "true"))
+        } else if locality == .remote {
+            queryParameters.append(.init(name: "remote", value: "true"))
         }
         return queryParameters
     }

--- a/Sources/TootSDK/TootClient/TootClient+Request.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Request.swift
@@ -39,15 +39,24 @@ extension TootClient {
             queryParameters.append(.init(name: "offset", value: String(offset)))
         }
         
-        if onlyMedia == true {
-            queryParameters.append(.init(name: "only_media", value: "true"))
+        if let onlyMedia = onlyMedia {
+            queryParameters.append(.init(name: "only_media", value: String(onlyMedia)))
         }
         
-        if locality == .local {
-            queryParameters.append(.init(name: "local", value: "true"))
-        } else if locality == .remote {
-            queryParameters.append(.init(name: "remote", value: "true"))
+        if let locality = locality {
+            switch locality {
+            case .local:
+                queryParameters.append(.init(name: "local", value: "true"))
+            case .remote:
+                queryParameters.append(.init(name: "remote", value: "true"))
+            case .all:
+                queryParameters.append(contentsOf: [
+                    .init(name: "local", value: "false"),
+                    .init(name: "remote", value: "false")
+                ])
+            }
         }
+        
         return queryParameters
     }
 

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -41,12 +41,13 @@ public extension TootClient {
     /// - Parameters:
     ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
     ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    ///   - onlyMedia: Return only statuses with media attachments
     /// - Returns: a PagedResult containing the posts retrieved
-    func getLocalTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
+    func getLocalTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil, onlyMedia: Bool? = nil) async throws -> PagedResult<[Post]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "timelines", "public"])
             $0.method = .get
-            $0.query = getQueryParams(pageInfo, limit: limit) + [URLQueryItem(name: "local", value: "true")]
+            $0.query = getQueryParams(pageInfo, limit: limit, onlyMedia: onlyMedia, locality: .local)
         }
         return try await getPosts(req, pageInfo, limit)
     }
@@ -55,12 +56,50 @@ public extension TootClient {
     /// - Parameters:
     ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
     ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    ///   - onlyMedia: Return only statuses with media attachments
     /// - Returns: a PagedResult containing the posts retrieved
-    func getFederatedTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
+    func getFederatedTimeline(_ pageInfo: PagedInfo? = nil, limit: Int? = nil, onlyMedia: Bool? = nil) async throws -> PagedResult<[Post]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "timelines", "public"])
             $0.method = .get
-            $0.query = getQueryParams(pageInfo, limit: limit)
+            $0.query = getQueryParams(pageInfo, limit: limit, onlyMedia: onlyMedia)
+        }
+        return try await getPosts(req, pageInfo, limit)
+    }
+    
+    /// Retrieves public statuses containing the given hashtag
+    /// - Parameters:
+    ///   - tag: The name of the hashtag, not including the `#` symbol
+    ///   - anyTags: Return statuses that contain any of these additional tags
+    ///   - allTags: Return statuses that contain all of these additional tags
+    ///   - noneTags: Return statuses that contain none of these additional tags
+    ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
+    ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    ///   - onlyMedia: Return only statuses with media attachments
+    ///   - locality: Whether to return only local or only remote statuses (optional, returns both if not specified)
+    /// - Returns: a PagedResult containing the posts retrieved
+    func getHashtagTimeline(tag: String, anyTags: [String]? = nil, allTags: [String]? = nil, noneTags: [String]? = nil, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil) async throws -> PagedResult<[Post]> {
+        var query = getQueryParams(pageInfo, limit: limit, onlyMedia: onlyMedia, locality: locality)
+        if let anyTags = anyTags {
+            for tag in anyTags {
+                query.append(.init(name: "any[]", value: tag))
+            }
+        }
+        if let allTags = allTags {
+            for tag in allTags {
+                query.append(.init(name: "all[]", value: tag))
+            }
+        }
+        if let noneTags = noneTags {
+            for tag in noneTags {
+                query.append(.init(name: "none[]", value: tag))
+            }
+        }
+        
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "timelines", "tag", tag])
+            $0.method = .get
+            $0.query = query
         }
         return try await getPosts(req, pageInfo, limit)
     }

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -76,7 +76,7 @@ public extension TootClient {
     ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
     ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
     ///   - onlyMedia: Return only statuses with media attachments
-    ///   - locality: Whether to return only local or only remote statuses (optional, returns both if not specified)
+    ///   - locality: Whether to return only local, only remote statuses, or explicitly not filter by source (optional, if not specified, uses Mastodon default of not filtering)
     /// - Returns: a PagedResult containing the posts retrieved
     func getHashtagTimeline(tag: String, anyTags: [String]? = nil, allTags: [String]? = nil, noneTags: [String]? = nil, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil) async throws -> PagedResult<[Post]> {
         var query = getQueryParams(pageInfo, limit: limit, onlyMedia: onlyMedia, locality: locality)

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -81,19 +81,13 @@ public extension TootClient {
     func getHashtagTimeline(tag: String, anyTags: [String]? = nil, allTags: [String]? = nil, noneTags: [String]? = nil, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil) async throws -> PagedResult<[Post]> {
         var query = getQueryParams(pageInfo, limit: limit, onlyMedia: onlyMedia, locality: locality)
         if let anyTags = anyTags {
-            for tag in anyTags {
-                query.append(.init(name: "any[]", value: tag))
-            }
+            query.append(contentsOf: anyTags.map({ URLQueryItem(name: "any[]", value: $0) }))
         }
         if let allTags = allTags {
-            for tag in allTags {
-                query.append(.init(name: "all[]", value: tag))
-            }
+            query.append(contentsOf: allTags.map({ URLQueryItem(name: "all[]", value: $0) }))
         }
         if let noneTags = noneTags {
-            for tag in noneTags {
-                query.append(.init(name: "none[]", value: tag))
-            }
+            query.append(contentsOf: noneTags.map({ URLQueryItem(name: "none[]", value: $0) }))
         }
         
         let req = HTTPRequestBuilder {

--- a/Sources/TootSDK/TootStream.swift
+++ b/Sources/TootSDK/TootStream.swift
@@ -18,13 +18,13 @@ public enum PostTootStreams: Hashable, Sendable {
     case timeLineHome
     
     /// A stream of the user's local timeline
-    case timeLineLocal(onlyMedia: Bool?)
+    case timeLineLocal(onlyMedia: Bool? = nil)
     
     /// A stream of the user's federated timeline
-    case timeLineFederated(onlyMedia: Bool?)
+    case timeLineFederated(onlyMedia: Bool? = nil)
     
     /// A stream of a hashtag timeline with the given options
-    case timeLineHashtag(tag: String, anyTags: [String]?, allTags: [String]?, noneTags: [String]?, onlyMedia: Bool?, locality: TimelineLocality?)
+    case timeLineHashtag(tag: String, anyTags: [String]? = nil, allTags: [String]? = nil, noneTags: [String]? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil)
 
     /// A stream of the user's favourite posts
     case favourites

--- a/Sources/TootSDK/TootStream.swift
+++ b/Sources/TootSDK/TootStream.swift
@@ -24,6 +24,8 @@ public enum PostTootStreams: Hashable, Sendable {
     case timeLineFederated(onlyMedia: Bool? = nil)
     
     /// A stream of a hashtag timeline with the given options
+    ///
+    /// For an explanation of the parameters, see ``TootClient/getHashtagTimeline(tag:anyTags:allTags:noneTags:_:limit:onlyMedia:locality:)``
     case timeLineHashtag(tag: String, anyTags: [String]? = nil, allTags: [String]? = nil, noneTags: [String]? = nil, onlyMedia: Bool? = nil, locality: TimelineLocality? = nil)
 
     /// A stream of the user's favourite posts


### PR DESCRIPTION
This adds support for the `/api/v1/timelines/tag/:hashtag` endpoint including the parameters to add or exclude additional tags. For my use case I also needed to use the `only_media` parameter, so I went ahead and added support for that to the local and federated timelines as well, hopefully that’s ok but I can break it out as a separate PR if needed.

For local/remote filtering I added the `TimelineLocality` enum which I thought seemed more swifty than the separate `local` and `remote` params that the Mastodon API provides (unless I’m misunderstanding something, I don’t think it makes any sense to be able to make a request filtered by local-only *and* remote-only at the same time).

To support all this in `TootStream`, I added the extra parameters as associated values on the relevant enum cases because that made the most sense to me, but let me know if you’d prefer a different way of handling them.

I also added a demo of this to the sample app – you can tap a hashtag in the search results to view the timeline for it.