### PR TITLE
Add support for reports

### DIFF
--- a/Sources/TootSDK/Models/PixelfedReportParams.swift
+++ b/Sources/TootSDK/Models/PixelfedReportParams.swift
@@ -1,0 +1,48 @@
+//
+//  PixelfedReportParams.swift
+//  
+//
+//  Created by Łukasz Rutkowski on 31/10/2023.
+//
+
+import Foundation
+
+/// Parameters to report a post on Pixelfed.
+public struct PixelfedReportParams: Codable {
+
+    /// Type of reported object (post or user).
+    public var objectType: ObjectType
+    /// ID of reported object.
+    public var objectId: String
+    /// Type of report.
+    public var type: ReportType
+
+    public init(objectType: ObjectType, objectId: String, type: ReportType) {
+        self.objectType = objectType
+        self.objectId = objectId
+        self.type = type
+    }
+
+    public enum ReportType: String, Codable {
+        case spam
+        case sensitive
+        case abusive
+        case underage
+        case violence
+        case copyright
+        case impersonation
+        case scam
+        case terrorism
+    }
+
+    public enum ObjectType: String, Codable {
+        case post
+        case user
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case objectType = "object_type"
+        case objectId = "object_id"
+        case type = "report_type"
+    }
+}

--- a/Sources/TootSDK/Models/PixelfedReportParams.swift
+++ b/Sources/TootSDK/Models/PixelfedReportParams.swift
@@ -7,35 +7,12 @@
 
 import Foundation
 
