### PR TITLE
feat: access to endorsements API

### DIFF
--- a/Sources/TootSDK/Models/Relationship.swift
+++ b/Sources/TootSDK/Models/Relationship.swift
@@ -59,7 +59,7 @@ public struct Relationship: Codable, Hashable, Identifiable, Sendable {
     public let domainBlocking: Bool?
     /// Is this user blocking you?
     public var blockedBy: Bool?
-    /// This user's profile bio
+    /// A note to yourself about this user (not the same as the user's bio, the Mastodon doc is incorrect on this).
     public var note: String?
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -7,7 +7,7 @@
 
 @preconcurrency import struct Foundation.Date
 
-/// Parameters to post a new scheduled post
+/// Parameters to post a new scheduled post. Returned as part of a ScheduledPost. In requests, this is converted to a ScheduledPostRequest for encoding.
 public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
 
     ///  Creates parameters to create a new scheduled post

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -187,8 +187,6 @@ extension TootClient {
 
     // swiftlint:disable todo
     // TODO: - Get lists containing this account
-    // TODO: - Feature account on your profile
-    // TODO: - Unfeature account from profile
     // TODO: - Set private note on profile
 
     // TODO: - Find familiar followers

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -154,7 +154,7 @@ extension TootClient {
         }
         return try await fetch(Relationship.self, req)
     }
-
+    
     /// Get all accounts which the current account is blocking
     /// - Returns: the accounts requested
     public func getMutedAccounts(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
@@ -165,6 +165,28 @@ extension TootClient {
         }
 
         return try await fetchPagedResult(req)
+    }
+    
+    /// Add the given account to the user’s featured profiles. (Featured profiles are currently shown on the user’s own public profile.)
+    /// - Parameter id: the ID of the Account in the instance database.
+    /// - Returns: the relationship to the account requested, or an error if unable to retrieve
+    public func pinAccount(by id: String) async throws -> Relationship {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", id, "pin"])
+            $0.method = .post
+        }
+        return try await fetch(Relationship.self, req)
+    }
+    
+    /// Remove the given account from the user’s featured profiles.
+    /// - Parameter id: the ID of the Account in the instance database.
+    /// - Returns: the relationship to the account requested, or an error if unable to retrieve
+    public func unpinAccount(by id: String) async throws -> Relationship {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", id, "unpin"])
+            $0.method = .post
+        }
+        return try await fetch(Relationship.self, req)
     }
 
     /// Find out whether a given account is followed, blocked, muted, etc.

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -121,6 +121,9 @@ extension TootClient {
     }
 
     /// Get all accounts which the current account is blocking
+    /// - Parameters:
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
     /// - Returns: the accounts requested
     public func getBlockedAccounts(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
         let req = HTTPRequestBuilder {
@@ -128,7 +131,6 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
         return try await fetchPagedResult(req)
     }
 
@@ -156,6 +158,9 @@ extension TootClient {
     }
     
     /// Get all accounts which the current account is blocking
+    /// - Parameters:
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
     /// - Returns: the accounts requested
     public func getMutedAccounts(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
         let req = HTTPRequestBuilder {
@@ -163,7 +168,6 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-
         return try await fetchPagedResult(req)
     }
     
@@ -187,6 +191,20 @@ extension TootClient {
             $0.method = .post
         }
         return try await fetch(Relationship.self, req)
+    }
+    
+    /// Accounts that the user is currently featuring on their profile.
+    /// - Parameters:
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: the accounts requested
+    public func getEndorsements(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "endorsements"])
+            $0.method = .get
+            $0.query = getQueryParams(pageInfo, limit: limit)
+        }
+        return try await fetchPagedResult(req)
     }
 
     /// Find out whether a given account is followed, blocked, muted, etc.


### PR DESCRIPTION
added TootClient.pinAccount, TootClient.unpinAccount, and TootClient.getEndorsements

https://docs.joinmastodon.org/methods/endorsements/

Also filled in some of the param doc in TootClient+Relationship.swift and added some clarifying doc for ScheduledPostParams in relation to ScheduledPost and ScheduledPostRequest.