### PR TITLE
Log debug messages using OSLog logger

### DIFF
--- a/Sources/TootSDK/Models/TootSDKFlavour.swift
+++ b/Sources/TootSDK/Models/TootSDKFlavour.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-public enum TootSDKFlavour: String, Codable, Sendable, CaseIterable {
+public enum TootSDKFlavour: String, Codable, Sendable, CaseIterable, CustomStringConvertible {
     /// Mastodon server. API Documentation can be found at https://docs.joinmastodon.org/api/
     case mastodon
 
@@ -18,4 +18,8 @@ public enum TootSDKFlavour: String, Codable, Sendable, CaseIterable {
 
     /// Akkoma server. API Documentation can be found at https://docs.akkoma.dev/stable/development/API/differences_in_mastoapi_responses/
     case akkoma
+
+    public var description: String {
+        rawValue
+    }
 }


### PR DESCRIPTION
Xcode 15 introduced improvements to debug console with extra support for OSLog messages. This pull request is just a quick change to start a discussion. Feel free to expand on it or share ideas. I didn’t test how this works on non iOS targets.

Some ideas for changes that could be made:
- Separate logger with different category for request/response instead of emoji
- Flag to disable logging of headers

Issues to resolve:
- It seems like there is a limit to length of displayed messages in console. Long messages appear cut. Not sure if this is customizable somewhere, it's a bug in Xcode, there is a different way to log long messages or it's entirely not supported.
- Check how it behaves on earlier versions of Xcode.

Examples:

![Screenshot 2023-06-10 at 20 22 33](https://github.com/TootSDK/TootSDK/assets/5156340/33f0186d-22cc-45e2-8e2d-4cb10c9a623c)
![Screenshot 2023-06-10 at 20 26 01](https://github.com/TootSDK/TootSDK/assets/5156340/1c523098-871b-4a92-a59d-98fcb154c949)
![Screenshot 2023-06-10 at 20 26 19](https://github.com/TootSDK/TootSDK/assets/5156340/cdb0ca80-8116-4fc6-aa4f-d3a15b3e0ec2)

Reference:

https://developer.apple.com/wwdc23/10226
https://developer.apple.com/documentation/os/logging