### PR TITLE
Allow setting a list as "exclusive"

### DIFF
--- a/Sources/TootSDK/Models/List.swift
+++ b/Sources/TootSDK/Models/List.swift
@@ -14,7 +14,7 @@ public struct List: Codable, Hashable, Identifiable {
 
     /// Which replies should be shown in the list.
     public var repliesPolicy: ListRepliesPolicy?
-    
+
     /// Whether members of this list need to get removed from the “Home” feed.
     public var exclusive: Bool?
 

--- a/Sources/TootSDK/Models/List.swift
+++ b/Sources/TootSDK/Models/List.swift
@@ -14,11 +14,15 @@ public struct List: Codable, Hashable, Identifiable {
 
     /// Which replies should be shown in the list.
     public var repliesPolicy: ListRepliesPolicy?
+    
+    /// Whether members of this list need to get removed from the “Home” feed.
+    public var exclusive: Bool?
 
-    public init(id: String, title: String, repliesPolicy: ListRepliesPolicy) {
+    public init(id: String, title: String, repliesPolicy: ListRepliesPolicy, exclusive: Bool? = nil) {
         self.id = id
         self.title = title
         self.repliesPolicy = repliesPolicy
+        self.exclusive = exclusive
     }
 }
 

--- a/Sources/TootSDK/Models/ListParams.swift
+++ b/Sources/TootSDK/Models/ListParams.swift
@@ -9,9 +9,12 @@ public struct ListParams: Codable {
     public var title: String
     /// The user-defined title of the list.
     public var repliesPolicy: ListRepliesPolicy?
+    /// Whether members of this list need to get removed from the “Home” feed
+    public var exclusive: Bool?
 
-    public init(title: String, repliesPolicy: ListRepliesPolicy? = nil) {
+    public init(title: String, repliesPolicy: ListRepliesPolicy? = nil, exclusive: Bool? = nil) {
         self.title = title
         self.repliesPolicy = repliesPolicy
+        self.exclusive = exclusive
     }
 }

--- a/Tests/TootSDKTests/ListTests.swift
+++ b/Tests/TootSDKTests/ListTests.swift
@@ -24,6 +24,7 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(result.id, "3309")
         XCTAssertEqual(result.title, "tech")
         XCTAssertEqual(result.repliesPolicy, .followed)
+        XCTAssertEqual(result.exclusive, false)
     }
 
 }


### PR DESCRIPTION
Added in Mastodon 4.2 (exclusive property already present in the List test case)

https://docs.joinmastodon.org/methods/lists/#create