### PR TITLE
PostEdit implements Hashable

### DIFF
--- a/Sources/TootSDK/Models/Emoji.swift
+++ b/Sources/TootSDK/Models/Emoji.swift
@@ -7,9 +7,9 @@ public struct Emoji: Codable, Hashable, Sendable {
     /// The name of the custom emoji.
     public var shortcode: String
     /// A link to the custom emoji.
-    public var staticUrl: String
-    /// A link to a static copy of the custom emoji.
     public var url: String
+    /// A link to a static copy of the custom emoji.
+    public var staticUrl: String
     ///  Whether this Emoji should be visible in the picker or unlisted.
     public var visibleInPicker: Bool
     /// Used for sorting custom emoji in the picker.

--- a/Sources/TootSDK/Models/PostEdit.swift
+++ b/Sources/TootSDK/Models/PostEdit.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct PostEdit: Codable, Sendable {
+public struct PostEdit: Codable, Hashable, Sendable {
     ///  The content of the post at this revision.
     public var content: String
     ///  The content of the subject or content warning at this revision


### PR DESCRIPTION
Seems like many or most of the TootSDK models implement Hashable, but PostEdit doesn't and in this case I need PostEdit to be Hashable to pass to a custom NavigationStack path like this:

```swift
enum Route : Hashable {
    case postDetail(Post)
    case postEdit(PostEdit)
    case profile(Account)
    case reply(Post)
}
```