### PR TITLE
Support Mastodon's `legal` category for reporting illegal content

### DIFF
--- a/Sources/TootSDK/Models/ReportCategory.swift
+++ b/Sources/TootSDK/Models/ReportCategory.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public enum ReportCategory: String, CaseIterable, Codable {
     case spam
+    /// Content that is illegal in the user's or the instance's country.
+    case legal
     case sensitive
     case abusive
     case underage
@@ -34,6 +36,7 @@ public enum ReportCategory: String, CaseIterable, Codable {
 
     public static let mastodonSupported: Set<ReportCategory> = [
         .spam,
+        .legal,
         .other,
         .violation,
     ]


### PR DESCRIPTION
This report category isn’t in Mastodon’s docs yet, but was added in mastodon/mastodon#23941 and released in Mastodon 4.2.0.