### PR TITLE
workaround for ScheduledPost.sensitive returning as string instead of bool

### DIFF
--- a/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "546eaa261ec5028b9cc5c7fa883fba9dd5881a3b",
-        "version" : "2.52.0"
+        "revision" : "cf281631ff10ec6111f2761052aa81896a83a007",
+        "version" : "2.58.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "0e96a20ffd37a515c5c963952d4335c89bed50a6",
-        "version" : "2.6.0"
+        "revision" : "8b6cf29eead8841a1fa7822481cb3af4ddaadba6",
+        "version" : "2.6.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "5f542894dd8efbd766d8adf73ef2f947b0cd5e21",
-        "version" : "2.56.0"
+        "revision" : "a2e487b77f17edbce9a65f2b7415f2f479dc8e48",
+        "version" : "2.57.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,9 @@ let package = Package(
                 .copy("Resources/pixelfed.json"),
                 .copy("Resources/mastodon.json"),
                 .copy("Resources/pleroma.json"),
+                .copy("Resources/scheduled_post_sensitive.json"),
+                .copy("Resources/scheduled_post_attachment.json"),
+                .copy("Resources/scheduled_post_reply.json")
             ]),
     ]
 )

--- a/Sources/TootSDK/Extensions/Decoding+Helpers.swift
+++ b/Sources/TootSDK/Extensions/Decoding+Helpers.swift
@@ -17,4 +17,16 @@ extension KeyedDecodingContainerProtocol {
             throw error
         }
     }
+    
+    func decodeBoolFromString(forKey key: Key) throws -> Bool {
+        do {
+            return try decode(Bool.self, forKey: key)
+        } catch {
+            let string = try decode(String.self, forKey: key)
+            if let bool = Bool(string) {
+                return bool
+            }
+            throw error
+        }
+    }
 }

