### PR TITLE
GoToSocial flavour

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,7 @@ let package = Package(
                 .copy("Resources/nodeinfo_catodon.json"),
                 .copy("Resources/nodeinfo_firefish.json"),
                 .copy("Resources/nodeinfo_friendica.json"),
+                .copy("Resources/nodeinfo_gotosocial.json"),
                 .copy("Resources/nodeinfo_iceshrimp.json"),
                 .copy("Resources/nodeinfo_mastodon.json"),
                 .copy("Resources/nodeinfo_pixelfed.json"),

--- a/Sources/TootSDK/Models/NodeInfo.swift
+++ b/Sources/TootSDK/Models/NodeInfo.swift
@@ -37,24 +37,15 @@ public struct WellKnownNodeInfo: Codable {
 
 extension NodeInfo {
     public var flavour: TootSDKFlavour {
-        if software.name == "pleroma" {
-            return .pleroma
+        switch software.name {
+        case "pleroma": return .pleroma
+        case "pixelfed": return .pixelfed
+        case "friendica": return .friendica
+        case "akkoma": return .akkoma
+        case "firefish", "catodon", "iceshrimp": return .firefish
+        case "sharkey": return .sharkey
+        case "gotosocial": return .goToSocial
+        default: return .mastodon
         }
-        if software.name == "pixelfed" {
-            return .pixelfed
-        }
-        if software.name == "friendica" {
-            return .friendica
-        }
-        if software.name == "akkoma" {
-            return .akkoma
-        }
-        if software.name == "firefish" || software.name == "catodon" || software.name == "iceshrimp" {
-            return .firefish
-        }
-        if software.name == "sharkey" {
-            return .sharkey
-        }
-        return .mastodon
     }
 }

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -75,6 +75,8 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return [.follow, .mention, .repost, .favourite]
             case .firefish:
                 return [.follow, .mention, .repost, .poll, .followRequest]
+            case .goToSocial:
+                return [.follow, .followRequest, .mention, .repost, .favourite, .poll, .post, .adminSignUp]
             }
         }
 
@@ -85,7 +87,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return Set(allCases)
             case .pleroma, .akkoma, .friendica, .sharkey:
                 return [.follow, .mention, .repost, .favourite, .poll]
-            case .pixelfed, .firefish:
+            case .pixelfed, .firefish, .goToSocial:
                 return []
             }
         }

