### PR TITLE
API to represent features and check if they are supported

### DIFF
--- a/Sources/TootSDK/Models/TootFeature.swift
+++ b/Sources/TootSDK/Models/TootFeature.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Represents a feature that is not supported by all flavours.
+public struct TootFeature {
+
+    /// Flavours that support this feature.
+    public let supportedFlavours: Set<TootSDKFlavour>
+}

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -13,7 +13,7 @@ public extension TootClient {
     /// - Parameter userID: ID of user in database.
     /// - Returns: The featured tags or an error if unable to retrieve.
     func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
-        try requireFlavour([.mastodon])
+        try requireFlavour(flavoursSupportingFeaturingTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
             $0.method = .get
@@ -25,7 +25,7 @@ public extension TootClient {
     ///
     /// - Returns: The featured tags or an error if unable to retrieve.
     func getFeaturedTags() async throws -> [FeaturedTag] {
-        try requireFlavour([.mastodon])
+        try requireFlavour(flavoursSupportingFeaturingTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .get
@@ -37,7 +37,7 @@ public extension TootClient {
     ///
     /// - Returns: Array of ``Tag``.
     func getFeaturedTagsSuggestions() async throws -> [Tag] {
-        try requireFlavour([.mastodon])
+        try requireFlavour(flavoursSupportingFeaturingTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", "suggestions"])
             $0.method = .get
@@ -50,7 +50,7 @@ public extension TootClient {
     /// - Parameter name: The hashtag to be featured, without the hash sign.
     @discardableResult
     func featureTag(name: String) async throws -> FeaturedTag {
-        try requireFlavour([.mastodon])
+        try requireFlavour(flavoursSupportingFeaturingTags)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .post
@@ -64,12 +64,21 @@ public extension TootClient {
     /// Stop promoting a hashtag on your profile.
     /// - Parameter id: The ID of the FeaturedTag in the database.
     func unfeatureTag(id: String) async throws {
-        try requireFlavour([.mastodon])
+        try requireFlavour(flavoursSupportingFeaturingTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", id])
             $0.method = .delete
         }
 
         _ = try await fetch(req: req)
+    }
+
+    /// Tells whether current flavour supports featuring tags.
+    var canFeatureTags: Bool {
+        flavoursSupportingFeaturingTags.contains(flavour)
+    }
+
+    private var flavoursSupportingFeaturingTags: Set<TootSDKFlavour> {
+        [.mastodon]
     }
 }

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -12,8 +12,9 @@ public extension TootClient {
     ///
     /// - Parameter userID: ID of user in database.
     /// - Returns: The featured tags or an error if unable to retrieve.
+    /// - Note: Requires featured tags feature to be available.
     func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
-        try requireFlavour(flavoursSupportingFeaturingTags)
+        try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
             $0.method = .get
@@ -24,8 +25,9 @@ public extension TootClient {
     /// List all hashtags featured on your profile.
     ///
     /// - Returns: The featured tags or an error if unable to retrieve.
+    /// - Note: Requires featured tags feature to be available.
     func getFeaturedTags() async throws -> [FeaturedTag] {
-        try requireFlavour(flavoursSupportingFeaturingTags)
+        try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .get
@@ -36,8 +38,9 @@ public extension TootClient {
     /// Shows up to 10 recently-used tags.
     ///
     /// - Returns: Array of ``Tag``.
+    /// - Note: Requires featured tags feature to be available.
     func getFeaturedTagsSuggestions() async throws -> [Tag] {
-        try requireFlavour(flavoursSupportingFeaturingTags)
+        try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", "suggestions"])
             $0.method = .get
@@ -48,9 +51,10 @@ public extension TootClient {
 
     /// Promote a hashtag on your profile.
     /// - Parameter name: The hashtag to be featured, without the hash sign.
+    /// - Note: Requires featured tags feature to be available.
     @discardableResult
     func featureTag(name: String) async throws -> FeaturedTag {
-        try requireFlavour(flavoursSupportingFeaturingTags)
+        try requireFeature(.featuredTags)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .post
@@ -63,8 +67,9 @@ public extension TootClient {
 
     /// Stop promoting a hashtag on your profile.
     /// - Parameter id: The ID of the FeaturedTag in the database.
+    /// - Note: Requires featured tags feature to be available.
     func unfeatureTag(id: String) async throws {
-        try requireFlavour(flavoursSupportingFeaturingTags)
+        try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", id])
             $0.method = .delete
@@ -72,13 +77,12 @@ public extension TootClient {
 
         _ = try await fetch(req: req)
     }
+}
 
-    /// Tells whether current flavour supports featuring tags.
-    var canFeatureTags: Bool {
-        flavoursSupportingFeaturingTags.contains(flavour)
-    }
+extension TootFeature {
 
-    private var flavoursSupportingFeaturingTags: Set<TootSDKFlavour> {
-        [.mastodon]
-    }
+    /// Ability to promote hashtags on user profiles.
+    ///
+    /// Available only for Mastodon.
+    public static let featuredTags = TootFeature(supportedFlavours: [.mastodon])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Tags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Tags.swift
@@ -19,10 +19,12 @@ public extension TootClient {
     }
 
     /// Follow a tag.
+    ///
     /// - Parameter id: Name of the tag.
+    /// - Note: Requires hashtag following feature to be available.
     @discardableResult
     func followTag(_ id: String) async throws -> Tag {
-        try requireFlavour(flavoursSupportingFollowingTags)
+        try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "tags", id, "follow"])
             $0.method = .post
@@ -32,10 +34,12 @@ public extension TootClient {
     }
 
     /// Unfollow a tag.
+    ///
     /// - Parameter id: Name of the tag.
+    /// - Note: Requires hashtag following feature to be available.
     @discardableResult
     func unfollowTag(_ id: String) async throws -> Tag {
-        try requireFlavour(flavoursSupportingFollowingTags)
+        try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "tags", id, "unfollow"])
             $0.method = .post
@@ -49,8 +53,9 @@ public extension TootClient {
     ///     - pageInfo: PagedInfo object for max/min/since ids.
     ///     - limit: Maximum number of results to return. Defaults to 100 tags. Max 200 tags.
     /// - Returns: the tags requested
+    /// - Note: Requires hashtag following feature to be available.
     func getFollowedTags(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Tag]> {
-        try requireFlavour(flavoursSupportingFollowingTags)
+        try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "followed_tags"])
             $0.method = .get
@@ -59,13 +64,12 @@ public extension TootClient {
 
         return try await fetchPagedResult(req)
     }
+}
 
-    /// Tells whether current flavour supports following or unfollowing tags.
-    var canFollowTags: Bool {
-        flavoursSupportingFollowingTags.contains(flavour)
-    }
+extension TootFeature {
 
-    private var flavoursSupportingFollowingTags: Set<TootSDKFlavour> {
-        [.mastodon, .friendica]
-    }
+    /// Ability to follow hashtags.
+    ///
+    /// Available for Mastodon and Friendica.
+    public static let hashtagFollowing = TootFeature(supportedFlavours: [.mastodon, .friendica])
 }

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -219,6 +219,10 @@ extension TootClient {
         try requireFlavour(supportedFlavours)
     }
 
+    internal func requireFeature(_ feature: TootFeature) throws {
+        try requireFlavour(feature.supportedFlavours)
+    }
+
     /// Performs a request that returns paginated arrays
     /// - Parameters:
     ///   - req: the HTTP request to execute
@@ -344,5 +348,13 @@ extension TootClient {
     /// Returns `true` if this instance of `TootClient` has no `accessToken`.
     public var isAnonymous: Bool {
         accessToken == nil
+    }
+    
+    /// Returns `true` if this instance of `TootClient` can perform methods that are related to given `feature`.
+    ///
+    /// - Parameter feature: The feature to check if is supported.
+    /// - Returns: `true` if the feature is supported.
+    public func supportsFeature(_ feature: TootFeature) -> Bool {
+        return feature.supportedFlavours.contains(flavour)
     }
 }

--- a/Tests/TootSDKTests/FeatureTests.swift
+++ b/Tests/TootSDKTests/FeatureTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import TootSDK
+
+final class FeatureTests: XCTestCase {
+
+    func testFeatureChecks() throws {
+        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+
+        client.flavour = .mastodon
+        XCTAssertTrue(client.supportsFeature(.featuredTags))
+        XCTAssertNoThrow(try client.requireFeature(.featuredTags))
+
+        client.flavour = .akkoma
+        XCTAssertFalse(client.supportsFeature(.featuredTags))
+        XCTAssertThrowsError(try client.requireFeature(.featuredTags))
+    }
+}


### PR DESCRIPTION
This pull request builds upon #187. Now that there are more features that I would like to check if are supported I decided to unify the api.

- Added a new `TootFeature` feature that describes requirements for a feature. Right now it has a list of supported flavours but could be extended to other requirements in future.
- Added requireFeature internal method that can be used to perform runtime check where necessary
- Use this new API to add featured tags and hashtag following features.
- This is a breaking change as it removes previously used `canXXX` variables. If necessary this removal can be reversed to preserve API compatibility.

Possibly related to #27.