### PR TITLE
fill in missing fields in Announcement and add TootClient.addAnnouncementReaction, TootClient.removeAnnouncementReaction

### DIFF
--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -14,6 +14,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
                 updatedAt: Date? = nil,
                 read: Bool? = nil,
                 mentions: [Announcement.Account],
+                statuses: [Announcement.Status],
                 tags: [Tag],
                 emojis: [Emoji],
                 reactions: [AnnouncementReaction],
@@ -28,6 +29,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
         self.updatedAt = updatedAt
         self.read = read
         self.mentions = mentions
+        self.statuses = statuses
         self.tags = tags
         self.emojis = emojis
         self.reactions = reactions
@@ -51,8 +53,11 @@ public struct Announcement: Codable, Hashable, Identifiable {
     public let updatedAt: Date?
     /// Whether the announcement has been read by the user.
     public let read: Bool?
-    /// Tags linked in the announcement text.
+    /// Accounts mentioned in the announcement text.
     public let mentions: [Announcement.Account]
+    /// Statuses mentioned in the announcement text.
+    public let statuses: [Announcement.Status]
+    /// Tags linked in the announcement text.
     public let tags: [Tag]
     /// Custom emoji used in the announcement text.
     public let emojis: [Emoji]
@@ -80,5 +85,17 @@ public struct Announcement: Codable, Hashable, Identifiable {
         /// The webfinger acct: URI of the mentioned user.
         /// Equivalent to username for local users, or username@domain for remote users.
         public var acct: String
+    }
+    
+    public struct Status: Codable, Hashable, Identifiable {
+        public init(id: String, url: String) {
+            self.id = id
+            self.url = url
+        }
+
+        /// The ID of an attached Status in the database.
+        public var id: String
+        /// The URL of an attached Status.
+        public var url: String
     }
 }

--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -13,6 +13,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
                 createdAt: Date? = nil,
                 updatedAt: Date? = nil,
                 read: Bool,
+                mentions: [Announcement.Account],
                 tags: [Tag],
                 emojis: [Emoji],
                 reactions: [AnnouncementReaction],
@@ -26,6 +27,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.read = read
+        self.mentions = mentions
         self.tags = tags
         self.emojis = emojis
         self.reactions = reactions
@@ -50,6 +52,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
     /// Whether the announcement has been read by the user.
     public let read: Bool
     /// Tags linked in the announcement text.
+    public let mentions: [Announcement.Account]
     public let tags: [Tag]
     /// Custom emoji used in the announcement text.
     public let emojis: [Emoji]
@@ -59,4 +62,23 @@ public struct Announcement: Codable, Hashable, Identifiable {
     public let startsAt: Date?
     ///  When the future announcement will end.
     public let endsAt: Date?
+
+    public struct Account: Codable, Hashable, Identifiable {
+        public init(id: String, username: String, url: String, acct: String) {
+            self.id = id
+            self.username = username
+            self.url = url
+            self.acct = acct
+        }
+
+        /// The account ID of the mentioned user.
+        public var id: String
+        /// The username of the mentioned user.
+        public var username: String
+        /// The location of the mentioned user’s profile.
+        public var url: String
+        /// The webfinger acct: URI of the mentioned user.
+        /// Equivalent to username for local users, or username@domain for remote users.
+        public var acct: String
+    }
 }

--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -13,6 +13,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
                 createdAt: Date? = nil,
                 updatedAt: Date? = nil,
                 read: Bool,
+                tags: [Tag],
                 emojis: [Emoji],
                 reactions: [AnnouncementReaction],
                 startsAt: Date? = nil,
@@ -25,6 +26,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.read = read
+        self.tags = tags
         self.emojis = emojis
         self.reactions = reactions
         self.startsAt = startsAt
@@ -47,6 +49,8 @@ public struct Announcement: Codable, Hashable, Identifiable {
     public let updatedAt: Date?
     /// Whether the announcement has been read by the user.
     public let read: Bool
+    /// Tags linked in the announcement text.
+    public let tags: [Tag]
     /// Custom emoji used in the announcement text.
     public let emojis: [Emoji]
     /// Emoji reactions attached to the announcement.

--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -86,7 +86,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
         /// Equivalent to username for local users, or username@domain for remote users.
         public var acct: String
     }