--- a/Sources/TootSDK/Models/TootSDKFlavour.swift
+++ b/Sources/TootSDK/Models/TootSDKFlavour.swift
@@ -24,4 +24,7 @@ public enum TootSDKFlavour: String, Codable, Sendable, CaseIterable {
 
     /// Sharkey server. Source at https://git.joinsharkey.org/Sharkey/Sharkey
     case sharkey
+
+    /// GoToSocial server. API Documentation can be found at https://docs.gotosocial.org/en/latest/api/swagger/
+    case goToSocial
 }

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -282,5 +282,5 @@ extension TootFeature {
 
     /// Ability to edit your profile
     ///
-    public static let updateCredentials = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey])
+    public static let updateCredentials = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Conversation.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Conversation.swift
@@ -50,5 +50,7 @@ extension TootFeature {
 
     /// Ability to retrieve conversations.
     ///
-    public static let conversations = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey, .goToSocial])
+    public static let conversations = TootFeature(supportedFlavours: [
+        .mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey, .goToSocial,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Conversation.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Conversation.swift
@@ -50,5 +50,5 @@ extension TootFeature {
 
     /// Ability to retrieve conversations.
     ///
-    public static let conversations = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey])
+    public static let conversations = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
+++ b/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
@@ -12,7 +12,7 @@ extension TootClient {
     /// Show information about all blocked domains.
     /// - Returns: array of blocked domains
     public func adminGetDomainBlocks() async throws -> [DomainBlock] {
-        try requireFeature(.domainBlocks)
+        try requireFeature(.adminDomainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks"])
             $0.method = .get
@@ -26,7 +26,7 @@ extension TootClient {
     /// - Parameter id: The ID of the DomainBlock in the instance's database
     /// - Returns: DomainBlock (optional)
     public func adminGetDomainBlock(id: String) async throws -> DomainBlock? {
-        try requireFeature(.domainBlocks)
+        try requireFeature(.adminDomainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks", id])
             $0.method = .get
@@ -43,7 +43,7 @@ extension TootClient {
     ///
     /// Note that the call will be successful even if the domain is already blocked, or if the domain does not exist, or if the domain is not a domain.
     public func adminBlockDomain(params: BlockDomainParams) async throws -> DomainBlock {
-        try requireFeature(.domainBlocks)
+        try requireFeature(.adminDomainBlocks)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks"])
             $0.method = .post
@@ -57,7 +57,7 @@ extension TootClient {
     /// Note that the call will be successful even if the domain was not previously blocked.
     /// - Parameter domain: The ID of the DomainAllow in the database.
     public func adminUnblockDomain(domain: String) async throws {
-        try requireFeature(.domainBlocks)
+        try requireFeature(.adminDomainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks", domain])
             $0.method = .delete
@@ -132,4 +132,7 @@ extension TootFeature {
     ///
     /// Not on Friendica
     public static let domainBlocks = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .sharkey])
+
+    /// Ability to block domains as an admin.
+    public static let adminDomainBlocks = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .sharkey, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -84,5 +84,5 @@ extension TootFeature {
 
     /// Ability to promote hashtags on user profiles.
     ///
-    public static let featuredTags = TootFeature(supportedFlavours: [.mastodon])
+    public static let featuredTags = TootFeature(supportedFlavours: [.mastodon, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Filters.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Filters.swift
@@ -83,5 +83,5 @@ extension TootFeature {
 
     /// Ability to  view/edit/create filters.
     ///
-    public static let filtersV2 = TootFeature(supportedFlavours: [.mastodon])
+    public static let filtersV2 = TootFeature(supportedFlavours: [.mastodon, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
@@ -75,5 +75,5 @@ extension TootClient {
 extension TootFeature {
 
     /// Ability to view and manage follow requests.
-    public static let followRequests = TootFeature(supportedFlavours: [.mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey])
+    public static let followRequests = TootFeature(supportedFlavours: [.mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
@@ -75,5 +75,7 @@ extension TootClient {
 extension TootFeature {
 
     /// Ability to view and manage follow requests.
-    public static let followRequests = TootFeature(supportedFlavours: [.mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey, .goToSocial])
+    public static let followRequests = TootFeature(supportedFlavours: [
+        .mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey, .goToSocial,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -109,5 +109,5 @@ extension TootFeature {
 
     /// Ability to create lists.
     ///
-    public static let lists = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey])
+    public static let lists = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Markers.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Markers.swift
@@ -59,5 +59,5 @@ extension TootClient {
 
 extension TootFeature {
     /// Ability to save timeline positions.
-    public static let markers = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma])
+    public static let markers = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -260,14 +260,14 @@ extension TootFeature {
 
     /// Ability to bookmark posts
     ///
-    public static let bookmark = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish])
+    public static let bookmark = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial])
 }
 
 extension TootFeature {
 
     /// Ability to mute a conversation that mentions you
     ///
-    public static let mutePost = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish])
+    public static let mutePost = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial])
 }
 
 extension TootFeature {

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -273,5 +273,5 @@ extension TootFeature {
 
     /// Ability to set a private note for an account
     ///
-    public static let privateNote = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .friendica])
+    public static let privateNote = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .friendica, .goToSocial])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Streaming.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Streaming.swift
@@ -192,5 +192,5 @@ extension TootFeature {
 
     /// Ability to stream incoming events via WebSocket
     ///
-    public static let streaming = TootFeature(supportedFlavours: [.mastodon, .pleroma, .akkoma])
+    public static let streaming = TootFeature(supportedFlavours: [.mastodon, .pleroma, .akkoma, .goToSocial])
 }

--- a/Tests/TootSDKTests/FlavourTests.swift
+++ b/Tests/TootSDKTests/FlavourTests.swift
@@ -100,4 +100,9 @@ final class FlavourTests: XCTestCase {
         let nodeInfo = try localObject(NodeInfo.self, "nodeinfo_sharkey")
         XCTAssertEqual(nodeInfo.flavour, .sharkey)
     }
+
+    func testDetectsNodeInfoGoToSocial() throws {
+        let instance = try localObject(NodeInfo.self, "nodeinfo_gotosocial")
+        XCTAssertEqual(instance.flavour, .goToSocial)
+    }
 }

--- a/Tests/TootSDKTests/Resources/nodeinfo_gotosocial.json
+++ b/Tests/TootSDKTests/Resources/nodeinfo_gotosocial.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0",
+  "software": {
+    "name": "gotosocial",
+    "version": "0.16.0+git-f1cbf6f"
+  },
+  "protocols": [
+    "activitypub"
+  ],
+  "services": {
+    "inbound": [],
+    "outbound": []
+  },
+  "openRegistrations": false,
+  "usage": {
+    "users": {
+      "total": 5
+    },
+    "localPosts": 3010
+  },
+  "metadata": {
+
+  }
+}


### PR DESCRIPTION
`domainBlocks` feature was split to `adminDomainBlocks` since only this part is supported by GoToSocial.

Closes #287 