### PR TITLE
Add support for `hint` property on `InstanceRule`

### DIFF
--- a/Sources/TootSDK/Models/InstanceRule.swift
+++ b/Sources/TootSDK/Models/InstanceRule.swift
@@ -15,4 +15,6 @@ public struct InstanceRule: Codable, Hashable, Identifiable {
     public var id: String
     /// The text content of the rule.
     public var text: String?
+    /// Optional text providing more details about the rule.
+    public var hint: String?
 }


### PR DESCRIPTION
This is another thing that was recently added to Mastodon (mastodon/mastodon#29539) but not officially released or documented yet (although mastodon.social and mastodon.online already have it deployed).

This one shouldn’t have any impact on usage with servers that don’t support it, because it’s optional.