### PR TITLE
added getProfileDirectory, getScheduledPosts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "2d8e6ca36fe3e8ed74b0883f593757a45463c34d",
-        "version" : "2.53.0"
+        "revision" : "6213ba7a06febe8fef60563a4a7d26a4085783cf",
+        "version" : "2.54.0"
       }
     },
     {

--- a/Sources/TootSDK/Models/ProfileDirectoryParams.swift
+++ b/Sources/TootSDK/Models/ProfileDirectoryParams.swift
@@ -10,9 +10,9 @@ import Foundation
 public struct ProfileDirectoryParams: Codable {
     
     /// Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
-    public var order: Order? = nil
+    public var order: Order?
     /// If true, returns only local accounts.
-    public var local: Bool? = nil
+    public var local: Bool?
 
     public init( order: Order? = nil,
                  local: Bool? = nil) {

--- a/Sources/TootSDK/Models/ProfileDirectoryParams.swift
+++ b/Sources/TootSDK/Models/ProfileDirectoryParams.swift
@@ -1,6 +1,6 @@
 //
 //  ProfileDirectoryParams.swift
-//  
+//
 //
 //  Created by Philip Chu on 5/29/23.
 //
@@ -8,20 +8,29 @@
 import Foundation
 
 public struct ProfileDirectoryParams: Codable {
-    
+
     /// Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
     public var order: Order?
     /// If true, returns only local accounts.
     public var local: Bool?
 
-    public init( order: Order? = nil,
-                 local: Bool? = nil) {
+    public init(order: Order? = nil,
+                local: Bool? = nil) {
         self.order = order
         self.local = local
     }
-    
+
     public enum Order: String, Codable, Hashable, CaseIterable {
         case active
         case new
+    }
+}
+
+extension ProfileDirectoryParams {
+    var queryItems: [URLQueryItem] {
+        [
+            URLQueryItem(name: "order", value: order?.rawValue),
+            URLQueryItem(name: "local", value: local?.description)
+        ].filter { $0.value != nil }
     }
 }

--- a/Sources/TootSDK/Models/ProfileDirectoryParams.swift
+++ b/Sources/TootSDK/Models/ProfileDirectoryParams.swift
@@ -1,0 +1,27 @@
+//
+//  ProfileDirectoryParams.swift
+//  
+//
+//  Created by Philip Chu on 5/29/23.
+//
+
+import Foundation
+
+public struct ProfileDirectoryParams: Codable {
+    
+    /// Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
+    public var order: Order? = nil
+    /// If true, returns only local accounts.
+    public var local: Bool? = nil
+
+    public init( order: Order? = nil,
+                 local: Bool? = nil) {
+        self.order = order
+        self.local = local
+    }
+    
+    public enum Order: String, Codable, Hashable, CaseIterable {
+        case active
+        case new
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -10,6 +10,8 @@ import Foundation
 public extension TootClient {
 
     /// Get all notifications concerning the user
+    ///  - Parameters:
+    ///     -  limit: Maximum number of results to return. Defaults to 15 notifications. Max 30 notifications.
     func getNotifications(params: TootNotificationParams = .init(), _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[TootNotification]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "notifications"])

--- a/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
@@ -1,0 +1,29 @@
+//
+//  TootClient+Directory.swift
+//  
+//
+//  Created by Philip Chu on 5/29/23.
+//
+
+import Foundation
+
+public extension TootClient {
+    
+    /// List accounts visible in the directory.
+    ///
+    /// - Parameters:
+    ///   - offset. Skip the first n results.
+    ///   - limit: How many accounts to load. Defaults to 40 accounts. Max 80 accounts.
+    ///   - order. Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
+    ///   - local. If true, returns only local accounts.
+    /// - Returns: Array of ``Account``.
+    func getProfileDirectory(offset: Int? = nil, limit: Int? = nil, params: ProfileDirectoryParams? = nil) async throws -> [Account] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "directory"])
+            $0.method = .get
+            $0.query = getQueryParams(limit: limit, offset: offset)
+        }
+        
+        return try await fetch([Account].self, req)
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
@@ -14,8 +14,7 @@ public extension TootClient {
     /// - Parameters:
     ///   - offset. Skip the first n results.
     ///   - limit: How many accounts to load. Defaults to 40 accounts. Max 80 accounts.
-    ///   - order. Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
-    ///   - local. If true, returns only local accounts.
+    ///   - params: Includes order and local parameters.
     /// - Returns: Array of ``Account``.
     func getProfileDirectory(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> [Account] {
         let req = HTTPRequestBuilder {

--- a/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
@@ -1,6 +1,6 @@
 //
 //  TootClient+Directory.swift
-//  
+//
 //
 //  Created by Philip Chu on 5/29/23.
 //
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension TootClient {
-    
+
     /// List accounts visible in the directory.
     ///
     /// - Parameters:
@@ -17,13 +17,13 @@ public extension TootClient {
     ///   - order. Use active to sort by most recently posted statuses (default) or new to sort by most recently created profiles.
     ///   - local. If true, returns only local accounts.
     /// - Returns: Array of ``Account``.
-    func getProfileDirectory(offset: Int? = nil, limit: Int? = nil, params: ProfileDirectoryParams? = nil) async throws -> [Account] {
+    func getProfileDirectory(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> [Account] {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "directory"])
             $0.method = .get
-            $0.query = getQueryParams(limit: limit, offset: offset)
+            $0.query = getQueryParams(limit: limit, offset: offset) + params.queryItems
         }
-        
+
         return try await fetch([Account].self, req)
     }
 }

--- a/Sources/TootSDK/TootClient/TootClient+ScheduledPost.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ScheduledPost.swift
@@ -51,6 +51,18 @@ public extension TootClient {
 
         return try await fetch([ScheduledPost].self, req)
     }
+    
+    /// Gets scheduled posts
+    /// - Returns: the scheduled posts requested, or an error if unable to retrieve
+    func getScheduledPosts(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[ScheduledPost]> {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "scheduled_statuses"])
+            $0.method = .get
+            $0.query = getQueryParams(pageInfo, limit: limit)
+        }
+        
+        return try await fetchPagedResult(req)
+    }
 
     /// Gets a single Scheduled post by id
     ///


### PR DESCRIPTION
Added TootClient.getProfileDirectory to access the Mastodon directory API.
Added a paged version of TootClient.getScheduledPosts (can probably replace the array-returning getScheduledPost)
Added parameter doc for limit in TootClient.getNotifications
Updated swift-nio package via Get Latest Packages in Xcode.

Sample result from getProfileDirectory

![IMG_2652](https://github.com/TootSDK/TootSDK/assets/1530082/b5188ace-c808-4787-91da-a4053ad8eea3)