### PR TITLE
cleanup: refactor fetch of paged result into a shared function

### DIFF
--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -40,7 +40,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Get all accounts which the given account is following, if network is not hidden by the account owner.
@@ -53,7 +53,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Attempts to register a user.

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -39,18 +39,8 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Account].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Get all accounts which the given account is following, if network is not hidden by the account owner.
@@ -62,18 +52,8 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Account].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Attempts to register a user.

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -70,18 +70,8 @@ public extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Account].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Add accounts to a list

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -71,7 +71,7 @@ public extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Add accounts to a list

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -16,18 +16,8 @@ public extension TootClient {
             $0.method = .get
             $0.query = createQuery(from: params) + getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([TootNotification].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Get info about a single notification

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -17,7 +17,7 @@ public extension TootClient {
             $0.query = createQuery(from: params) + getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Get info about a single notification

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -129,7 +129,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Mute the given account. Clients should filter posts and notifications from this account, if received (e.g. due to a boost in the Home timeline).
@@ -164,7 +164,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Find out whether a given account is followed, blocked, muted, etc.

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -128,18 +128,8 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Account].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Mute the given account. Clients should filter posts and notifications from this account, if received (e.g. due to a boost in the Home timeline).
@@ -174,17 +164,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Account].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Find out whether a given account is followed, blocked, muted, etc.

--- a/Sources/TootSDK/TootClient/TootClient+Tags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Tags.swift
@@ -53,18 +53,8 @@ public extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Tag].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Tells whether current flavour supports following or unfollowing tags.

--- a/Sources/TootSDK/TootClient/TootClient+Tags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Tags.swift
@@ -54,7 +54,7 @@ public extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Tells whether current flavour supports following or unfollowing tags.

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -17,7 +17,7 @@ extension TootClient {
     /// - Returns: a paged result with an array of posts
     internal func getPosts(_ req: HTTPRequestBuilder, _ pageInfo: PagedInfo? = nil, _ limit: Int? = nil) async throws -> PagedResult<[Post]> {
         
-        return try await fetchPagedResult(req, pageInfo, limit: limit)
+        return try await fetchPagedResult(req)
     }
 
     /// Provides the url paths as an array of strings, based on the type of timeline

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -16,17 +16,8 @@ extension TootClient {
     ///   - limit: the limit of posts being requested
     /// - Returns: a paged result with an array of posts
     internal func getPosts(_ req: HTTPRequestBuilder, _ pageInfo: PagedInfo? = nil, _ limit: Int? = nil) async throws -> PagedResult<[Post]> {
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([Post].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        
+        return try await fetchPagedResult(req, pageInfo, limit: limit)
     }
 
     /// Provides the url paths as an array of strings, based on the type of timeline

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -220,8 +220,10 @@ extension TootClient {
     }
     
     /// Performs a request that returns paginated arrays
+    /// - Parameters:
+    ///   - req: the HTTP request to execute
     /// - Returns: the fetched paged array and page info
-    internal func fetchPagedResult<T: Decodable>(_ req: HTTPRequestBuilder, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[T]> {
+    internal func fetchPagedResult<T: Decodable>(_ req: HTTPRequestBuilder) async throws -> PagedResult<[T]> {
 
         let (data, response) = try await fetch(req: req)
         let decoded = try decode([T].self, from: data)

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -218,6 +218,24 @@ extension TootClient {
         let supportedFlavours = Set(TootSDKFlavour.allCases).subtracting(unsupportedFalvours)
         try requireFlavour(supportedFlavours)
     }
+    
+    /// Performs a request that returns paginated arrays
+    /// - Returns: the fetched paged array and page info
+    internal func fetchPagedResult<T: Decodable>(_ req: HTTPRequestBuilder, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[T]> {
+
+        let (data, response) = try await fetch(req: req)
+        let decoded = try decode([T].self, from: data)
+        var pagination: Pagination?
+
+        if let links = response.value(forHTTPHeaderField: "Link") {
+            pagination = Pagination(links: links)
+        }
+
+        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
+
+        return PagedResult(result: decoded, info: info)
+    }
+
 }
 
 extension TootClient: Equatable {


### PR DESCRIPTION
added TootClient.fetchPagedResult(req) called by all the functions that return PagedResult.

It's basically the same as getPosts (which I changed to call this new function), but with a generic type (specified as Decodable, but that can be omitted, the type inference handles it).