### PR TITLE
Make attachment meta focus coordinates optional

### DIFF
--- a/Sources/TootSDK/Models/MediaAttachment.swift
+++ b/Sources/TootSDK/Models/MediaAttachment.swift
@@ -83,8 +83,8 @@ public extension MediaAttachment {
 }
 
 public struct AttachmentMetaFocus: Codable, Hashable, Sendable {
-    public var x: Double
-    public var y: Double
+    public var x: Double?
+    public var y: Double?
 }
 
 public extension AttachmentMetaFocus {


### PR DESCRIPTION
Encountered post that has missing `y` coordinate: https://darkfriend.social/@hybridhavoc/110027606492965987