### PR TITLE
API to update media attachment

### DIFF
--- a/Sources/TootSDK/Models/UpdateMediaAttachmentParams.swift
+++ b/Sources/TootSDK/Models/UpdateMediaAttachmentParams.swift
@@ -1,0 +1,30 @@
+// Created by Łukasz Rutkowski on 05/03/2023.
+// Copyright (c) 2023. All rights reserved.
+
+import Foundation
+
+public struct UpdateMediaAttachmentParams: Codable, Sendable {
+
+    public init(description: String? = nil, focus: String? = nil) {
+        self.thumbnail = nil
+        self.thumbnailMimeType = nil
+        self.description = description
+        self.focus = focus
+    }
+
+    public init(thumbnail: Data, thumbnailMimeType: String, description: String? = nil, focus: String? = nil) {
+        self.thumbnail = thumbnail
+        self.thumbnailMimeType = thumbnailMimeType
+        self.description = description
+        self.focus = focus
+    }
+
+    /// The custom thumbnail of the media to be attached, encoded using multipart form data.
+    public let thumbnail: Data?
+    /// The mime type of thumbnail.
+    public let thumbnailMimeType: String?
+    /// A plain-text description of the media, for accessibility purposes.
+    public let description: String?
+    /// Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0
+    public let focus: String?
+}


### PR DESCRIPTION
https://docs.joinmastodon.org/methods/media/#update
https://api.pleroma.social/#operation/MediaController.update

Because mime type is only necessary when updating thumbnail I decided to provide 2 separate initializers for params. First skips thumbnail and second makes it required together with mime type. It might be more inconvenient if someone would want to update thumbnail only conditionally, but we are preventing situation where someone passes it without mime type.