--- a/Sources/TootSDK/Models/FeaturedTag.swift
+++ b/Sources/TootSDK/Models/FeaturedTag.swift
@@ -35,7 +35,7 @@ public struct FeaturedTag: Codable, Hashable, Identifiable {
         self.url = try container.decode(String.self, forKey: .url)
         // Mastodon incorrectly returns this count as string
         self.postsCount = try container.decodeIntFromString(forKey: .postsCount)
-        self.lastPostAt = try? container.decode(Date.self, forKey: .lastPostAt)
+        self.lastPostAt = try? container.decodeIfPresent(Date.self, forKey: .lastPostAt)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TootSDK/Models/ScheduledPost.swift
+++ b/Sources/TootSDK/Models/ScheduledPost.swift
@@ -4,10 +4,10 @@
 @preconcurrency import struct Foundation.Date
 
 /// Represents a post that will be published at a future scheduled date.
-public struct ScheduledPost: Codable, Identifiable, Sendable {
+public struct ScheduledPost: Codable, Equatable, Hashable, Identifiable, Sendable {
     /// ID of the scheduled post in the database.
     public var id: String
-    /// ID of the post in the database.
+    /// The timestamp for when the status will be posted.
     public var scheduledAt: Date?
     /// The parameters to be used when the post is posted
     public var params: ScheduledPostParams

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -8,7 +8,7 @@
 @preconcurrency import struct Foundation.Date
 
 /// Parameters to post a new scheduled post
-public struct ScheduledPostParams: Codable, Sendable {
+public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
 
     ///  Creates parameters to create a new scheduled post
     /// - Parameters:
@@ -77,5 +77,22 @@ public struct ScheduledPostParams: Codable, Sendable {
         case scheduledAt = "scheduled_at"
         case contentType = "content_type"
         case inReplyToConversationId = "in_reply_to_conversation_id"
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.text = try? container.decode(String.self, forKey: .text)
+        self.mediaIds = try? container.decode([String].self, forKey: .mediaIds)
+        self.poll = try? container.decode(CreatePoll.self, forKey: .poll)
+        self.inReplyToId = try? container.decode(String.self, forKey: .inReplyToId)
+        // Mastodon incorrectly returns this as string
+        self.sensitive = try? container.decodeBoolFromString(forKey: .sensitive)
+        self.spoilerText = try? container.decode(String.self, forKey: .spoilerText)
+        self.visibility = (try? container.decode(Post.Visibility.self, forKey: .visibility)) ?? .public
+        self.language = try? container.decode(String.self, forKey: .language)
+        self.idempotency = try? container.decode(String.self, forKey: .idempotency)
+        self.scheduledAt = try? container.decode(Date.self, forKey: .scheduledAt)
+        self.contentType = try? container.decode(String.self, forKey: .contentType)
+        self.inReplyToConversationId = try? container.decode(String.self, forKey: .inReplyToConversationId)
     }
 }

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -74,9 +74,9 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
         case visibility
         case language
         case idempotency
-        case scheduledAt = "scheduled_at"
-        case contentType = "content_type"
-        case inReplyToConversationId = "in_reply_to_conversation_id"
+        case scheduledAt
+        case contentType
+        case inReplyToConversationId
     }
     
     public init(from decoder: Decoder) throws {

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -88,7 +88,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
         // Mastodon incorrectly returns this as string
         self.sensitive = try? container.decodeBoolFromString(forKey: .sensitive)
         self.spoilerText = try? container.decodeIfPresent(String.self, forKey: .spoilerText)
-        self.visibility = (try? container.decode(Post.Visibility.self, forKey: .visibility)) ?? .public
+        self.visibility = try container.decode(Post.Visibility.self, forKey: .visibility)
         self.language = try? container.decodeIfPresent(String.self, forKey: .language)
         self.idempotency = try? container.decodeIfPresent(String.self, forKey: .idempotency)
         self.scheduledAt = try? container.decodeIfPresent(Date.self, forKey: .scheduledAt)

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -81,18 +81,18 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.text = try? container.decode(String.self, forKey: .text)
-        self.mediaIds = try? container.decode([String].self, forKey: .mediaIds)
-        self.poll = try? container.decode(CreatePoll.self, forKey: .poll)
-        self.inReplyToId = try? container.decode(String.self, forKey: .inReplyToId)
+        self.text = try? container.decodeIfPresent(String.self, forKey: .text)
+        self.mediaIds = try? container.decodeIfPresent([String].self, forKey: .mediaIds)
+        self.poll = try? container.decodeIfPresent(CreatePoll.self, forKey: .poll)
+        self.inReplyToId = try? container.decodeIfPresent(String.self, forKey: .inReplyToId)
         // Mastodon incorrectly returns this as string
         self.sensitive = try? container.decodeBoolFromString(forKey: .sensitive)
-        self.spoilerText = try? container.decode(String.self, forKey: .spoilerText)
+        self.spoilerText = try? container.decodeIfPresent(String.self, forKey: .spoilerText)
         self.visibility = (try? container.decode(Post.Visibility.self, forKey: .visibility)) ?? .public
-        self.language = try? container.decode(String.self, forKey: .language)
-        self.idempotency = try? container.decode(String.self, forKey: .idempotency)
-        self.scheduledAt = try? container.decode(Date.self, forKey: .scheduledAt)
-        self.contentType = try? container.decode(String.self, forKey: .contentType)
-        self.inReplyToConversationId = try? container.decode(String.self, forKey: .inReplyToConversationId)
+        self.language = try? container.decodeIfPresent(String.self, forKey: .language)
+        self.idempotency = try? container.decodeIfPresent(String.self, forKey: .idempotency)
+        self.scheduledAt = try? container.decodeIfPresent(Date.self, forKey: .scheduledAt)
+        self.contentType = try? container.decodeIfPresent(String.self, forKey: .contentType)
+        self.inReplyToConversationId = try? container.decodeIfPresent(String.self, forKey: .inReplyToConversationId)
     }
 }

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -23,7 +23,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
     ///   - scheduledAt: UTC Datetime at which to schedule a post. Must be at least 5 minutes in the future.
     ///   - contentType: (Pleroma) The MIME type of the post, it is transformed into HTML by the backend. You can get the list of the supported MIME types with the nodeinfo endpoint.
     ///   - inReplyToConversationId:(Pleroma) Will reply to a given conversation, addressing only the people who are part of the recipient set of that conversation. Sets the visibility to direct.
-    public init(text: String? = nil, mediaIds: [String]? = nil, sensitive: Bool? = nil, spoilerText: String? = nil, visibility: Post.Visibility, language: String? = nil, scheduledAt: Date? = nil, poll: CreatePoll? = nil, idempotency: String? = nil, inReplyToId: String? = nil, contentType: String? = nil, inReplyToConversationId: String? = nil) {
+    public init(text: String? = nil, mediaIds: [String]? = nil, sensitive: Bool? = nil, spoilerText: String? = nil, visibility: Post.Visibility, language: String? = nil, scheduledAt: Date? = nil, poll: CreatePoll? = nil, idempotency: String? = nil, inReplyToId: Int? = nil, contentType: String? = nil, inReplyToConversationId: String? = nil) {
 
         self.text = text
         self.mediaIds = mediaIds
@@ -58,7 +58,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
     /// Unique post to prevent double posting
     public var idempotency: String?
     ///  ID of the post being replied to, if post is a reply.
-    public var inReplyToId: String?
+    public var inReplyToId: Int?
     /// (Pleroma) The MIME type of the post, it is transformed into HTML by the backend. You can get the list of the supported MIME types with the nodeinfo endpoint.
     public var contentType: String?
     /// (Pleroma) Will reply to a given conversation, addressing only the people who are part of the recipient set of that conversation. Sets the visibility to direct.
@@ -66,11 +66,11 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case text
-        case mediaIds = "media_ids"
+        case mediaIds
         case poll
-        case inReplyToId = "in_reply_to_id"
+        case inReplyToId
         case sensitive
-        case spoilerText = "spoiler_text"
+        case spoilerText
         case visibility
         case language
         case idempotency
@@ -84,7 +84,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
         self.text = try? container.decodeIfPresent(String.self, forKey: .text)
         self.mediaIds = try? container.decodeIfPresent([String].self, forKey: .mediaIds)
         self.poll = try? container.decodeIfPresent(CreatePoll.self, forKey: .poll)
-        self.inReplyToId = try? container.decodeIfPresent(String.self, forKey: .inReplyToId)
+        self.inReplyToId = try? container.decodeIfPresent(Int.self, forKey: .inReplyToId)
         // Mastodon incorrectly returns this as string
         self.sensitive = try? container.decodeBoolFromString(forKey: .sensitive)
         self.spoilerText = try? container.decodeIfPresent(String.self, forKey: .spoilerText)

--- a/Sources/TootSDK/Models/ScheduledPostRequest.swift
+++ b/Sources/TootSDK/Models/ScheduledPostRequest.swift
@@ -58,6 +58,6 @@ extension ScheduledPostRequest {
             throw TootSDKError.invalidParameter(parameterName: "scheduledAt")
         }
 
-        self = ScheduledPostRequest(post: from.text, mediaIds: from.mediaIds, sensitive: from.sensitive, spoilerText: from.spoilerText, visibility: from.visibility, language: from.language, scheduledAt: TootEncoder.dateFormatter.string(from: scheduledAtDate), poll: from.poll, idempotency: from.idempotency, inReplyToId: from.inReplyToId != nil ? String(from.inReplyToId!) : nil, contentType: from.contentType, inReplyToConversationId: from.inReplyToConversationId)
+        self = ScheduledPostRequest(post: from.text, mediaIds: from.mediaIds, sensitive: from.sensitive, spoilerText: from.spoilerText, visibility: from.visibility, language: from.language, scheduledAt: TootEncoder.dateFormatter.string(from: scheduledAtDate), poll: from.poll, idempotency: from.idempotency, inReplyToId: from.inReplyToId, contentType: from.contentType, inReplyToConversationId: from.inReplyToConversationId)
     }
 }

--- a/Sources/TootSDK/Models/ScheduledPostRequest.swift
+++ b/Sources/TootSDK/Models/ScheduledPostRequest.swift
@@ -58,6 +58,6 @@ extension ScheduledPostRequest {
             throw TootSDKError.invalidParameter(parameterName: "scheduledAt")
         }
 
-        self = ScheduledPostRequest(post: from.text, mediaIds: from.mediaIds, sensitive: from.sensitive, spoilerText: from.spoilerText, visibility: from.visibility, language: from.language, scheduledAt: TootEncoder.dateFormatter.string(from: scheduledAtDate), poll: from.poll, idempotency: from.idempotency, inReplyToId: from.inReplyToId, contentType: from.contentType, inReplyToConversationId: from.inReplyToConversationId)
+        self = ScheduledPostRequest(post: from.text, mediaIds: from.mediaIds, sensitive: from.sensitive, spoilerText: from.spoilerText, visibility: from.visibility, language: from.language, scheduledAt: TootEncoder.dateFormatter.string(from: scheduledAtDate), poll: from.poll, idempotency: from.idempotency, inReplyToId: from.inReplyToId != nil ? String(from.inReplyToId!) : nil, contentType: from.contentType, inReplyToConversationId: from.inReplyToConversationId)
     }
 }

