### PR TITLE
feat: featured_tags API

### DIFF
--- a/Sources/TootSDK/Models/FeatureTagParams.swift
+++ b/Sources/TootSDK/Models/FeatureTagParams.swift
@@ -1,0 +1,18 @@
+//
+//  FeatureTagParams.swift
+//  
+//
+//  Created by Philip Chu on 6/10/23.
+//
+
+import Foundation
+
+/// Params to feature a hashtag
+public struct FeatureTagParams: Codable {
+    /// The hashtag to be featured, without the hash sign.
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/Sources/TootSDK/Models/FeaturedTag.swift
+++ b/Sources/TootSDK/Models/FeaturedTag.swift
@@ -18,9 +18,9 @@ public struct FeaturedTag: Codable, Hashable, Identifiable {
     public var postsCount: Int
 
     /// The date of last authored post containing this tag.
-    public var lastPostAt: Date
+    public var lastPostAt: Date?
 
-    public init(id: String, name: String, url: String, postsCount: Int, lastPostAt: Date) {
+    public init(id: String, name: String, url: String, postsCount: Int, lastPostAt: Date? = nil) {
         self.id = id
         self.name = name
         self.url = url

--- a/Sources/TootSDK/Models/FeaturedTag.swift
+++ b/Sources/TootSDK/Models/FeaturedTag.swift
@@ -35,7 +35,7 @@ public struct FeaturedTag: Codable, Hashable, Identifiable {
         self.url = try container.decode(String.self, forKey: .url)
         // Mastodon incorrectly returns this count as string
         self.postsCount = try container.decodeIntFromString(forKey: .postsCount)
-        self.lastPostAt = try container.decode(Date.self, forKey: .lastPostAt)
+        self.lastPostAt = try? container.decode(Date.self, forKey: .lastPostAt)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -85,18 +85,6 @@ extension TootClient {
         }
     }
 
-    /// Get tags featured by user.
-    ///
-    /// - Parameter userID: ID of user in database.
-    /// - Returns: The featured tags or an error if unable to retrieve.
-    public func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
-        let req = HTTPRequestBuilder {
-            $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
-            $0.method = .get
-        }
-        return try await fetch([FeaturedTag].self, req)
-    }
-
     // swiftlint:disable todo
     // TODO: - Update account credentials
 

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -7,14 +7,25 @@
 
 import Foundation
 
-extension TootClient {
+public extension TootClient {
     /// Get tags featured by user.
     ///
     /// - Parameter userID: ID of user in database.
     /// - Returns: The featured tags or an error if unable to retrieve.
-    public func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
+    func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
+            $0.method = .get
+        }
+        return try await fetch([FeaturedTag].self, req)
+    }
+    
+    /// List all hashtags featured on your profile.
+    ///
+    /// - Returns: The featured tags or an error if unable to retrieve.
+    func getFeaturedTags() async throws -> [FeaturedTag] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .get
         }
         return try await fetch([FeaturedTag].self, req)

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -42,4 +42,27 @@ public extension TootClient {
 
         return try await fetch([Tag].self, req)
     }
+    
+    /// Promote a hashtag on your profile.
+    @discardableResult
+    func featureTag(params: FeatureTagParams) async throws -> FeaturedTag {
+        let req = try HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "featured_tags"])
+            $0.method = .post
+            $0.body = try .json(params, encoder: self.encoder)
+        }
+        
+        return try await fetch(FeaturedTag.self, req)
+    }
+    
+    /// Stop promoting a hashtag on your profile.
+    /// - Parameter id: The ID of the FeaturedTag in the database.
+    func unfeatureTag(id: String) async throws {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "featured_tags", id])
+            $0.method = .delete
+        }
+        
+        _ = try await fetch(req: req)
+    }
 }

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -13,6 +13,7 @@ public extension TootClient {
     /// - Parameter userID: ID of user in database.
     /// - Returns: The featured tags or an error if unable to retrieve.
     func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
+        try requireFlavour([.mastodon])
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
             $0.method = .get
@@ -24,6 +25,7 @@ public extension TootClient {
     ///
     /// - Returns: The featured tags or an error if unable to retrieve.
     func getFeaturedTags() async throws -> [FeaturedTag] {
+        try requireFlavour([.mastodon])
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .get
@@ -35,6 +37,7 @@ public extension TootClient {
     ///
     /// - Returns: Array of ``Tag``.
     func getFeaturedTagsSuggestions() async throws -> [Tag] {
+        try requireFlavour([.mastodon])
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", "suggestions"])
             $0.method = .get
@@ -47,6 +50,7 @@ public extension TootClient {
     /// - Parameter name: The hashtag to be featured, without the hash sign.
     @discardableResult
     func featureTag(name: String) async throws -> FeaturedTag {
+        try requireFlavour([.mastodon])
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .post
@@ -60,6 +64,7 @@ public extension TootClient {
     /// Stop promoting a hashtag on your profile.
     /// - Parameter id: The ID of the FeaturedTag in the database.
     func unfeatureTag(id: String) async throws {
+        try requireFlavour([.mastodon])
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", id])
             $0.method = .delete

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -44,12 +44,14 @@ public extension TootClient {
     }
     
     /// Promote a hashtag on your profile.
+    /// - Parameter name: The hashtag to be featured, without the hash sign.
     @discardableResult
-    func featureTag(params: FeatureTagParams) async throws -> FeaturedTag {
+    func featureTag(name: String) async throws -> FeaturedTag {
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .post
-            $0.body = try .json(params, encoder: self.encoder)
+            $0.body = try .json(FeatureTagParams(name: name),
+                                encoder: self.encoder)
         }
         
         return try await fetch(FeaturedTag.self, req)

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -1,0 +1,34 @@
+//
+//  TootClient+FeaturedTags.swift
+//  
+//
+//  Created by Philip Chu on 6/9/23.
+//
+
+import Foundation
+
+extension TootClient {
+    /// Get tags featured by user.
+    ///
+    /// - Parameter userID: ID of user in database.
+    /// - Returns: The featured tags or an error if unable to retrieve.
+    public func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
+            $0.method = .get
+        }
+        return try await fetch([FeaturedTag].self, req)
+    }
+
+    /// Shows up to 10 recently-used tags.
+    ///
+    /// - Returns: Array of ``Tag``.
+    func getFeaturedTagsSuggestions() async throws -> [Tag] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "featured_tags", "suggestions"])
+            $0.method = .get
+        }
+
+        return try await fetch([Tag].self, req)
+    }
+}


### PR DESCRIPTION
Added TootClient functions to access the Mastodon featured_tags API for featuring/unfeaturing tags, and viewing and suggesting featured tags.

https://docs.joinmastodon.org/methods/featured_tags/

Placed them in TootClient+FeaturedTags.swift and moved the existing getFeaturedTags (that takes an account ID) there.