### PR TITLE
API for update_credentials

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "6213ba7a06febe8fef60563a4a7d26a4085783cf",
-        "version" : "2.54.0"
+        "revision" : "5f542894dd8efbd766d8adf73ef2f947b0cd5e21",
+        "version" : "2.56.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "0e96a20ffd37a515c5c963952d4335c89bed50a6",
-        "version" : "2.6.0"
+        "revision" : "8b6cf29eead8841a1fa7822481cb3af4ddaadba6",
+        "version" : "2.6.1"
       }
     }
   ],

--- a/Sources/MultipartKitTootSDK/MultipartPart.swift
+++ b/Sources/MultipartKitTootSDK/MultipartPart.swift
@@ -7,7 +7,7 @@ public struct MultipartPart: Equatable {
 
     /// The part's raw data.
     public var body: ByteBuffer
-    
+
     /// Gets or sets the `name` attribute from the part's `"Content-Disposition"` header.
     public var name: String? {
         get { self.headers.getParameter("Content-Disposition", "name") }
@@ -33,16 +33,35 @@ public struct MultipartPart: Equatable {
     ///     - headers: The part's headers.
     ///     - body: The part's data.
     public init<Data>(headers: HTTPHeaders = .init(), body: Data)
-        where Data: DataProtocol
+    where Data: DataProtocol
     {
         var buffer = ByteBufferAllocator().buffer(capacity: body.count)
         buffer.writeBytes(body)
         self.init(headers: headers, body: buffer)
     }
-    
+
     public init(headers: HTTPHeaders = .init(), body: ByteBuffer) {
         self.headers = headers
         self.body = body
+    }
+
+    /// convenience init that sets form-data name
+    public init(name: String, body: String) {
+        self.init(headers: [
+            "Content-Disposition": "form-data; name=\"\(name)\""
+            ],
+            body: body
+        )
+    }
+
+    /// convenience init for file/data upload
+    public init<Data>(file: String, mimeType: String, body: Data) where Data: DataProtocol {
+        self.init(headers: [
+            "Content-Disposition": "form-data; name=\"\(file)\"; filename=\"\(file)\"",
+            "Content-Type": mimeType
+            ],
+            body: body
+        )
     }
 }
 

--- a/Sources/TootSDK/HTTP/HTTPMethod.swift
+++ b/Sources/TootSDK/HTTP/HTTPMethod.swift
@@ -6,6 +6,7 @@ import Foundation
 public enum HTTPMethod: String {
     case delete = "DELETE"
     case get = "GET"
+    case patch = "PATCH"
     case post = "POST"
     case put = "PUT"
 }

--- a/Sources/TootSDK/Models/UpdateCredentialsParams.swift
+++ b/Sources/TootSDK/Models/UpdateCredentialsParams.swift
@@ -1,0 +1,72 @@
+//
+//  UpdateCredentialsParams.swift
+//  
+//
+//  Created by Philip Chu on 6/26/23.
+//
+
+import Foundation
+
+public struct UpdateCredentialsParams: Codable {
+    /// The display name to use for the profile.
+    public var displayName: String?
+    /// The account bio.
+    public var note: String?
+    /// Avatar image encoded using multipart/form-data
+    public var avatar: Data?
+    public var avatarMimeType: String?
+    /// Header image encoded using multipart/form-data
+    public var header: Data?
+    public var headerMimeType: String?
+    /// Whether manual approval of follow requests is required.
+    public var locked: Bool?
+    /// Whether the account has a bot flag.
+    public var bot: Bool?
+    /// Whether he account should be shown in the profile directory.
+    public var discoverable: Bool?
+    /// Additional metadata attached to a profile as name-value pairs
+    public let fieldsAttributes: [String: Field]?
+    /// An extra entity to be used with API methods to verify credentials and update credentials
+    public let source: Source?
+
+    public init(displayName: String? = nil, note: String? = nil, avatar: Data? = nil, avatarMimeType: String? = nil, header: Data? = nil, headerMimeType: String? = nil, locked: Bool? = nil, bot: Bool? = nil, discoverable: Bool? = nil, fieldsAttributes: [String: Field]? = nil, source: Source? = nil) {
+        self.displayName = displayName
+        self.note = note
+        self.avatar = avatar
+        self.avatarMimeType = avatarMimeType
+        self.header = header
+        self.headerMimeType = headerMimeType
+        self.locked = locked
+        self.bot = bot
+        self.discoverable = discoverable
+        self.fieldsAttributes = fieldsAttributes
+        self.source = source
+    }
+    
+    /// Represents a profile field as a name-value pair 
+    public struct Field: Codable, Hashable, Sendable {
+        public init(name: String, value: String) {
+            self.name = name
+            self.value = value
+        }
+
+        /// The key of a given field's key-value pair.
+        public var name: String
+        /// The value associated with the name key.
+        public var value: String
+    }
+    
+    public struct Source: Codable, Hashable, Sendable {
+        public init(privacy: Post.Visibility? = nil, sensitive: Bool? = nil, language: String? = nil) {
+            self.privacy = privacy
+            self.sensitive = sensitive
+            self.language = language
+        }
+        /// The default post privacy to be used for new posts.
+        public var privacy: Post.Visibility?
+        /// Whether new posts should be marked sensitive by default.
+        public var sensitive: Bool?
+        ///  The default posting language for new posts.
+        public var language: String?
+    }
+}


### PR DESCRIPTION
added updateCredentials in TootClient+Account, takes arguments in UpdateCredentialsParams
added PATCH method to support the call
patterned the multipart encoding/aggregation after uploadMedia (update_credentials accepts uploads of avatar/header images), and added a couple of MultipartPart convenience inits to avoid repeatedly pasting header text
SwiftNIO and SwiftSoup packages are updated