--- a/Tests/TootSDKTests/PostTests.swift
+++ b/Tests/TootSDKTests/PostTests.swift
@@ -101,7 +101,7 @@ final class PostTests: XCTestCase {
          XCTAssertEqual(result.id, "1032")
          XCTAssertNotNil(result.scheduledAt)
          XCTAssertNotNil(result.params)
-         XCTAssertEqual(result.params.inReplyToId, 110883505948339014)
+         XCTAssertEqual(result.params.inReplyToId, "110883505948339014")
          XCTAssertNil(result.params.inReplyToConversationId)
          XCTAssertNil(result.params.sensitive)
          XCTAssertEqual(result.params.text, "@technicat testing scheduled reply")

--- a/Tests/TootSDKTests/PostTests.swift
+++ b/Tests/TootSDKTests/PostTests.swift
@@ -35,4 +35,82 @@ final class PostTests: XCTestCase {
         // act
         XCTAssertNoThrow(try ScheduledPostRequest(from: params))
     }
+    
+    func testDecodesSensitiveAsBoolean() throws {
+         // arrange
+         let json = localContent("scheduled_post_sensitive")
+         let decoder = TootDecoder()
+
+         // act
+         let result = try decoder.decode(ScheduledPost.self, from: json)
+
+         // assert
+         XCTAssertNotNil(result)
+         XCTAssertEqual(result.id, "1023")
+         XCTAssertNotNil(result.scheduledAt)
+         XCTAssertNotNil(result.params)
+         XCTAssertNil(result.params.inReplyToId)
+         XCTAssertNil(result.params.inReplyToConversationId)
+         XCTAssertEqual(result.params.sensitive, true)
+         XCTAssertEqual(result.params.text, "Test")
+         XCTAssertNil(result.params.scheduledAt)
+         XCTAssertNil(result.params.mediaIds)
+         XCTAssertNil(result.params.poll)
+         XCTAssertNil(result.params.idempotency)
+         XCTAssertEqual(result.params.spoilerText, "Warn")
+         XCTAssertEqual(result.params.language, "en")
+         XCTAssertEqual(result.params.visibility, .direct)
+     }
+    
+    func testScheduledPostMediaIds() throws {
+         // arrange
+         let json = localContent("scheduled_post_attachment")
+         let decoder = TootDecoder()
+
+         // act
+         let result = try decoder.decode(ScheduledPost.self, from: json)
+
+         // assert
+         XCTAssertNotNil(result)
+         XCTAssertEqual(result.id, "1031")
+         XCTAssertNotNil(result.scheduledAt)
+         XCTAssertNotNil(result.params)
+         XCTAssertNil(result.params.inReplyToId)
+         XCTAssertNil(result.params.inReplyToConversationId)
+         XCTAssertNil(result.params.sensitive)
+         XCTAssertEqual(result.params.text, "Testing scheduled attachment")
+         XCTAssertNil(result.params.scheduledAt)
+         XCTAssertNotNil(result.params.mediaIds)
+         XCTAssertNil(result.params.poll)
+         XCTAssertNil(result.params.idempotency)
+         XCTAssertNil(result.params.spoilerText)
+         XCTAssertEqual(result.params.language, "en")
+         XCTAssertEqual(result.params.visibility, .private)
+     }
+    
+    func testScheduledPostReplyIds() throws {
+         // arrange
+         let json = localContent("scheduled_post_reply")
+         let decoder = TootDecoder()
+
+         // act
+         let result = try decoder.decode(ScheduledPost.self, from: json)
+
+         // assert
+         XCTAssertNotNil(result)
+         XCTAssertEqual(result.id, "1032")
+         XCTAssertNotNil(result.scheduledAt)
+         XCTAssertNotNil(result.params)
+         XCTAssertEqual(result.params.inReplyToId, 110883505948339014)
+         XCTAssertNil(result.params.inReplyToConversationId)
+         XCTAssertNil(result.params.sensitive)
+         XCTAssertEqual(result.params.text, "@technicat testing scheduled reply")
+         XCTAssertNil(result.params.scheduledAt)
+         XCTAssertNil(result.params.mediaIds)
+         XCTAssertNil(result.params.poll)
+         XCTAssertNil(result.params.idempotency)
+         XCTAssertNil(result.params.spoilerText)
+         XCTAssertEqual(result.params.language, "en")
+         XCTAssertEqual(result.params.visibility, .unlisted)
+     }
 }

