### PR TITLE
add default empty string param for ExtendedDescription

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,7 @@ let package = Package(
                 .copy("Resources/featured_tag.json"),
                 .copy("Resources/featured_tag_unused.json"),
                 .copy("Resources/instance_akkoma.json"),
+                .copy("Resources/instance_catodon_contact_removed.json"),
                 .copy("Resources/instance_firefish_contact_removed.json"),
                 .copy("Resources/instance_friendica_nocontact.json"),
                 .copy("Resources/instance_iceshrimp_contact_removed.json"),

--- a/Sources/TootSDK/Models/ExtendedDescription.swift
+++ b/Sources/TootSDK/Models/ExtendedDescription.swift
@@ -16,7 +16,7 @@ public struct ExtendedDescription: Codable, Hashable {
     /// The rendered HTML content of the extended description.
     public var content: String
 
-    public init(updatedAt: Date? = nil, content: String) {
+    public init(updatedAt: Date? = nil, content: String = "") {
         self.updatedAt = updatedAt
         self.content = content
     }

--- a/Sources/TootSDK/Models/Instance.swift
+++ b/Sources/TootSDK/Models/Instance.swift
@@ -225,7 +225,8 @@ extension Instance {
         }
         // 3.0.0 (compatible; Firefish 1.0.4-dev5)
         // 4.2.1 (compatible; Iceshrimp 2023.12-pre3)
-        if version.lowercased().contains("firefish") || version.lowercased().contains("iceshrimp") {
+        // 4.2.1 (compatible; Catodon 24.01-dev)
+        if version.lowercased().contains("firefish") || version.lowercased().contains("catodon") || version.lowercased().contains("iceshrimp") {
             return .firefish
         }
         // 3.0.0 (compatible; Sharkey 2023.12.0.beta3)

--- a/Tests/TootSDKTests/FlavourTests.swift
+++ b/Tests/TootSDKTests/FlavourTests.swift
@@ -37,6 +37,11 @@ final class FlavourTests: XCTestCase {
         XCTAssertEqual(instance.flavour, .firefish)
     }
     
+    func testDetectsCatodonAsFirefish() throws {
+        let instance = try localObject(Instance.self, "instance_catodon_contact_removed")
+        XCTAssertEqual(instance.flavour, .firefish)
+    }
+    
     func testDetectsIceshrimpAsFirefish() throws {
         let instance = try localObject(Instance.self, "instance_iceshrimp_contact_removed")
         XCTAssertEqual(instance.flavour, .firefish)

--- a/Tests/TootSDKTests/Resources/instance_catodon_contact_removed.json
+++ b/Tests/TootSDKTests/Resources/instance_catodon_contact_removed.json
@@ -1,0 +1,92 @@
+{
+  "description" : "🌎 Home of Catodon, a new platform for fedi communities, initially based on Firefish/Misskey. Be aware that our first release is not out yet, so things are still experimental.",
+  "languages" : [
+
+  ],
+  "stats" : {
+    "domain_count" : 13102,
+    "user_count" : 255,
+    "status_count" : 16179
+  },
+  "version" : "4.2.1 (compatible; Catodon 24.01-dev)",
+  "uri" : "catodon.social",
+  "short_description" : "🌎 Home of Catodon, a new platform for fedi commun",
+  "invites_enabled" : false,
+  "rules" : [
+
+  ],
+  "configuration" : {
+    "statuses" : {
+      "max_media_attachments" : 16,
+      "supported_mime_types" : [
+        "text/x.misskeymarkdown"
+      ],
+      "max_characters" : 8000,
+      "characters_reserved_per_url" : 23
+    },
+    "reactions" : {
+      "max_reactions" : 1
+    },
+    "polls" : {
+      "max_expiration" : 2629746,
+      "min_expiration" : 50,
+      "max_characters_per_option" : 50,
+      "max_options" : 10
+    },
+    "accounts" : {
+
+      "max_featured_tags" : 20
+    },
+    "media_attachments" : {
+      "image_matrix_limit" : 16777216,
+      "supported_mime_types" : [
+        "image/png",
+        "image/gif",
+        "image/jpeg",
+        "image/webp",
+        "image/apng",
+        "image/bmp",
+        "image/tiff",
+        "image/x-icon",
+        "image/avif",
+        "audio/opus",
+        "video/ogg",
+        "audio/ogg",
+        "application/ogg",
+        "video/quicktime",
+        "video/mp4",
+        "video/vnd.avi",
+        "audio/mp4",
+        "video/x-m4v",
+        "audio/x-m4a",
+        "video/3gpp",
+        "video/3gpp2",
+        "video/3gp2",
+        "audio/3gpp",
+        "audio/3gpp2",
+        "audio/3gp2",
+        "video/mpeg",
+        "audio/mpeg",
+        "video/webm",
+        "audio/webm",
+        "audio/aac",
+        "audio/x-flac",
+        "audio/flac",
+        "audio/vnd.wave"
+      ],
+      "video_matrix_limit" : 2304000,
+      "video_size_limit" : 41943040,
+      "video_frame_limit" : 60,
+      "image_size_limit" : 10485760
+    }
+  },
+  "title" : "Catodon Social",
+  "urls" : {
+    "streaming_api" : "wss://social.thisworksonmycomputer.local"
+  },
+  "approval_required" : false,
+  "max_toot_chars" : 8000,
+  "thumbnail" : "/static-assets/transparent.png",
+  "email" : "contact@social.thisworksonmycomputer.local",
+  "registrations" : true
+}


### PR DESCRIPTION
so you can instantiate with

ExtendedDescripion()

vs

ExtendedDescription(content: "")

edit: catodon.social updated today with code newly synced to iceshrimp but with catodon added to the version string, so updated the TootSDK flavour check accordingly