### PR TITLE
Notifications API improvements

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/DeletePushSubscription.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/DeletePushSubscription.swift
@@ -1,12 +1,12 @@
 //
 //  DeletePushSubscription.swift
-//  
+//
 //
 //  Created by Łukasz Rutkowski on 29/12/2023.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 import TootSDK
 
 struct DeletePushSubscription: AsyncParsableCommand {

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/GetPushSubscription.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/GetPushSubscription.swift
@@ -1,12 +1,12 @@
 //
 //  GetPushSubscription.swift
-//  
+//
 //
 //  Created by Łukasz Rutkowski on 28/12/2023.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 import TootSDK
 
 struct GetPushSubscription: AsyncParsableCommand {
@@ -21,4 +21,3 @@ struct GetPushSubscription: AsyncParsableCommand {
         print(subscription)
     }
 }
-

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/ListAllNotifications.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/ListAllNotifications.swift
@@ -4,18 +4,16 @@ import TootSDK
 
 struct ListAllNotifications: AsyncParsableCommand {
 
-    @Option(name: .short, help: "URL to the instance to connect to")
-    var url: String
-
-    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
-    var token: String
+    @OptionGroup var auth: AuthOptions
+    @Option var types: [TootNotification.NotificationType] = [.mention]
+    @Option var excludeTypes: [TootNotification.NotificationType] = []
 
     mutating func run() async throws {
-        let client = try await TootClient(connect: URL(string: url)!, accessToken: token)
+        let client = try await TootClient(connect: auth.url, accessToken: auth.token)
 
         var pagedInfo: PagedInfo? = nil
         var hasMore = true
-        let query = TootNotificationParams(types: [.mention])
+        let query = TootNotificationParams(excludeTypes: excludeTypes, types: types)
 
         while hasMore {
             let page = try await client.getNotifications(params: query, pagedInfo)
@@ -29,5 +27,11 @@ struct ListAllNotifications: AsyncParsableCommand {
             pagedInfo = page.previousPage
         }
 
+    }
+}
+
+extension TootNotification.NotificationType: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
     }
 }

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/ListAllNotifications.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Notifications/ListAllNotifications.swift
@@ -13,7 +13,7 @@ struct ListAllNotifications: AsyncParsableCommand {
 
         var pagedInfo: PagedInfo? = nil
         var hasMore = true
-        let query = TootNotificationParams(excludeTypes: excludeTypes, types: types)
+        let query = TootNotificationParams(excludeTypes: Set(excludeTypes), types: Set(types))
 
         while hasMore {
             let page = try await client.getNotifications(params: query, pagedInfo)

--- a/Sources/TootSDK/Models/Alerts.swift
+++ b/Sources/TootSDK/Models/Alerts.swift
@@ -4,7 +4,16 @@
 import Foundation
 
 public struct Alerts: Codable, Hashable, Sendable {
-    public init(follow: Bool, favourite: Bool, repost: Bool, mention: Bool, poll: Bool? = nil, followRequest: Bool? = nil, post: Bool? = nil) {
+    public init(
+        follow: Bool,
+        favourite: Bool,
+        repost: Bool,
+        mention: Bool,
+        poll: Bool? = nil,
+        followRequest: Bool? = nil,
+        post: Bool? = nil,
+        update: Bool? = nil
+    ) {
         self.follow = follow
         self.favourite = favourite
         self.repost = repost
@@ -12,21 +21,24 @@ public struct Alerts: Codable, Hashable, Sendable {
         self.poll = poll
         self.followRequest = followRequest
         self.post = post
+        self.update = update
     }
 
-    /// Receive a push notification when someone has followed you? Boolean.
+    /// Receive a push notification when someone has followed you.
     public var follow: Bool
-    /// Receive a push notification when a post you created has been favourited by someone else? Boolean.
+    /// Receive a push notification when a post you created has been favourited by someone else.
     public var favourite: Bool
-    /// Receive a push notification when a post you created has been boosted by someone else? Boolean.
+    /// Receive a push notification when a post you created has been boosted by someone else.
     public var repost: Bool
-    /// Receive a push notification when someone else has mentioned you in a post? Boolean.
+    /// Receive a push notification when someone else has mentioned you in a post.
     public var mention: Bool
-    /// Receive a push notification when a poll you voted in or created has ended? Boolean. Added in 2.8.0
+    /// Receive a push notification when a poll you voted in or created has ended. Added in 2.8.0
     public var poll: Bool?
+    /// Receive a push notification when someone requested to follow you.
     public var followRequest: Bool?
+    /// Receive a push notification when someone you enabled notifications for has submitted a post.
     public var post: Bool?
-
+    /// Receive a push notification when a post you boosted with has been edited.
     public var update: Bool?
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TootSDK/Models/PushSubscription.swift
+++ b/Sources/TootSDK/Models/PushSubscription.swift
@@ -5,10 +5,11 @@ import Foundation
 
 /// Represents a subscription to the push streaming server.
 public struct PushSubscription: Codable, Sendable {
-    public init(endpoint: String, alerts: Alerts, serverKey: String) {
+    public init(endpoint: String, alerts: Alerts, serverKey: String, policy: PushSubscriptionPolicy?) {
         self.endpoint = endpoint
         self.alerts = alerts
         self.serverKey = serverKey
+        self.policy = policy
     }
 
     /// Where push alerts will be sent to.
@@ -17,4 +18,6 @@ public struct PushSubscription: Codable, Sendable {
     public var alerts: Alerts
     /// The streaming server's VAPID key.
     public var serverKey: String
+    /// From who to receive push notifications.
+    public var policy: PushSubscriptionPolicy?
 }

--- a/Sources/TootSDK/Models/PushSubscription.swift
+++ b/Sources/TootSDK/Models/PushSubscription.swift
@@ -5,7 +5,7 @@ import Foundation
 
 /// Represents a subscription to the push streaming server.
 public struct PushSubscription: Codable, Sendable {
-    public init(endpoint: String, alerts: Alerts, serverKey: String, policy: PushSubscriptionPolicy?) {
+    public init(endpoint: String, alerts: Alerts, serverKey: String, policy: PushSubscriptionPolicy = .all) {
         self.endpoint = endpoint
         self.alerts = alerts
         self.serverKey = serverKey

--- a/Sources/TootSDK/Models/PushSubscriptionParams.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionParams.swift
@@ -59,11 +59,12 @@ public struct PushSubscriptionParams: Codable, Sendable {
     }
 
     public struct SubscriptionData: Codable, Sendable {
+        /// Specify which alerts should be received.
         public var alerts: Alerts?
         /// Specify whether to receive push notifications from all, followed, follower, or none users.
-        public var policy: String?
+        public var policy: PushSubscriptionPolicy?
 
-        public init(alerts: Alerts? = nil, policy: String? = nil) {
+        public init(alerts: Alerts? = nil, policy: PushSubscriptionPolicy? = nil) {
             self.alerts = alerts
             self.policy = policy
         }

--- a/Sources/TootSDK/Models/PushSubscriptionPolicy.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionPolicy.swift
@@ -1,0 +1,20 @@
+//
+//  PushSubscriptionPolicy.swift
+//  
+//
+//  Created by Łukasz Rutkowski on 06/01/2024.
+//
+
+import Foundation
+
+/// Decides from who to receive push notifications.
+public enum PushSubscriptionPolicy: String, Codable, Hashable, Sendable {
+    /// Allow push notifications from everyone.
+    case all
+    /// Allow push notifications only from followed users.
+    case followed
+    /// Allow push notifications only from followers.
+    case follower
+    /// Disallow all push notifications.
+    case disabled = "none"
+}

--- a/Sources/TootSDK/Models/PushSubscriptionPolicy.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionPolicy.swift
@@ -1,6 +1,6 @@
 //
 //  PushSubscriptionPolicy.swift
-//  
+//
 //
 //  Created by Łukasz Rutkowski on 06/01/2024.
 //

--- a/Sources/TootSDK/Models/PushSubscriptionUpdateParams.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionUpdateParams.swift
@@ -5,14 +5,11 @@ import Foundation
 
 /// Change Web Push API subscription configuration request
 public struct PushSubscriptionUpdateParams: Codable, Sendable {
-    public var data: SubscriptionData?
-    public struct SubscriptionData: Codable, Sendable {
-        public var alerts: Alerts?
-        /// Specify whether to receive push notifications from all, followed, follower, or none users.
-        public var policy: String?
-    }
+    public var data: SubscriptionData
 
-    public init(data: PushSubscriptionUpdateParams.SubscriptionData? = nil) {
+    public init(data: SubscriptionData) {
         self.data = data
     }
+
+    public typealias SubscriptionData = PushSubscriptionParams.SubscriptionData
 }

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -41,6 +41,44 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
         case post = "status"
         /// A post you interacted with has been edited
         case update = "update"
+        
+        /// Returns notification types supported by the given `flavour`.
+        public static func supported(by flavour: TootSDKFlavour) -> Set<NotificationType> {
+            switch flavour {
+            case .mastodon:
+                return Set(allCases)
+            case .pleroma, .akkoma:
+                return [.follow, .mention, .repost, .favourite, .poll, .followRequest, .update]
+            case .friendica:
+                return [.follow, .mention, .repost, .favourite, .poll]
+            case .pixelfed:
+                return [.follow, .mention, .repost, .favourite]
+            case .firefish:
+                return [.follow, .mention, .repost, .poll, .followRequest]
+            }
+        }
+        
+        /// Returns push notification types supported by the given `flavour`.
+        public static func supportedAsPush(by flavour: TootSDKFlavour) -> Set<NotificationType> {
+            switch flavour {
+            case .mastodon:
+                return Set(allCases)
+            case .pleroma, .akkoma, .friendica:
+                return [.follow, .mention, .repost, .favourite, .poll]
+            case .pixelfed, .firefish:
+                return []
+            }
+        }
+        
+        /// Returns true if this notification type is supported by the given `flavour`.
+        public func isSupported(by flavour: TootSDKFlavour) -> Bool {
+            return Self.supported(by: flavour).contains(self)
+        }
+        
+        /// Returns true if this notification type is supported as push notification by the given `flavour`.
+        public func isSupportedAsPush(by flavour: TootSDKFlavour) -> Bool {
+            return Self.supportedAsPush(by: flavour).contains(self)
+        }
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -41,7 +41,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
         case post = "status"
         /// A post you interacted with has been edited
         case update = "update"
-        
+
         /// Returns notification types supported by the given `flavour`.
         public static func supported(by flavour: TootSDKFlavour) -> Set<NotificationType> {
             switch flavour {
@@ -57,7 +57,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return [.follow, .mention, .repost, .poll, .followRequest]
             }
         }
-        
+
         /// Returns push notification types supported by the given `flavour`.
         public static func supportedAsPush(by flavour: TootSDKFlavour) -> Set<NotificationType> {
             switch flavour {
@@ -69,12 +69,12 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return []
             }
         }
-        
+
         /// Returns true if this notification type is supported by the given `flavour`.
         public func isSupported(by flavour: TootSDKFlavour) -> Bool {
             return Self.supported(by: flavour).contains(self)
         }
-        
+
         /// Returns true if this notification type is supported as push notification by the given `flavour`.
         public func isSupportedAsPush(by flavour: TootSDKFlavour) -> Bool {
             return Self.supportedAsPush(by: flavour).contains(self)

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -24,7 +24,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
     /// Post that was the object of the notification, e.g. in mentions, reposts, favourites, or polls.
     public var post: Post?
 
-    public enum NotificationType: String, Codable, Sendable {
+    public enum NotificationType: String, Codable, Sendable, CaseIterable {
         /// Someone followed you
         case follow
         /// Someone mentioned you in their post

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -45,7 +45,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
         /// Returns notification types supported by the given `flavour`.
         public static func supported(by flavour: TootSDKFlavour) -> Set<NotificationType> {
             switch flavour {
-            case .mastodon:
+            case .mastodon, .sharkey:
                 return Set(allCases)
             case .pleroma, .akkoma:
                 return [.follow, .mention, .repost, .favourite, .poll, .followRequest, .update]
@@ -63,7 +63,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
             switch flavour {
             case .mastodon:
                 return Set(allCases)
-            case .pleroma, .akkoma, .friendica:
+            case .pleroma, .akkoma, .friendica, .sharkey:
                 return [.follow, .mention, .repost, .favourite, .poll]
             case .pixelfed, .firefish:
                 return []

--- a/Sources/TootSDK/Models/TootNotificationParams.swift
+++ b/Sources/TootSDK/Models/TootNotificationParams.swift
@@ -37,7 +37,7 @@ extension TootNotificationParams {
         guard flavour == .friendica else { return self }
         var params = self
         if let types = params.types {
-            var correctedExcludeTypes = Set(TootNotification.NotificationType.allCases).subtracting(types)
+            var correctedExcludeTypes = TootNotification.NotificationType.supported(by: flavour).subtracting(types)
             if let excludeTypes = params.excludeTypes {
                 correctedExcludeTypes.formUnion(excludeTypes)
             }

--- a/Sources/TootSDK/Models/TootNotificationParams.swift
+++ b/Sources/TootSDK/Models/TootNotificationParams.swift
@@ -34,7 +34,7 @@ public struct TootNotificationParams: Codable, Sendable {
 
 extension TootNotificationParams {
     func corrected(for flavour: TootSDKFlavour) -> TootNotificationParams {
-        guard flavour == .friendica else { return self }
+        guard flavour == .friendica || flavour == .sharkey else { return self }
         var params = self
         if let types = params.types {
             var correctedExcludeTypes = TootNotification.NotificationType.supported(by: flavour).subtracting(types)

--- a/Sources/TootSDK/Models/TootNotificationParams.swift
+++ b/Sources/TootSDK/Models/TootNotificationParams.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public struct TootNotificationParams: Codable, Sendable {
-    public init(excludeTypes: [TootNotification.NotificationType]? = nil, types: [TootNotification.NotificationType]? = nil) {
+    public init(
+        excludeTypes: Set<TootNotification.NotificationType>? = nil,
+        types: Set<TootNotification.NotificationType>? = nil
+    ) {
         self.excludeTypes = excludeTypes
         self.types = types
     }
@@ -19,12 +22,28 @@ public struct TootNotificationParams: Codable, Sendable {
     }
 
     /// Types of notifications to exclude from the search results
-    public var excludeTypes: [TootNotification.NotificationType]?
+    public var excludeTypes: Set<TootNotification.NotificationType>?
     /// Types of notifications to include in the search results
-    public var types: [TootNotification.NotificationType]?
+    public var types: Set<TootNotification.NotificationType>?
 
     enum CodingKeys: String, CodingKey {
         case excludeTypes = "exclude_types"
         case types = "types"
+    }
+}
+
+extension TootNotificationParams {
+    func corrected(for flavour: TootSDKFlavour) -> TootNotificationParams {
+        guard flavour == .friendica else { return self }
+        var params = self
+        if let types = params.types {
+            var correctedExcludeTypes = Set(TootNotification.NotificationType.allCases).subtracting(types)
+            if let excludeTypes = params.excludeTypes {
+                correctedExcludeTypes.formUnion(excludeTypes)
+            }
+            params.excludeTypes = correctedExcludeTypes
+            params.types = nil
+        }
+        return params
     }
 }

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -120,11 +120,11 @@ extension TootClient {
         let params = params.corrected(for: flavour)
 
         if let types = params.types, !types.isEmpty {
-            let name =
-                switch flavour {
-                case .pleroma, .akkoma: "include_types[]"
-                default: "types[]"
-                }
+            let name: String
+            switch flavour {
+            case .pleroma, .akkoma: name = "include_types[]"
+            default: name = "types[]"
+            }
             queryParameters.append(contentsOf: types.map({ .init(name: name, value: $0.rawValue) }))
         }
 

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -171,7 +171,7 @@ extension TootClient {
         }
 
         if let policy = params.data?.policy {
-            queryParameters.append(.init(name: "data[policy]", value: policy))
+            queryParameters.append(.init(name: "data[policy]", value: policy.rawValue))
         }
         return queryParameters
     }
@@ -179,36 +179,36 @@ extension TootClient {
     internal func createQuery(from params: PushSubscriptionUpdateParams) -> [URLQueryItem] {
         var queryParameters = [URLQueryItem]()
 
-        if let alert = params.data?.alerts?.mention {
+        if let alert = params.data.alerts?.mention {
             queryParameters.append(.init(name: "data[alerts][mention]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.post {
+        if let alert = params.data.alerts?.post {
             queryParameters.append(.init(name: "data[alerts][status]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.follow {
+        if let alert = params.data.alerts?.follow {
             queryParameters.append(.init(name: "data[alerts][follow]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.followRequest {
+        if let alert = params.data.alerts?.followRequest {
             queryParameters.append(.init(name: "data[alerts][follow_request]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.favourite {
+        if let alert = params.data.alerts?.favourite {
             queryParameters.append(.init(name: "data[alerts][favourite]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.poll {
+        if let alert = params.data.alerts?.poll {
             queryParameters.append(.init(name: "data[alerts][poll]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data?.alerts?.update {
+        if let alert = params.data.alerts?.update {
             queryParameters.append(.init(name: "data[alerts][update]", value: String(alert).lowercased()))
         }
 
-        if let policy = params.data?.policy {
-            queryParameters.append(.init(name: "data[policy]", value: policy))
+        if let policy = params.data.policy {
+            queryParameters.append(.init(name: "data[policy]", value: policy.rawValue))
         }
         return queryParameters
     }

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -108,6 +108,9 @@ extension TootClient {
 extension TootFeature {
     /// Ability to create Web Push API subscriptions to receive notifications.
     public static let pushSubscriptions = TootFeature(supportedFlavours: [.mastodon, .akkoma, .friendica, .pleroma])
+
+    /// Ability to specify policy for push notifications.
+    public static let pushSubscriptionsPolicy = TootFeature(supportedFlavours: [.mastodon])
 }
 
 extension TootClient {

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -140,77 +140,49 @@ extension TootClient {
         queryParameters.append(.init(name: "subscription[endpoint]", value: params.subscription.endpoint))
         queryParameters.append(.init(name: "subscription[keys][p256dh]", value: params.subscription.keys.p256dh))
         queryParameters.append(.init(name: "subscription[keys][auth]", value: params.subscription.keys.auth))
-
-        if let alert = params.data?.alerts?.mention {
-            queryParameters.append(.init(name: "data[alerts][mention]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.post {
-            queryParameters.append(.init(name: "data[alerts][status]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.repost {
-            queryParameters.append(.init(name: "data[alerts][reblog]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.follow {
-            queryParameters.append(.init(name: "data[alerts][follow]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.followRequest {
-            queryParameters.append(.init(name: "data[alerts][follow_request]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.favourite {
-            queryParameters.append(.init(name: "data[alerts][favourite]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.poll {
-            queryParameters.append(.init(name: "data[alerts][poll]", value: String(alert).lowercased()))
-        }
-
-        if let alert = params.data?.alerts?.update {
-            queryParameters.append(.init(name: "data[alerts][update]", value: String(alert).lowercased()))
-        }
-
-        if let policy = params.data?.policy {
-            queryParameters.append(.init(name: "data[policy]", value: policy.rawValue))
-        }
+        queryParameters.append(contentsOf: createQuery(from: params.data))
         return queryParameters
     }
 
     internal func createQuery(from params: PushSubscriptionUpdateParams) -> [URLQueryItem] {
-        var queryParameters = [URLQueryItem]()
+        return createQuery(from: params.data)
+    }
 
-        if let alert = params.data.alerts?.mention {
+    internal func createQuery(from data: PushSubscriptionParams.SubscriptionData?) -> [URLQueryItem] {
+        var queryParameters: [URLQueryItem] = []
+        if let alert = data?.alerts?.mention {
             queryParameters.append(.init(name: "data[alerts][mention]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.post {
+        if let alert = data?.alerts?.post {
             queryParameters.append(.init(name: "data[alerts][status]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.follow {
+        if let alert = data?.alerts?.repost {
+            queryParameters.append(.init(name: "data[alerts][reblog]", value: String(alert).lowercased()))
+        }
+
+        if let alert = data?.alerts?.follow {
             queryParameters.append(.init(name: "data[alerts][follow]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.followRequest {
+        if let alert = data?.alerts?.followRequest {
             queryParameters.append(.init(name: "data[alerts][follow_request]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.favourite {
+        if let alert = data?.alerts?.favourite {
             queryParameters.append(.init(name: "data[alerts][favourite]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.poll {
+        if let alert = data?.alerts?.poll {
             queryParameters.append(.init(name: "data[alerts][poll]", value: String(alert).lowercased()))
         }
 
-        if let alert = params.data.alerts?.update {
+        if let alert = data?.alerts?.update {
             queryParameters.append(.init(name: "data[alerts][update]", value: String(alert).lowercased()))
         }
 
-        if let policy = params.data.policy {
+        if let policy = data?.policy {
             queryParameters.append(.init(name: "data[policy]", value: policy.rawValue))
         }
         return queryParameters

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -114,8 +114,15 @@ extension TootClient {
     internal func createQuery(from params: TootNotificationParams) -> [URLQueryItem] {
         var queryParameters = [URLQueryItem]()
 
+        let params = params.corrected(for: flavour)
+
         if let types = params.types, !types.isEmpty {
-            queryParameters.append(contentsOf: types.map({ .init(name: "types[]", value: $0.rawValue) }))
+            let name =
+                switch flavour {
+                case .pleroma, .akkoma: "include_types[]"
+                default: "types[]"
+                }
+            queryParameters.append(contentsOf: types.map({ .init(name: name, value: $0.rawValue) }))
         }
 
         if let types = params.excludeTypes, !types.isEmpty {

--- a/Tests/TootSDKTests/TootNotificationParamsTests.swift
+++ b/Tests/TootSDKTests/TootNotificationParamsTests.swift
@@ -24,19 +24,19 @@ final class TootNotificationParamsTests: XCTestCase {
 
     func testFriendicaConvertTypesToExcludeTypes_whenOnlyTypesProvided() throws {
         let params = TootNotificationParams(types: [.mention]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
         XCTAssertEqual(params.types, nil)
     }
 
     func testFriendicaConvertTypesToExcludeTypes_whenBothTypesAndExcludedTypesProvided() throws {
         let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
         XCTAssertEqual(params.types, nil)
     }
 
     func testFriendicaConvertTypesToExcludeTypes_whenTypesOverlap() throws {
         let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention, .favourite]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
         XCTAssertEqual(params.types, nil)
     }
 
@@ -57,12 +57,9 @@ final class TootNotificationParamsTests: XCTestCase {
         let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
         XCTAssertEqual(query, [
             URLQueryItem(name: "exclude_types[]", value: "follow"),
-            URLQueryItem(name: "exclude_types[]", value: "follow_request"),
             URLQueryItem(name: "exclude_types[]", value: "mention"),
             URLQueryItem(name: "exclude_types[]", value: "poll"),
             URLQueryItem(name: "exclude_types[]", value: "reblog"),
-            URLQueryItem(name: "exclude_types[]", value: "status"),
-            URLQueryItem(name: "exclude_types[]", value: "update"),
         ])
     }
 

--- a/Tests/TootSDKTests/TootNotificationParamsTests.swift
+++ b/Tests/TootSDKTests/TootNotificationParamsTests.swift
@@ -10,48 +10,79 @@ import XCTest
 
 final class TootNotificationParamsTests: XCTestCase {
 
-    func testFriendicaKeepUnchanged_whenNothingSpecified() throws {
-        let params = TootNotificationParams().corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, nil)
-        XCTAssertEqual(params.types, nil)
-    }
+    private let flavoursNotSupportingTypes: [TootSDKFlavour] = [.friendica, .sharkey]
 
-    func testFriendicaKeepUnchanged_whenOnlyExcludedTypesProvided() throws {
-        let params = TootNotificationParams(excludeTypes: [.mention]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.mention])
-        XCTAssertEqual(params.types, nil)
-    }
-
-    func testFriendicaConvertTypesToExcludeTypes_whenOnlyTypesProvided() throws {
-        let params = TootNotificationParams(types: [.mention]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
-        XCTAssertEqual(params.types, nil)
-    }
-
-    func testFriendicaConvertTypesToExcludeTypes_whenBothTypesAndExcludedTypesProvided() throws {
-        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
-        XCTAssertEqual(params.types, nil)
-    }
-
-    func testFriendicaConvertTypesToExcludeTypes_whenTypesOverlap() throws {
-        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention, .favourite]).corrected(for: .friendica)
-        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll])
-        XCTAssertEqual(params.types, nil)
-    }
-
-    func testUnmodifiedForOtherFlavours() throws {
-        let flavours = Set(TootSDKFlavour.allCases).subtracting([.friendica])
-        for flavour in flavours {
-            let params = TootNotificationParams(types: [.mention]).corrected(for: flavour)
-            XCTAssertEqual(params.excludeTypes, nil)
-            XCTAssertEqual(params.types, [.mention])
+    func testFriendicaSharkeyKeepUnchanged_whenNothingSpecified() throws {
+        for flavour in flavoursNotSupportingTypes {
+            let params = TootNotificationParams().corrected(for: flavour)
+            XCTAssertEqual(params.excludeTypes, nil, "Incorrect exclude types for \(flavour)")
+            XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
         }
     }
 
-    func testFriendicaQueryParams() throws {
+    func testFriendicaSharkeyKeepUnchanged_whenOnlyExcludedTypesProvided() throws {
+        for flavour in flavoursNotSupportingTypes {
+            let params = TootNotificationParams(excludeTypes: [.mention]).corrected(for: flavour)
+            XCTAssertEqual(params.excludeTypes, [.mention], "Incorrect exclude types for \(flavour)")
+            XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+        }
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenOnlyTypesProvided() throws {
+        let flavour = TootSDKFlavour.friendica
+        let params = TootNotificationParams(types: [.mention]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll], "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testSharkeyConvertTypesToExcludeTypes_whenOnlyTypesProvided() throws {
+        let flavour = TootSDKFlavour.sharkey
+        let params = TootNotificationParams(types: [.mention]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, Set(TootNotification.NotificationType.allCases).subtracting([.mention]), "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenBothTypesAndExcludedTypesProvided() throws {
+        let flavour = TootSDKFlavour.friendica
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll], "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testSharkeyConvertTypesToExcludeTypes_whenBothTypesAndExcludedTypesProvided() throws {
+        let flavour = TootSDKFlavour.sharkey
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, Set(TootNotification.NotificationType.allCases).subtracting([.mention]), "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenTypesOverlap() throws {
+        let flavour = TootSDKFlavour.friendica
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention, .favourite]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll], "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testSharkeyConvertTypesToExcludeTypes_whenTypesOverlap() throws {
+        let flavour = TootSDKFlavour.sharkey
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention, .favourite]).corrected(for: flavour)
+        XCTAssertEqual(params.excludeTypes, Set(TootNotification.NotificationType.allCases).subtracting([.mention]), "Incorrect exclude types for \(flavour)")
+        XCTAssertEqual(params.types, nil, "Incorrect types for \(flavour)")
+    }
+
+    func testUnmodifiedForOtherFlavours() throws {
+        let flavours = Set(TootSDKFlavour.allCases).subtracting([.friendica, .sharkey])
+        for flavour in flavours {
+            let params = TootNotificationParams(types: [.mention]).corrected(for: flavour)
+            XCTAssertEqual(params.excludeTypes, nil, "Incorrect exclude types for \(flavour)")
+            XCTAssertEqual(params.types, [.mention], "Incorrect types for \(flavour)")
+        }
+    }
+
+    func testFriendicaSharkeyQueryParams() throws {
+        let flavour = TootSDKFlavour.friendica
         let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-        client.flavour = .friendica
+        client.flavour = flavour
 
         let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
         let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
@@ -60,7 +91,25 @@ final class TootNotificationParamsTests: XCTestCase {
             URLQueryItem(name: "exclude_types[]", value: "mention"),
             URLQueryItem(name: "exclude_types[]", value: "poll"),
             URLQueryItem(name: "exclude_types[]", value: "reblog"),
-        ])
+        ], "Incorrect params for \(flavour)")
+    }
+
+    func testFriendicaQueryParams() throws {
+        let flavour = TootSDKFlavour.sharkey
+        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+        client.flavour = flavour
+
+        let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
+        let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
+        XCTAssertEqual(query, [
+            URLQueryItem(name: "exclude_types[]", value: "follow"),
+            URLQueryItem(name: "exclude_types[]", value: "follow_request"),
+            URLQueryItem(name: "exclude_types[]", value: "mention"),
+            URLQueryItem(name: "exclude_types[]", value: "poll"),
+            URLQueryItem(name: "exclude_types[]", value: "reblog"),
+            URLQueryItem(name: "exclude_types[]", value: "status"),
+            URLQueryItem(name: "exclude_types[]", value: "update"),
+        ], "Incorrect params for \(flavour)")
     }
 
     func testPleromaAkkomaQueryParams() throws {

--- a/Tests/TootSDKTests/TootNotificationParamsTests.swift
+++ b/Tests/TootSDKTests/TootNotificationParamsTests.swift
@@ -1,0 +1,94 @@
+//
+//  TootNotificationParamsTests.swift
+//
+//
+//  Created by Łukasz Rutkowski on 05/01/2024.
+//
+
+import XCTest
+@testable import TootSDK
+
+final class TootNotificationParamsTests: XCTestCase {
+
+    func testFriendicaKeepUnchanged_whenNothingSpecified() throws {
+        let params = TootNotificationParams().corrected(for: .friendica)
+        XCTAssertEqual(params.excludeTypes, nil)
+        XCTAssertEqual(params.types, nil)
+    }
+
+    func testFriendicaKeepUnchanged_whenOnlyExcludedTypesProvided() throws {
+        let params = TootNotificationParams(excludeTypes: [.mention]).corrected(for: .friendica)
+        XCTAssertEqual(params.excludeTypes, [.mention])
+        XCTAssertEqual(params.types, nil)
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenOnlyTypesProvided() throws {
+        let params = TootNotificationParams(types: [.mention]).corrected(for: .friendica)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.types, nil)
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenBothTypesAndExcludedTypesProvided() throws {
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention]).corrected(for: .friendica)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.types, nil)
+    }
+
+    func testFriendicaConvertTypesToExcludeTypes_whenTypesOverlap() throws {
+        let params = TootNotificationParams(excludeTypes: [.favourite], types: [.mention, .favourite]).corrected(for: .friendica)
+        XCTAssertEqual(params.excludeTypes, [.follow, .repost, .favourite, .poll, .followRequest, .post, .update])
+        XCTAssertEqual(params.types, nil)
+    }
+
+    func testUnmodifiedForOtherFlavours() throws {
+        let flavours = Set(TootSDKFlavour.allCases).subtracting([.friendica])
+        for flavour in flavours {
+            let params = TootNotificationParams(types: [.mention]).corrected(for: flavour)
+            XCTAssertEqual(params.excludeTypes, nil)
+            XCTAssertEqual(params.types, [.mention])
+        }
+    }
+
+    func testFriendicaQueryParams() throws {
+        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+        client.flavour = .friendica
+
+        let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
+        let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
+        XCTAssertEqual(query, [
+            URLQueryItem(name: "exclude_types[]", value: "follow"),
+            URLQueryItem(name: "exclude_types[]", value: "follow_request"),
+            URLQueryItem(name: "exclude_types[]", value: "mention"),
+            URLQueryItem(name: "exclude_types[]", value: "poll"),
+            URLQueryItem(name: "exclude_types[]", value: "reblog"),
+            URLQueryItem(name: "exclude_types[]", value: "status"),
+            URLQueryItem(name: "exclude_types[]", value: "update"),
+        ])
+    }
+
+    func testPleromaAkkomaQueryParams() throws {
+        for flavour in [TootSDKFlavour.pleroma, .akkoma] {
+            let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+            client.flavour = flavour
+
+            let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
+            let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
+            XCTAssertEqual(query, [
+                URLQueryItem(name: "exclude_types[]", value: "mention"),
+                URLQueryItem(name: "include_types[]", value: "favourite"),
+            ], "Incorrect params for \(flavour)")
+        }
+    }
+
+    func testMastodonQueryParams() throws {
+        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+        client.flavour = .mastodon
+
+        let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
+        let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
+        XCTAssertEqual(query, [
+            URLQueryItem(name: "exclude_types[]", value: "mention"),
+            URLQueryItem(name: "types[]", value: "favourite"),
+        ])
+    }
+}


### PR DESCRIPTION
This pull request introduces lots of changes related to notifications and push notifications API. Needed to correctly implement notifications support across all available flavours in SDK.

- Added option to configure `update` notification alert in init
- Added optional `policy` to push subscription response
- Changed `policy` to enum with known values
- Added `static NotificationType.supported(by:)`, `NotificationType.isSupported(by:)` to determine if given flavour supports selected notification type
- Added `static NotificationType.supportedAsPush(by:)`, `NotificationType.isSupportedAsPush(by:)` to determine if given flavour supports selected notification type in push subscriptions
- Added mapping from `types` to `excludeTypes` for Friendica which doesn't support the former
- Fixed akkoma and pleroma not respecting `types` parameter
- Added `TootFeature.pushSubscriptionsPolicy` to determine if push subscriptions support policy setting
- [BREAKING] Changed `types` and `excludeTypes` in `TootNotificationParams` to Set
- Fixed update subscription call was missing `repost` query item

The supported notification types and policy were verified manually via trial and error plus source code analysis due to lack of documentation. I'm not 100% sure whether it's all correct.

---

Other issues I identified but was unable to resolve on TootSDK side:
- Friendica (venera.social) returns duplicate push subscription json from call to POST /v1/push/subscription causing response parsing to fail
- Friendica (venera.social) returns 403 instead of 404 from call to GET /v1/push/subscription if there is no subscription
- Friendica (venera.social) returns 403 from successful call to DELETE /v1/push/subscription
- Friendica (venera.social) does not update subscription after call to PUT /v1/push/subscription