-    
+
     public struct Status: Codable, Hashable, Identifiable {
         public init(id: String, url: String) {
             self.id = id

--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -13,6 +13,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
                 createdAt: Date? = nil,
                 updatedAt: Date? = nil,
                 read: Bool,
+                emojis: [Emoji],
                 reactions: [AnnouncementReaction],
                 startsAt: Date? = nil,
                 endsAt: Date? = nil) {
@@ -24,6 +25,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.read = read
+        self.emojis = emojis
         self.reactions = reactions
         self.startsAt = startsAt
         self.endsAt = endsAt
@@ -45,6 +47,8 @@ public struct Announcement: Codable, Hashable, Identifiable {
     public let updatedAt: Date?
     /// Whether the announcement has been read by the user.
     public let read: Bool
+    /// Custom emoji used in the announcement text.
+    public let emojis: [Emoji]
     /// Emoji reactions attached to the announcement.
     public let reactions: [AnnouncementReaction]
     ///  When the future announcement will start.

--- a/Sources/TootSDK/Models/Announcement.swift
+++ b/Sources/TootSDK/Models/Announcement.swift
@@ -12,7 +12,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
                 allDay: Bool,
                 createdAt: Date? = nil,
                 updatedAt: Date? = nil,
-                read: Bool,
+                read: Bool? = nil,
                 mentions: [Announcement.Account],
                 tags: [Tag],
                 emojis: [Emoji],
@@ -50,7 +50,7 @@ public struct Announcement: Codable, Hashable, Identifiable {
     /// When the announcement was last updated.
     public let updatedAt: Date?
     /// Whether the announcement has been read by the user.
-    public let read: Bool
+    public let read: Bool?
     /// Tags linked in the announcement text.
     public let mentions: [Announcement.Account]
     public let tags: [Tag]

--- a/Sources/TootSDK/TootClient/TootClient+Announcements.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Announcements.swift
@@ -31,6 +31,34 @@ public extension TootClient {
 
         _ = try await fetch(req: req)
     }
+    
+    /// React to an announcement with an emoji.
+    /// - Parameters:
+    ///   - id: The ID of the Announcement in the database.
+    ///   - name: Unicode emoji, or the shortcode of a custom emoji.
+    func addAnnouncementReaction(id: String, name: String) async throws {
+        try requireFeature(.announcements)
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "announcements", id, "reactions", name])
+            $0.method = .put
+        }
+
+        _ = try await fetch(req: req)
+    }
+    
+    /// Undo a react emoji to an announcement.
+    /// - Parameters:
+    ///   - id: The ID of the Announcement in the database.
+    ///   - name: Unicode emoji, or the shortcode of a custom emoji.
+    func removeAnnouncementReaction(id: String, name: String) async throws {
+        try requireFeature(.announcements)
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "announcements", id, "reactions", name])
+            $0.method = .delete
+        }
+
+        _ = try await fetch(req: req)
+    }
 }
 
 extension TootFeature {

--- a/Sources/TootSDK/TootClient/TootClient+Announcements.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Announcements.swift
@@ -31,7 +31,7 @@ public extension TootClient {
 
         _ = try await fetch(req: req)
     }
-    
+
     /// React to an announcement with an emoji.
     /// - Parameters:
     ///   - id: The ID of the Announcement in the database.
@@ -45,7 +45,7 @@ public extension TootClient {
 
         _ = try await fetch(req: req)
     }
-    
+
     /// Undo a react emoji to an announcement.
     /// - Parameters:
     ///   - id: The ID of the Announcement in the database.


### PR DESCRIPTION
The additional fields include emojis and emoji reactions, as shown in this screenshot of the announcement on mstdn.social. Also made Announcement.read optional per the mastodon spec.

https://docs.joinmastodon.org/entities/Announcement/#read

![IMG_5177](https://github.com/TootSDK/TootSDK/assets/1530082/e78fd312-721a-425d-9d21-1b990dc59504)
