### PR TITLE
add removeSuggestion

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "546eaa261ec5028b9cc5c7fa883fba9dd5881a3b",
-        "version" : "2.52.0"
+        "revision" : "2d8e6ca36fe3e8ed74b0883f593757a45463c34d",
+        "version" : "2.53.0"
       }
     },
     {

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -31,7 +31,10 @@ extension TootClient {
     }
 
     /// Get all accounts which follow the given account, if network is not hidden by the account owner.
-    /// - Parameter id: the ID of the Account in the instance database.
+    /// - Parameters
+    ///     - id: the ID of the Account in the instance database.
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
     /// - Returns: the accounts requested, or an error if unable to retrieve
     public func getFollowers(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
         let req = HTTPRequestBuilder {
@@ -44,7 +47,10 @@ extension TootClient {
     }
 
     /// Get all accounts which the given account is following, if network is not hidden by the account owner.
-    /// - Parameter id: the ID of the Account in the instance database.
+    /// - Parameters:
+    ///     - id: the ID of the Account in the instance database.
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
     /// - Returns: the accounts requested, or an error if unable to retrieve
     public func getFollowing(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
         let req = HTTPRequestBuilder {

--- a/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public extension TootClient {
-    
+
     /// Accounts that are promoted by staff, or that the user has had past positive interactions with, but is not yet following.
     ///
     /// - Parameters:
@@ -19,6 +19,16 @@ public extension TootClient {
         }
 
         return try await fetch([Suggestion].self, req)
+    }
+
+    /// Remove an account from follow suggestions.
+    /// - Parameter id: The ID of the Account in the database.
+    func removeSuggestion(id: String) async throws {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "suggestions", id])
+            $0.method = .delete
+        }
+        _ = try await fetch(req: req)
     }
 
 }

--- a/Sources/TootSDK/TootClient/TootClient+Tags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Tags.swift
@@ -45,6 +45,9 @@ public extension TootClient {
     }
 
     /// Get all tags which the current account is following.
+    /// - Parameters:
+    ///     - pageInfo: PagedInfo object for max/min/since ids.
+    ///     - limit: Maximum number of results to return. Defaults to 100 tags. Max 200 tags.
     /// - Returns: the tags requested
     func getFollowedTags(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Tag]> {
         try requireFlavour(flavoursSupportingFollowingTags)


### PR DESCRIPTION
Added TootClient.removeSuggestion which accesses this API

https://docs.joinmastodon.org/methods/suggestions/#remove

I tested this on universeodon.com and it works, but apparently only on suggestions with a past_interactions source (which isn't documented but kind of makes sense, that's the only suggestion type that is tailored to the user)