### PR TITLE
Make UIKitAttribStringRenderer macOS Compatible

### DIFF
--- a/Examples/swiftui-toot/SwiftUI-Toot-Info.plist
+++ b/Examples/swiftui-toot/SwiftUI-Toot-Info.plist
@@ -15,12 +15,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict/>
-	</dict>
 </dict>
 </plist>

--- a/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
+++ b/Examples/swiftui-toot/SwiftUI-Toot.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SwiftUI-Toot-Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -416,6 +417,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.lightbeamapps.TootSDK-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -434,6 +438,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SwiftUI-Toot-Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -445,6 +450,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.lightbeamapps.TootSDK-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Examples/swiftui-toot/TootSDK-Demo/TootSDK_DemoApp.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/TootSDK_DemoApp.swift
@@ -43,9 +43,15 @@ struct TootSDK_DemoApp: App {
             .onChange(of: tootManager.authenticated) { authenticated in
                 authIsPresented = !authenticated
             }
-            .fullScreenCover(isPresented: $authIsPresented) {
-                AuthorizeView()
-            }
+#if os(macOS)
+			.sheet(isPresented: $authIsPresented) {
+				AuthorizeView()
+			}
+#else
+			.fullScreenCover(isPresented: $authIsPresented) {
+				AuthorizeView()
+			}
+#endif
             .environmentObject(tootManager)
         }
     }

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/AuthorizeView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/AuthorizeView.swift
@@ -25,8 +25,9 @@ struct AuthorizeView: View {
                 
                 TextField("https://instance.tld", text: $urlString)
                     .autocorrectionDisabled(true)
+#if os(iOS)
                     .autocapitalization(.none)
-                
+#endif
                 Button {
                     Task {
                         do {

--- a/Examples/swiftui-toot/TootSDK-Demo/Views/MakePostView.swift
+++ b/Examples/swiftui-toot/TootSDK-Demo/Views/MakePostView.swift
@@ -91,7 +91,7 @@ struct MakePostView: View {
             }
             .toolbar {
                 if let _ = lastPostID {
-                    ToolbarItem(placement: .navigationBarTrailing) {
+                    ToolbarItem(placement: .automatic) {
                         Button {
                             if !lastPostScheduledPost {
                                 path.append(MakePostDestination.postOperations)
@@ -126,10 +126,17 @@ struct MakePostView: View {
         }
         
         if attachImage {
-            guard let imageData = UIImage(named: "dexter")?.jpegData(compressionQuality: 1.0) else {
-                print("🍅 Attachment image not found")
-                return nil
-            }
+#if os(macOS)
+			guard let img = NSImage(named: "dexter"), let imageData = img.tiffRepresentation else {
+				print("🍅 Attachment image not found")
+				return nil
+			}
+#else
+			guard let imageData = UIImage(named: "dexter")?.jpegData(compressionQuality: 1.0) else {
+				print("🍅 Attachment image not found")
+				return nil
+			}
+#endif
             
             let uploadParams = UploadMediaAttachmentParams(file: imageData, thumbnail: nil, description: "Dexter the cat helping me perfect file uploads in TootSDK", focus: nil)
             let uploadedAttachment = try await tootClient.uploadMedia(uploadParams, mimeType: "image/jpeg")

--- a/Sources/TootSDK/HTMLRendering/UIKitAttribStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/UIKitAttribStringRenderer.swift
@@ -53,10 +53,10 @@ public class UIKitAttribStringRenderer {
 		   let body = doc.body(),
 		   let attributedText = attributedTextForHTMLNode(body) {
 			let mutAttrString = NSMutableAttributedString(attributedString: attributedText)
-#if os(iOS)
-			mutAttrString.trimTrailingCharactersInSet(.whitespacesAndNewlines)
-#else
+#if os(macOS)
 			mutAttrString.trimCharactersInSet(charSet: .whitespacesAndNewlines)
+#else
+			mutAttrString.trimTrailingCharactersInSet(.whitespacesAndNewlines)
 #endif
 
 			return TootContent(wrappedValue: html, plainContent: plainText, attributedString: mutAttrString)
@@ -98,17 +98,17 @@ public class UIKitAttribStringRenderer {
 		case "strong", "b":
 			updateAttributedTextForBold(element, attributed: &attributed)
 		case "del":
-#if os(iOS)
-			attributed.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributed.fullRange)
-#else
+#if os(macOS)
 			attributed.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributed.fullRange())
+#else
+			attributed.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributed.fullRange)
 #endif
 		case "ol", "ul":
 			attributed.append(NSAttributedString(string: "\n\n"))
-#if os(iOS)
-			attributed.trimLeadingCharactersInSet(.whitespacesAndNewlines)
-#else
+#if os(macOS)
 			attributed.trimCharactersInSet(charSet: .whitespacesAndNewlines)
+#else
+			attributed.trimLeadingCharactersInSet(.whitespacesAndNewlines)
 #endif
 		case "li":
 			updateAttributedTextForList(element, attributed: &attributed)
@@ -138,29 +138,29 @@ public class UIKitAttribStringRenderer {
 
 		if let webURL = WebURL(href),
 		   let url = URL(webURL) {
-#if os(iOS)
-			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
-#else
+#if os(macOS)
 			attributed.addAttribute(.link, value: url, range: attributed.fullRange())
+#else
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
 #endif
 		} else if let url = URL(string: href) {
-#if os(iOS)
-			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
-#else
+#if os(macOS)
 			attributed.addAttribute(.link, value: url, range: attributed.fullRange())
+#else
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
 #endif
 		}
 	}
 
 	private func updateAttributedTextForItalic(_ element: Element, attributed: inout NSMutableAttributedString) {
 		if attributed.length > 0 {
-#if os(iOS)
-			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
-				try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange)
-			}
-#else
+#if os(macOS)
 			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont {
 				try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange())
+			}
+#else
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange)
 			}
 #endif
 		} else {
@@ -170,13 +170,13 @@ public class UIKitAttribStringRenderer {
 
 	private func updateAttributedTextForBold(_ element: Element, attributed: inout NSMutableAttributedString) {
 		if attributed.length > 0 {
-#if os(iOS)
-			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
-				try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange)
-			}
-#else
+#if os(macOS)
 			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont {
 				try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange())
+			}
+#else
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange)
 			}
 #endif
 		} else {

--- a/Sources/TootSDK/HTMLRendering/UIKitAttribStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/UIKitAttribStringRenderer.swift
@@ -1,184 +1,217 @@
 //  UIKitAttribStringRenderer.swift
 //  Created by dave on 28/12/22.
 
-#if canImport(UIKit)
-import Foundation
+#if os(iOS)
 import UIKit
+#else
+import AppKit
+#endif
+import Foundation
 import WebURL
 import WebURLFoundationExtras
 import SwiftSoup
 
 public class UIKitAttribStringRenderer {
 
-    public init() {}
+	public init() {}
 
-    /// Renders the provided HTML string
-    /// - Parameters:
-    ///   - html: html description
-    ///   - emojis: the custom emojis used in the HTML, provided with shortcode values between ":"
-    /// - Returns: an instance `TootContent` with various representations of the content
-    public func render(html: String?,
-                       emojis: [Emoji]) throws -> TootContent {
+	/// Renders the provided HTML string
+	/// - Parameters:
+	///   - html: html description
+	///   - emojis: the custom emojis used in the HTML, provided with shortcode values between ":"
+	/// - Returns: an instance `TootContent` with various representations of the content
+	public func render(html: String?,
+					   emojis: [Emoji]) throws -> TootContent {
 
-        guard let html = html else {
-            return TootContent(wrappedValue: "", plainContent: "", attributedString: NSAttributedString(string: ""))
-        }
+		guard let html = html else {
+			return TootContent(wrappedValue: "", plainContent: "", attributedString: NSAttributedString(string: ""))
+		}
 
-        return try renderHTML(html: html, emojis: emojis)
-    }
+		return try renderHTML(html: html, emojis: emojis)
+	}
 
-    // MARK: - Properties
+	// MARK: - Properties
 
-    /// Renders the provided HTML string
-    /// - Parameters:
-    ///   - html: html description
-    ///   - emojis: the custom emojis used in the HTML, provided with shortcode values between ":"
-    /// - Returns: an instance `TootContent` with various representations of the content
-    private func renderHTML(html: String,
-                            emojis: [Emoji]) throws -> TootContent {
-        var html = html
+	/// Renders the provided HTML string
+	/// - Parameters:
+	///   - html: html description
+	///   - emojis: the custom emojis used in the HTML, provided with shortcode values between ":"
+	/// - Returns: an instance `TootContent` with various representations of the content
+	private func renderHTML(html: String,
+							emojis: [Emoji]) throws -> TootContent {
+		var html = html
 
-        // attempt to parse emojis and other special content
-        // Replace the custom emojis with image refs
-        emojis.forEach { emoji in
-            html = html.replacingOccurrences(of: ":" + emoji.shortcode + ":", with: "<img src='" + emoji.staticUrl + "' alt='" + emoji.shortcode + "' data-tootsdk-emoji='true'>")
-        }
+		// attempt to parse emojis and other special content
+		// Replace the custom emojis with image refs
+		emojis.forEach { emoji in
+			html = html.replacingOccurrences(of: ":" + emoji.shortcode + ":", with: "<img src='" + emoji.staticUrl + "' alt='" + emoji.shortcode + "' data-tootsdk-emoji='true'>")
+		}
 
-        let plainText = TootHTML.extractAsPlainText(html: html) ?? ""
+		let plainText = TootHTML.extractAsPlainText(html: html) ?? ""
 
-        if let doc = try? SwiftSoup.parseBodyFragment(html),
-           let body = doc.body(),
-           let attributedText = attributedTextForHTMLNode(body) {
-            let mutAttrString = NSMutableAttributedString(attributedString: attributedText)
-            mutAttrString.trimTrailingCharactersInSet(.whitespacesAndNewlines)
-
-            return TootContent(wrappedValue: html, plainContent: plainText, attributedString: mutAttrString)
-        } else {
-            return TootContent(wrappedValue: html, plainContent: plainText, attributedString: NSAttributedString(string: html))
-        }
-    }
-
-    private func attributedTextForHTMLNode(_ node: Node) -> NSAttributedString? {
-        switch node {
-        case let node as TextNode:
-            return  NSAttributedString(string: node.text())
-        case let node as Element:
-            return attributedTextForElement(node)
-        default:
-            return nil
-        }
-    }
-
-    private func attributedTextForElement(_ element: Element) -> NSAttributedString? {  // swiftlint:disable:this cyclomatic_complexity
-        var attributed = NSMutableAttributedString(string: "")
-
-        for child in element.getChildNodes() {
-            /// Recursive appending
-            if let childAttributed = attributedTextForHTMLNode(child) {
-                attributed.append(childAttributed)
-            }
-        }
-
-        switch element.tagName() {
-        case "br":
-            attributed.append(NSAttributedString(string: "\n"))
-        case "p":
-            attributed.append(NSAttributedString(string: "\n\n"))
-        case "a":
-            attributedTextForHref(element, attributed: &attributed)
-        case "em", "i":
-            updateAttributedTextForItalic(element, attributed: &attributed)
-        case "strong", "b":
-            updateAttributedTextForBold(element, attributed: &attributed)
-        case "del":
-            attributed.addAttribute(.strikethroughStyle,
-                                    value: NSUnderlineStyle.single.rawValue,
-                                    range: attributed.fullRange)
-        case "ol", "ul":
-            attributed.append(NSAttributedString(string: "\n\n"))
-            attributed.trimLeadingCharactersInSet(.whitespacesAndNewlines)
-        case "li":
-            updateAttributedTextForList(element, attributed: &attributed)
-        case "img":
-            if let imgAttr = try? attributedTextForImage(element) {
-                attributed.append(imgAttr)
-            }
-        default:
-            break
-        }
-
-        return attributed
-    }
-
-    private func attributedTextForImage(_ element: Element) throws -> NSAttributedString? {
-        guard let _ = try? element.attr("src") else { return nil }
-        if let _ = try? element.attr("data-tootsdk-emoji"), let alt = try? element.attr("alt") {
-            // fallback to the the :short_code
-            return NSAttributedString(string: ":" + alt)
-        }
-
-        return NSAttributedString(string: try element.html())
-    }
-
-    private func attributedTextForHref(_ element: Element, attributed: inout NSMutableAttributedString) {
-        guard let href = try? element.attr("href") else { return }
-
-        if let webURL = WebURL(href),
-           let url = URL(webURL) {
-            attributed.addAttribute(.link, value: url, range: attributed.fullRange)
-        } else if let url = URL(string: href) {
-            attributed.addAttribute(.link, value: url, range: attributed.fullRange)
-        }
-    }
-
-    private func updateAttributedTextForItalic(_ element: Element, attributed: inout NSMutableAttributedString) {
-        if attributed.length > 0,
-           let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
-            try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange)
-        } else {
-            // try? attributed.addAttribute(.font, value: config.font.asItalic(), range: attributed.fullRange)
-        }
-    }
-
-    private func updateAttributedTextForBold(_ element: Element, attributed: inout NSMutableAttributedString) {
-        if attributed.length > 0,
-           let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
-            try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange)
-        } else {
-            // try? attributed.addAttribute(.font, value: config.font.asBold(), range: attributed.fullRange)
-        }
-    }
-
-    private func updateAttributedTextForList(_ element: Element, attributed: inout NSMutableAttributedString) {
-        if let parentTag = element.parent()?.tagName() {
-            let bullet: NSAttributedString
-
-            switch parentTag {
-            case "ol":
-                let index = (try? element.elementSiblingIndex()) ?? 0
-                bullet = NSAttributedString(string: "\(index + 1).\t")
-            case "ul":
-                bullet = NSAttributedString(string: "\u{2022}\t")
-            default:
-                bullet = NSAttributedString()
-            }
-
-            attributed.insert(bullet, at: 0)
-            attributed.append(NSAttributedString(string: "\n"))
-        }
-    }
-
-    /// Renders a post into TootContent
-    /// - Parameter tootPost: the post to render
-    /// - Returns: the TootContent constructed
-    public func render(_ tootPost: Post) -> TootContent {
-        do {
-            return try render(html: tootPost.content ?? "", emojis: tootPost.emojis)
-        } catch {
-            print("TootSDK(UIKitAttribStringRenderer): Failed to render post: \(String(describing: error))")
-            return .init(wrappedValue: "", plainContent: "", attributedString: .init(string: ""))
-        }
-    }
-}
-
+		if let doc = try? SwiftSoup.parseBodyFragment(html),
+		   let body = doc.body(),
+		   let attributedText = attributedTextForHTMLNode(body) {
+			let mutAttrString = NSMutableAttributedString(attributedString: attributedText)
+#if os(iOS)
+			mutAttrString.trimTrailingCharactersInSet(.whitespacesAndNewlines)
+#else
+			mutAttrString.trimCharactersInSet(charSet: .whitespacesAndNewlines)
 #endif
+
+			return TootContent(wrappedValue: html, plainContent: plainText, attributedString: mutAttrString)
+		} else {
+			return TootContent(wrappedValue: html, plainContent: plainText, attributedString: NSAttributedString(string: html))
+		}
+	}
+
+	private func attributedTextForHTMLNode(_ node: Node) -> NSAttributedString? {
+		switch node {
+		case let node as TextNode:
+			return  NSAttributedString(string: node.text())
+		case let node as Element:
+			return attributedTextForElement(node)
+		default:
+			return nil
+		}
+	}
+
+	private func attributedTextForElement(_ element: Element) -> NSAttributedString? {  // swiftlint:disable:this cyclomatic_complexity
+		var attributed = NSMutableAttributedString(string: "")
+
+		for child in element.getChildNodes() {
+			/// Recursive appending
+			if let childAttributed = attributedTextForHTMLNode(child) {
+				attributed.append(childAttributed)
+			}
+		}
+
+		switch element.tagName() {
+		case "br":
+			attributed.append(NSAttributedString(string: "\n"))
+		case "p":
+			attributed.append(NSAttributedString(string: "\n\n"))
+		case "a":
+			attributedTextForHref(element, attributed: &attributed)
+		case "em", "i":
+			updateAttributedTextForItalic(element, attributed: &attributed)
+		case "strong", "b":
+			updateAttributedTextForBold(element, attributed: &attributed)
+		case "del":
+#if os(iOS)
+			attributed.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributed.fullRange)
+#else
+			attributed.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributed.fullRange())
+#endif
+		case "ol", "ul":
+			attributed.append(NSAttributedString(string: "\n\n"))
+#if os(iOS)
+			attributed.trimLeadingCharactersInSet(.whitespacesAndNewlines)
+#else
+			attributed.trimCharactersInSet(charSet: .whitespacesAndNewlines)
+#endif
+		case "li":
+			updateAttributedTextForList(element, attributed: &attributed)
+		case "img":
+			if let imgAttr = try? attributedTextForImage(element) {
+				attributed.append(imgAttr)
+			}
+		default:
+			break
+		}
+
+		return attributed
+	}
+
+	private func attributedTextForImage(_ element: Element) throws -> NSAttributedString? {
+		guard let _ = try? element.attr("src") else { return nil }
+		if let _ = try? element.attr("data-tootsdk-emoji"), let alt = try? element.attr("alt") {
+			// fallback to the the :short_code
+			return NSAttributedString(string: ":" + alt)
+		}
+
+		return NSAttributedString(string: try element.html())
+	}
+
+	private func attributedTextForHref(_ element: Element, attributed: inout NSMutableAttributedString) {
+		guard let href = try? element.attr("href") else { return }
+
+		if let webURL = WebURL(href),
+		   let url = URL(webURL) {
+#if os(iOS)
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
+#else
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange())
+#endif
+		} else if let url = URL(string: href) {
+#if os(iOS)
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange)
+#else
+			attributed.addAttribute(.link, value: url, range: attributed.fullRange())
+#endif
+		}
+	}
+
+	private func updateAttributedTextForItalic(_ element: Element, attributed: inout NSMutableAttributedString) {
+		if attributed.length > 0 {
+#if os(iOS)
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange)
+			}
+#else
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asItalic(), range: attributed.fullRange())
+			}
+#endif
+		} else {
+			// try? attributed.addAttribute(.font, value: config.font.asItalic(), range: attributed.fullRange)
+		}
+	}
+
+	private func updateAttributedTextForBold(_ element: Element, attributed: inout NSMutableAttributedString) {
+		if attributed.length > 0 {
+#if os(iOS)
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange)
+			}
+#else
+			if let fontInAttributes = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont {
+				try? attributed.addAttribute(.font, value: fontInAttributes.asBold(), range: attributed.fullRange())
+			}
+#endif
+		} else {
+			// try? attributed.addAttribute(.font, value: config.font.asBold(), range: attributed.fullRange)
+		}
+	}
+
+	private func updateAttributedTextForList(_ element: Element, attributed: inout NSMutableAttributedString) {
+		if let parentTag = element.parent()?.tagName() {
+			let bullet: NSAttributedString
+
+			switch parentTag {
+			case "ol":
+				let index = (try? element.elementSiblingIndex()) ?? 0
+				bullet = NSAttributedString(string: "\(index + 1).\t")
+			case "ul":
+				bullet = NSAttributedString(string: "\u{2022}\t")
+			default:
+				bullet = NSAttributedString()
+			}
+
+			attributed.insert(bullet, at: 0)
+			attributed.append(NSAttributedString(string: "\n"))
+		}
+	}
+
+	/// Renders a post into TootContent
+	/// - Parameter tootPost: the post to render
+	/// - Returns: the TootContent constructed
+	public func render(_ tootPost: Post) -> TootContent {
+		do {
+			return try render(html: tootPost.content ?? "", emojis: tootPost.emojis)
+		} catch {
+			print("TootSDK(UIKitAttribStringRenderer): Failed to render post: \(String(describing: error))")
+			return .init(wrappedValue: "", plainContent: "", attributedString: .init(string: ""))
+		}
+	}
+}


### PR DESCRIPTION
Changed UIKitAttribStringRenderer so that it compiles under macOS (not Catalyst) correctly. Also changed the example project so that it will build as a macOS target.

Maybe would want to rename UIKitAttribStringRenderer since it's not just for UIKit?