### PR TITLE
added a list of apps built with TootSDK to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ This is a permissive license which allows for any type of use, provided the copy
 
 ## Built with TootSDK ##
 
-- [Fedicat](https://fedicat.com/))
+- [Fedicat](https://fedicat.com/)
 - [Pipilo](https://apps.apple.com/pl/app/pipilo/id1584544719)
 - [TootyGraph](https://github.com/samscam/tootygraph)
 - [Topiary](https://lightbeamapps.com/topiary/)

--- a/README.md
+++ b/README.md
@@ -273,3 +273,10 @@ This is a permissive license which allows for any type of use, provided the copy
 - The Mastodon API documentation https://github.com/mastodon/documentation
 - We hat-tip top Metatext's source for some guidance on what's where: https://github.com/metabolist/metatext
 - [Kris Slazinski](https://mastodon.social/@kslazinski) for our TootSDK logo 🤩
+
+## Built with TootSDK ##
+
+- [Fedicat *Testflight*](https://testflight.apple.com/join/b6GatWTY) ([Website](https://fedicat.com/) \| [Mastodon](https://iosdev.space/@technicat) \| [GitHub](https://github.com/technicat/fedicat) \|\| **free during Testflight**)
+- [Pipilo](https://apps.apple.com/pl/app/pipilo/id1584544719) ([Testflight](https://testflight.apple.com/join/0RfZtIsx)  \| [Mastodon](https://indieapps.space/@pipilo)) - Fediverse client with a horizontally scrolling timeline.
+- TootyGraph ([Mastodon](https://togl.me/@tootygraph) \| [GitHub](https://github.com/samscam/tootygraph)) - a playful, photography-focussed, fediverse client app for iOS
+- [Topiary](https://apps.apple.com/us/app/topiary-trim-your-followers/id6446443154) ([Website](https://lightbeamapps.com/topiary/)) - Manage your Mastodon account

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ This is a permissive license which allows for any type of use, provided the copy
 
 ## Built with TootSDK ##
 
-- [Fedicat *Testflight*](https://testflight.apple.com/join/b6GatWTY) ([Website](https://fedicat.com/) \| [Mastodon](https://iosdev.space/@technicat) \| [GitHub](https://github.com/technicat/fedicat) \|\| **free during Testflight**)
-- [Pipilo](https://apps.apple.com/pl/app/pipilo/id1584544719) ([Testflight](https://testflight.apple.com/join/0RfZtIsx)  \| [Mastodon](https://indieapps.space/@pipilo)) - Fediverse client with a horizontally scrolling timeline.
-- TootyGraph ([Mastodon](https://togl.me/@tootygraph) \| [GitHub](https://github.com/samscam/tootygraph)) - a playful, photography-focussed, fediverse client app for iOS
-- [Topiary](https://apps.apple.com/us/app/topiary-trim-your-followers/id6446443154) ([Website](https://lightbeamapps.com/topiary/)) - Manage your Mastodon account
+- [Fedicat](https://fedicat.com/))
+- [Pipilo](https://apps.apple.com/pl/app/pipilo/id1584544719)
+- [TootyGraph](https://github.com/samscam/tootygraph)
+- [Topiary](https://lightbeamapps.com/topiary/)


### PR DESCRIPTION
This is just to get started, with tootsdk apps that I have on my own list and added to the awesome-mastodon list (they have a format that includes several links for each app but for this I just picked what seemed like the main link for each).

I'm sure I've seen a bunch of these built-with lists on other projects, for example SDWebImage has one on a separate page (but they have a lot of users)

https://github.com/SDWebImage/SDWebImage/wiki/Who-Uses-SDWebImage