### PR TITLE
Add follow-account example command

### DIFF
--- a/Examples/swiftyadmin/Package.resolved
+++ b/Examples/swiftyadmin/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "b51f1d6845b353a2121de1c6a670738ec33561a6",
+        "version" : "3.1.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/FollowAccount.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/FollowAccount.swift
@@ -17,9 +17,9 @@ struct FollowAccount: AsyncParsableCommand {
     var id: String
 
     @Option(help: "Receive notifications when this account posts a post")
-    var notify: Bool?
+    var notify: Bool = false
     @Option(help: "Receive this account’s reposts in home timeline")
-    var reposts: Bool?
+    var reposts: Bool = true
     @Option(help: "Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages")
     var languages: [String] = []
 

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/FollowAccount.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/FollowAccount.swift
@@ -1,0 +1,40 @@
+//
+//  FollowAccount.swift
+//
+//
+//  Created by Łukasz Rutkowski on 14/01/2024.
+//
+
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct FollowAccount: AsyncParsableCommand {
+
+    @OptionGroup var auth: AuthOptions
+
+    @Option(name: .shortAndLong, help: "id of the account")
+    var id: String
+
+    @Option(help: "Receive notifications when this account posts a post")
+    var notify: Bool?
+    @Option(help: "Receive this account’s reposts in home timeline")
+    var reposts: Bool?
+    @Option(help: "Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages")
+    var languages: [String] = []
+
+    mutating func run() async throws {
+        let client = try await TootClient(connect: auth.url, accessToken: auth.token)
+        if auth.verbose {
+            client.debugOn()
+        }
+
+        let params = FollowAccountParams(
+            reposts: reposts,
+            notify: notify,
+            languages: languages.isEmpty ? nil : languages
+        )
+        let relationship = try await client.followAccount(by: id, params: params)
+        print(relationship)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -42,5 +42,6 @@ struct SwiftyAdmin: AsyncParsableCommand {
             RejectFollowRequest.self,
             GetPushSubscription.self,
             DeletePushSubscription.self,
+            FollowAccount.self,
         ])
 }

--- a/Sources/TootSDK/Models/FollowAccountParams.swift
+++ b/Sources/TootSDK/Models/FollowAccountParams.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct FollowAccountParams: Codable, Sendable {
     /// Receive notifications when this account posts a post? Defaults to false.
-    var notify: Bool?
+    var notify: Bool
     /// Receive this account’s reposts in home timeline? Defaults to true.
-    var reposts: Bool?
+    var reposts: Bool
     /// Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages. If not provided, you will receive this account’s posts in all languages.
     var languages: [String]?
 
@@ -20,8 +20,8 @@ public struct FollowAccountParams: Codable, Sendable {
     ///   - notify: Receive notifications when this account posts a post?  Defaults to false.
     ///   - languages: Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages. If not provided, you will receive this account’s posts in all languages.
     public init(
-        reposts: Bool? = nil,
-        notify: Bool? = nil,
+        reposts: Bool = true,
+        notify: Bool = false,
         languages: [String]? = nil
     ) {
         self.notify = notify

--- a/Sources/TootSDK/Models/FollowAccountParams.swift
+++ b/Sources/TootSDK/Models/FollowAccountParams.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct FollowAccountParams: Codable, Sendable {
     /// Receive notifications when this account posts a post? Defaults to false.
-    var notify: Bool
+    var notify: Bool?
     /// Receive this account’s reposts in home timeline? Defaults to true.
-    var reposts: Bool
+    var reposts: Bool?
     /// Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages. If not provided, you will receive this account’s posts in all languages.
     var languages: [String]?
 
@@ -20,8 +20,8 @@ public struct FollowAccountParams: Codable, Sendable {
     ///   - notify: Receive notifications when this account posts a post?  Defaults to false.
     ///   - languages: Array of String (ISO 639-1 language two-letter code). Filter received posts for these languages. If not provided, you will receive this account’s posts in all languages.
     public init(
-        reposts: Bool = true,
-        notify: Bool = false,
+        reposts: Bool? = nil,
+        notify: Bool? = nil,
         languages: [String]? = nil
     ) {
         self.notify = notify


### PR DESCRIPTION
With this change it will be possible to update account following parameters one by one. For example to be able to enable account notifications without changing boosts following status.
Default values are set to `nil` to follow server preferences.