--- a/Tests/TootSDKTests/Resources/scheduled_post_attachment.json
+++ b/Tests/TootSDKTests/Resources/scheduled_post_attachment.json
@@ -1,0 +1,49 @@
+{
+    "id" : "1031",
+    "scheduled_at" : "2023-08-30T23:20:00.000Z",
+    "params" : {
+      "scheduled_at" : null,
+      "in_reply_to_id" : null,
+      "media_ids" : [
+        "110884868918054337"
+      ],
+      "application_id" : 91595,
+      "poll" : null,
+      "spoiler_text" : null,
+      "idempotency" : null,
+      "allowed_mentions" : null,
+      "text" : "Testing scheduled attachment",
+      "language" : "en",
+      "visibility" : "private",
+      "with_rate_limit" : false,
+      "sensitive" : null
+    },
+    "media_attachments" : [
+      {
+        "preview_url" : "https:\/\/media.universeodon.com\/media_attachments\/files\/110\/884\/868\/918\/054\/337\/small\/93d235b25788c9fd.jpeg",
+        "text_url" : null,
+        "id" : "110884868918054337",
+        "blurhash" : "UaFrnr00xZxu?cD%s+xaE3%1RjRkE3%1RjRk",
+        "preview_remote_url" : null,
+        "meta" : {
+          "original" : {
+            "size" : "3000x2002",
+            "aspect" : 1.4985014985014986,
+            "width" : 3000,
+            "height" : 2002
+          },
+          "small" : {
+            "size" : "587x392",
+            "aspect" : 1.4974489795918366,
+            "width" : 587,
+            "height" : 392
+          }
+        },
+        "type" : "image",
+        "remote_url" : null,
+        "description" : null,
+        "url" : "https:\/\/media.universeodon.com\/media_attachments\/files\/110\/884\/868\/918\/054\/337\/original\/93d235b25788c9fd.jpeg"
+      }
+    ]
+  }
+