-/// Parameters to report a post on Pixelfed.
-public struct PixelfedReportParams: Codable {
+struct PixelfedReportParams: Codable {
+    var objectType: ObjectType
+    var objectId: String
+    var type: ReportCategory
 
-    /// Type of reported object (post or user).
-    public var objectType: ObjectType
-    /// ID of reported object.
-    public var objectId: String
-    /// Type of report.
-    public var type: ReportType
-
-    public init(objectType: ObjectType, objectId: String, type: ReportType) {
-        self.objectType = objectType
-        self.objectId = objectId
-        self.type = type
-    }
-
-    public enum ReportType: String, Codable {
-        case spam
-        case sensitive
-        case abusive
-        case underage
-        case violence
-        case copyright
-        case impersonation
-        case scam
-        case terrorism
-    }
-
-    public enum ObjectType: String, Codable {
+    enum ObjectType: String, Codable {
         case post
         case user
     }

--- a/Sources/TootSDK/Models/ReportCategory.swift
+++ b/Sources/TootSDK/Models/ReportCategory.swift
@@ -1,0 +1,40 @@
+//
+//  ReportCategory.swift
+//  
+//
+//  Created by Łukasz Rutkowski on 01/11/2023.
+//
+
+import Foundation
+
+public enum ReportCategory: String, CaseIterable, Codable {
+    case spam
+    case sensitive
+    case abusive
+    case underage
+    case violence
+    case copyright
+    case impersonation
+    case scam
+    case terrorism
+    case other
+    case violation
+
+    public static let pixelfedSupported: Set<ReportCategory> = [
+        .spam,
+        .sensitive,
+        .abusive,
+        .underage,
+        .violence,
+        .copyright,
+        .impersonation,
+        .scam,
+        .terrorism
+    ]
+
+    public static let mastodonSupported: Set<ReportCategory> = [
+        .spam,
+        .other,
+        .violation
+    ]
+}

--- a/Sources/TootSDK/Models/ReportParams.swift
+++ b/Sources/TootSDK/Models/ReportParams.swift
@@ -25,7 +25,7 @@ public struct ReportParams {
     public var category: ReportCategory
 
     /// For violation category reports, specify the ID of the exact rules broken.
-    public var ruleIds: [Int]?
+    public var ruleIds: [Int]
 
     public init(
         accountId: String,
@@ -33,7 +33,7 @@ public struct ReportParams {
         postIds: [String] = [],
         comment: String? = nil,
         forward: Bool? = nil,
-        ruleIds: [Int]? = nil
+        ruleIds: [Int] = []
     ) {
         self.accountId = accountId
         self.postIds = postIds

--- a/Sources/TootSDK/Models/ReportParams.swift
+++ b/Sources/TootSDK/Models/ReportParams.swift
@@ -1,0 +1,40 @@
+//
+//  ReportParams.swift
+//  
+//
+//  Created by Łukasz Rutkowski on 31/10/2023.
+//
+
+import Foundation
+
+/// Parameters to report a post.
+public struct ReportParams {
+    /// ID of the account to report.
+    public var accountId: String
+    /// IDs of reported posts for additional context.
+    public var postIds: [String]
+    /// The reason for the report. Default maximum of 1000 characters.
+    public var comment: String?
+    /// If the account is remote, should the report be forwarded to the remote admin? Defaults to `false`.
+    public var forward: Bool?
+    /// Specify if the report is due to spam, violation of enumerated instance rules, or some other reason. Defaults to "other". Will be set to "violation" if `ruleIds` is provided (regardless of any category value you provide).
+    public var category: String?
+    /// For violation category reports, specify the ID of the exact rules broken.
+    public var ruleIds: [Int]?
+
+    public init(
+        accountId: String,
+        postIds: [String] = [],
+        comment: String? = nil,
+        forward: Bool? = nil,
+        category: String? = nil,
+        ruleIds: [Int]? = nil
+    ) {
+        self.accountId = accountId
+        self.postIds = postIds
+        self.comment = comment
+        self.forward = forward
+        self.category = category
+        self.ruleIds = ruleIds
+    }
+}

--- a/Sources/TootSDK/Models/ReportParams.swift
+++ b/Sources/TootSDK/Models/ReportParams.swift
@@ -11,23 +11,28 @@ import Foundation
 public struct ReportParams {
     /// ID of the account to report.
     public var accountId: String
+
     /// IDs of reported posts for additional context.
     public var postIds: [String]
+
     /// The reason for the report. Default maximum of 1000 characters.
     public var comment: String?
+
     /// If the account is remote, should the report be forwarded to the remote admin? Defaults to `false`.
     public var forward: Bool?
-    /// Specify if the report is due to spam, violation of enumerated instance rules, or some other reason. Defaults to "other". Will be set to "violation" if `ruleIds` is provided (regardless of any category value you provide).
-    public var category: String?
+
+    /// Specify if the report is due to spam, violation of enumerated instance rules, or some other reason. Will be set to `violation` if `ruleIds` is provided (regardless of any category value you provide).
+    public var category: ReportCategory
+
     /// For violation category reports, specify the ID of the exact rules broken.
     public var ruleIds: [Int]?
 
     public init(
         accountId: String,
+        category: ReportCategory,
         postIds: [String] = [],
         comment: String? = nil,
         forward: Bool? = nil,
-        category: String? = nil,
         ruleIds: [Int]? = nil
     ) {
         self.accountId = accountId

--- a/Sources/TootSDK/TootClient/TootClient+Reports.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Reports.swift
@@ -70,7 +70,7 @@ extension TootClient {
         if ReportCategory.mastodonSupported.contains(params.category) {
             queryItems.append(.init(name: "category", value: params.category.rawValue))
         }
-        for ruleId in params.ruleIds ?? [] {
+        for ruleId in params.ruleIds {
             queryItems.append(.init(name: "rule_ids[]", value: String(ruleId)))
         }
         return queryItems

--- a/Sources/TootSDK/TootClient/TootClient+Reports.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Reports.swift
@@ -1,0 +1,63 @@
+//
+//  TootClient+Reports.swift
+//  
+//
+//  Created by Łukasz Rutkowski on 26/10/2023.
+//
+
+import Foundation
+
+public extension TootClient {
+
+    /// Report problematic users or posts to moderators.
+    ///
+    /// - Warning: For Pixelfed use `PixelfedReportParams`.
+    @discardableResult
+    func report(_ params: ReportParams) async throws -> Report {
+        try requireFlavour(otherThan: [.pixelfed])
+        let req = try HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "reports"])
+            $0.method = .post
+            $0.body = try .form(queryItems: createQuery(from: params))
+        }
+
+        return try await fetch(Report.self, req)
+    }
+
+    /// Report problematic users or posts to moderators.
+    ///
+    /// - Warning: For flavours other than Pixelfed use `ReportParams`.
+    func report(_ params: PixelfedReportParams) async throws {
+        try requireFlavour([.pixelfed])
+        let req = try HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1.1", "report"])
+            $0.method = .post
+            $0.body = try .json(params)
+        }
+        _ = try await fetch(req: req)
+    }
+}
+
+extension TootClient {
+    internal func createQuery(from params: ReportParams) -> [URLQueryItem] {
+        var queryItems = [
+            URLQueryItem(name: "account_id", value: params.accountId)
+        ]
+        for postId in params.postIds {
+            queryItems.append(URLQueryItem(name: "status_ids[]", value: postId))
+        }
+        if let comment = params.comment {
+            queryItems.append(.init(name: "comment", value: comment))
+        }
+        if let forward = params.forward {
+            queryItems.append(.init(name: "forward", value: String(forward).lowercased()))
+        }
+        if let category = params.category {
+            queryItems.append(.init(name: "category", value: category))
+        }
+        for ruleId in params.ruleIds ?? [] {
+            queryItems.append(.init(name: "rule_ids[]", value: String(ruleId)))
+        }
+        return queryItems
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Reports.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Reports.swift
@@ -10,11 +10,10 @@ import Foundation
 public extension TootClient {
 
     /// Report problematic users or posts to moderators.
-    @discardableResult
-    func report(_ params: ReportParams) async throws -> Report? {
+    func report(_ params: ReportParams) async throws {
         if flavour == .pixelfed {
             try await pixelfedReport(params)
-            return nil
+            return
         }
 
         let req = try HTTPRequestBuilder {
@@ -23,7 +22,7 @@ public extension TootClient {
             $0.body = try .form(queryItems: createQuery(from: params))
         }
 
-        return try await fetch(Report.self, req)
+        _ = try await fetch(req: req)
     }
     
     /// Report categories supported by current flavour.


### PR DESCRIPTION
All flavours except for Pixelfed use:
- https://docs.joinmastodon.org/methods/reports/#post

Pixelfed doesn't implement that API but has its own. Unfortunately I didn't find public documentation so this implementation is based on source code.

- [Endpoint route](https://github.com/pixelfed/pixelfed/blob/4b9d0dc6efb1206ac51fc00e6f94c264da33d278/routes/api.php#L114)
- [Endpoint implementation](https://github.com/pixelfed/pixelfed/blob/4b9d0dc6efb1206ac51fc00e6f94c264da33d278/app/Http/Controllers/Api/ApiV1Dot1Controller.php#L68)
- Example from Vernissage (open source Pixelfed iOS app): [Reports.swift](https://github.com/VernissageApp/Vernissage/blob/2b88870995366de53ac99b250f68e2f928e5482b/PixelfedKit/Sources/PixelfedKit/Targets/Reports.swift#L15), [Report.swift](https://github.com/VernissageApp/Vernissage/blob/2b88870995366de53ac99b250f68e2f928e5482b/PixelfedKit/Sources/PixelfedKit/Entities/Report.swift#L10C32-L10C32)

---

In implementation I decided to differentiate these by a different type of params. Alternatively could rename one of the functions. Didn't see a way to use single function as the calls are too different.