### PR TITLE
fix "no UISCene configuration directory" warning

### DIFF
--- a/Examples/swiftui-toot/SwiftUI-Toot-Info.plist
+++ b/Examples/swiftui-toot/SwiftUI-Toot-Info.plist
@@ -15,5 +15,12 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 </dict>
 </plist>

--- a/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
+++ b/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
@@ -405,7 +405,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SwiftUI-Toot-Info.plist";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -435,7 +434,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SwiftUI-Toot-Info.plist";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
When running the SwiftuUI-Toot example, the Xcode console shows this warning right in the beginning:

Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")

The warning is removed by adding a UISceneConfigurations key to info.plist as described here:

https://stackoverflow.com/questions/74805019/info-plist-contained-no-uiscene-configuration-dictionary-looking-for-configurat

Note that the parent UIApplicationSceneManifest key and UIApplicationSupportsMultipleScenes sibling key are already visible in the Xcode info display but show up in info.plist after adding the UISceneConfigurations key.