--- a/Tests/TootSDKTests/Resources/scheduled_post_reply.json
+++ b/Tests/TootSDKTests/Resources/scheduled_post_reply.json
@@ -1,0 +1,22 @@
+  {
+    "id" : "1032",
+    "scheduled_at" : "2023-08-15T00:00:00.000Z",
+    "params" : {
+      "scheduled_at" : null,
+      "in_reply_to_id" : 110883505948339014,
+      "media_ids" : null,
+      "application_id" : 91595,
+      "poll" : null,
+      "spoiler_text" : null,
+      "idempotency" : null,
+      "allowed_mentions" : null,
+      "text" : "@technicat testing scheduled reply",
+      "language" : "en",
+      "visibility" : "unlisted",
+      "with_rate_limit" : false,
+      "sensitive" : null
+    },
+    "media_attachments" : [
+
+    ]
+  }

--- a/Tests/TootSDKTests/Resources/scheduled_post_sensitive.json
+++ b/Tests/TootSDKTests/Resources/scheduled_post_sensitive.json
@@ -1,0 +1,23 @@
+{
+"id" : "1023",
+"scheduled_at" : "2023-08-31T08:12:00.000Z",
+"params" : {
+"scheduled_at" : null,
+"in_reply_to_id" : null,
+"media_ids" : null,
+"application_id" : 91595,
+"poll" : null,
+"spoiler_text" : "Warn",
+"idempotency" : null,
+"allowed_mentions" : null,
+"text" : "Test",
+"language" : "en",
+"visibility" : "direct",
+"with_rate_limit" : false,
+"sensitive" : "true"
+},
+"media_attachments" : [
+
+]
+
+}


### PR DESCRIPTION
Scheduling a post with a content warning was breaking reading of scheduled posts because the sensitive flag was returned as a string instead of bool. Workaround is to have a custom decoder that calls decodeFromBool (patterned after the existing decodeFromInt).

Other misc stuff: fix comment doc for scheduledAt, make ScheduledPost Hashable (so it can be passed in routes), and update packages, specifically swift-nio.