### PR TITLE
Allow accessing details about unprocessed media attachments

### DIFF
--- a/Sources/TootSDK/Models/MediaAttachment.swift
+++ b/Sources/TootSDK/Models/MediaAttachment.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// Represents a file or media attachment that can be added to a post.
-public struct MediaAttachment: Codable, Hashable, Identifiable, Sendable {
+public struct MediaAttachment: Codable, Hashable, Identifiable, Sendable, MediaAttachmentProtocol {
 
     public init(id: String, type: AttachmentType, url: String, remoteUrl: String? = nil, previewUrl: String? = nil, meta: AttachmentMeta? = nil, description: String? = nil, blurhash: String? = nil) {
         self.id = id
@@ -91,10 +91,87 @@ public extension AttachmentMetaFocus {
     static let `default` = Self(x: 0, y: 0)
 }
 
-public struct UploadedMediaAttachment: Identifiable, Sendable {
+public struct UnprocessedMediaAttachment: Codable, Hashable, Identifiable, Sendable, MediaAttachmentProtocol {
     /// Identifier of the `MediaAttachment`
-    public let id: String
-    public let state: State
+    public var id: String
+    /// The type of the attachment.
+    public var type: AttachmentType
+    /// The location of the full-size original attachment on the remote website.
+    public var remoteUrl: String?
+    /// The location of a scaled-down preview of the attachment.
+    public var previewUrl: String?
+    /// Metadata returned by Paperclip, only `original`, `small` and `focus` are serialized.
+    public var meta: AttachmentMeta?
+    /// Alternate text that describes what is in the media attachment, to be used for the visually impaired or when media attachments do not load.
+    public var description: String?
+    /// A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+    public var blurhash: String?
+}
+
+public protocol MediaAttachmentProtocol {
+    /// Identifier of the `MediaAttachment`
+    var id: String { get }
+    /// The type of the attachment.
+    var type: AttachmentType { get }
+    /// The location of the full-size original attachment on the remote website.
+    var remoteUrl: String? { get }
+    /// The location of a scaled-down preview of the attachment.
+    var previewUrl: String? { get }
+    /// Metadata returned by Paperclip, only `original`, `small` and `focus` are serialized.
+    var meta: AttachmentMeta? { get }
+    /// Alternate text that describes what is in the media attachment, to be used for the visually impaired or when media attachments do not load.
+    var description: String? { get }
+    /// A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+    var blurhash: String? { get }
+}
+
+public enum UploadedMediaAttachment: Decodable, Identifiable, Sendable {
+
+    /// Represents media attachment which has been processed by server and has url available.
+    case uploaded(MediaAttachment)
+    /// Represents media attachment which is not yet processed by server and has no url available.
+    case unprocessed(UnprocessedMediaAttachment)
+
+    /// Identifier of the `MediaAttachment`
+    public var id: String {
+        return mediaAttachment.id
+    }
+
+    /// The state of media upload operation.
+    public var state: State {
+        switch self {
+        case .uploaded:
+            return .uploaded
+        case .unprocessed:
+            return .serverProcessing
+        }
+    }
+
+    /// Information about the attachment available for both uploaded and not yet processed attachments.
+    public var mediaAttachment: any MediaAttachmentProtocol {
+        switch self {
+        case .uploaded(let attachment):
+            return attachment
+        case .unprocessed(let attachment):
+            return attachment
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let singleValueContainer = try decoder.singleValueContainer()
+        if try container.decodeIfPresent(String.self, forKey: .url) != nil {
+            let attachment = try singleValueContainer.decode(MediaAttachment.self)
+            self = .uploaded(attachment)
+        } else {
+            let attachment = try singleValueContainer.decode(UnprocessedMediaAttachment.self)
+            self = .unprocessed(attachment)
+        }
+    }
+
+    enum CodingKeys: CodingKey {
+        case url
+    }
 
     public enum State: Sendable {
         /// The attachment is still being processed by the server
@@ -102,9 +179,4 @@ public struct UploadedMediaAttachment: Identifiable, Sendable {
         /// The attachment has been uploaded
         case uploaded
     }
-}
-
-internal struct UploadMediaAttachmentResponse: Codable {
-    public let id: String
-    public let url: String?
 }

--- a/Sources/TootSDK/TootClient/TootClient+Media.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Media.swift
@@ -28,9 +28,7 @@ public extension TootClient {
             ))
             $0.body = try .multipart(parts, boundary: UUID().uuidString)
         }
-        let uploadResponse = try await fetch(UploadMediaAttachmentResponse.self, req)
-
-        return uploadResponse.url != nil ? UploadedMediaAttachment(id: uploadResponse.id, state: .uploaded) : UploadedMediaAttachment(id: uploadResponse.id, state: .serverProcessing)
+        return try await fetch(UploadedMediaAttachment.self, req)
     }
 
     /// Retrieve the details of a media attachment that corresponds to the given identifier.


### PR DESCRIPTION
I'm adding video upload support to my app. In order to make user experience better for not yet uploaded videos I want to display their previews as soon as they are available. Right now this is impossible because TootSDK returns information other than processing state only when upload fully finishes.

In order to implement this I made following changes:

1. Changed `UploadedMediaAttachment` returned by `uploadMedia(_:mimeType:)` call to be an enum with both possible states and related models available as associated value.
2. Introduced `MediaAttachmentProtocol` with information that API returns both for fully uploaded and not yet processed media. This protocol is accessible as `mediaAttachment` property on `UploadedMediaAttachment`
3. Introduced `UnprocessedMediaAttachment` that has the same properties as `MediaAttachment` minus `url`.
4. Depending on the presence of `url` property in API response made TootSDK decode proper model.

If someone used uploadMedia before these changes they don't have to change their code. Both state and id that were previously returned are still available as properties of `UploadedMediaAttachment`.
