### PR TITLE
added optional withSuspended param to TootClient.getRelationships (specifies whether to ignore suspended accounts)

### DIFF
--- a/Sources/TootSDK/Models/RelationshipParams.swift
+++ b/Sources/TootSDK/Models/RelationshipParams.swift
@@ -1,0 +1,28 @@
+//
+//  RelationshipParams.swift
+//
+//
+//  Created by Philip Chu on 4/5/24.
+//
+
+import Foundation
+
+public struct RelationshipParams: Codable, Sendable {
+
+    /// Whether relationships should be returned for suspended users, defaults to false.
+    public var withSuspended: Bool?
+
+    public init(withSuspended: Bool? = nil) {
+        self.withSuspended = withSuspended
+    }
+}
+
+extension RelationshipParams {
+    var queryItems: [URLQueryItem] {
+        [
+            URLQueryItem(
+                name: "with_suspended",
+                value: withSuspended?.description)
+        ].filter { $0.value != nil }
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -224,7 +224,7 @@ extension TootClient {
     /// Find out whether a given account is followed, blocked, muted, etc.
     /// - Parameter id: the ID of the Account in the instance database.
     /// - Returns: the relationship to the account requested, or an error if unable to retrieve
-    public func getRelationships(by ids: [String]) async throws -> [Relationship] {
+    public func getRelationships(by ids: [String], withSuspended: Bool = false) async throws -> [Relationship] {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", "relationships"])
             $0.method = .get

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -224,11 +224,11 @@ extension TootClient {
     /// Find out whether a given account is followed, blocked, muted, etc.
     /// - Parameter id: the ID of the Account in the instance database.
     /// - Returns: the relationship to the account requested, or an error if unable to retrieve
-    public func getRelationships(by ids: [String], withSuspended: Bool = false) async throws -> [Relationship] {
+    public func getRelationships(by ids: [String], params: RelationshipParams = .init()) async throws -> [Relationship] {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", "relationships"])
             $0.method = .get
-            $0.query = ids.map({ URLQueryItem(name: "id[]", value: $0) })
+            $0.query = ids.map({ URLQueryItem(name: "id[]", value: $0) }) + params.queryItems
         }
         return try await fetch([Relationship].self, req)
     }


### PR DESCRIPTION
Introduced in Mastodon 4.3.0

https://docs.joinmastodon.org/methods/accounts/#relationships

Passed via a RelationshipParams struct in the same manner as params in getAnnouncements (and others).