### PR TITLE
Add support for instance rules

### DIFF
--- a/Sources/TootSDK/Models/Instance.swift
+++ b/Sources/TootSDK/Models/Instance.swift
@@ -20,7 +20,8 @@ public struct Instance: Codable, Hashable {
         stats: Instance.Stats,
         thumbnail: String? = nil,
         configuration: Configuration? = nil,
-        contactAccount: Account? = nil
+        contactAccount: Account? = nil,
+        rules: [InstanceRule]? = nil
     ) {
         self.uri = uri
         self.title = title
@@ -37,6 +38,7 @@ public struct Instance: Codable, Hashable {
         self.thumbnail = thumbnail
         self.configuration = configuration
         self.contactAccount = contactAccount
+        self.rules = rules
     }
 
     /// The domain name of the instance.
@@ -69,6 +71,8 @@ public struct Instance: Codable, Hashable {
     public var configuration: Configuration?
     /// A user that can be contacted, as an alternative to email.
     public var contactAccount: Account?
+    /// An itemized list of rules for users of the instance.
+    public var rules: [InstanceRule]?
 
     public struct InstanceURLs: Codable, Hashable {
         /// Websockets address for push streaming. String (URL).

--- a/Sources/TootSDK/Models/InstanceRule.swift
+++ b/Sources/TootSDK/Models/InstanceRule.swift
@@ -1,0 +1,18 @@
+//
+//  InstanceRule.swift
+//
+//
+//  Created by Dale Price on 10/26/23.
+//
+
+import Foundation
+
+/// Represents a rule that server users should follow.
+public struct InstanceRule: Codable, Hashable, Identifiable {
+    /// Identifier for the rule.
+    ///
+    /// > Note: Cast from integer, but not guaranteed to be a number.
+    public var id: String
+    /// The text content of the rule.
+    public var text: String?
+}

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -15,4 +15,12 @@ extension TootClient {
         }
         return try await fetch(Instance.self, req)
     }
+    
+    public func getInstanceRules() async throws -> [InstanceRule] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "rules"])
+            $0.method = .get
+        }
+        return try await fetch([InstanceRule].self, req)
+    }
 }


### PR DESCRIPTION
- Parse instance rules from instance info (https://docs.joinmastodon.org/entities/Instance/#rules) when using `TootClient.getInstanceInfo()`
- Ability to request just the rules from [`api/v1/instance/rules`](https://docs.joinmastodon.org/methods/instance/#rules) using `TootClient.getInstanceRules()`