### PR TITLE
Prevent trailing new line from being added to extracted post plain text

### DIFF
--- a/Sources/TootSDK/HTMLRendering/TootHTML.swift
+++ b/Sources/TootSDK/HTMLRendering/TootHTML.swift
@@ -15,6 +15,9 @@ public struct TootHTML {
         let linebreak = "|tootsdk-linebreak|"
 
         html = html.replacingOccurrences(of: "<p>", with: "")
+        if html.hasSuffix("</p>") {
+            html.removeLast("</p>".count)
+        }
         html = html.replacingOccurrences(of: "</p>", with: linebreak)
         html = html.replacingOccurrences(of: "<br />", with: linebreak)
         html = html.replacingOccurrences(of: "<br>", with: linebreak)

--- a/Tests/TootSDKTests/AttribStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttribStringRendererTests.swift
@@ -55,7 +55,6 @@
                 Hey fellow #Swift devs 👋!
                 As some of you may know, @konstantin and @davidgarywood have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
                 The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
-
                 """
 
             // just a sanity check on the expected mutable string
@@ -123,7 +122,6 @@
                 🟩🟩🟩⬛🟩
                 🟩🟩🟩⬛🟩
                 🟩🟩🟩⬛🟩
-
                 """
 
             // act

--- a/Tests/TootSDKTests/HTMLRenderingTests.swift
+++ b/Tests/TootSDKTests/HTMLRenderingTests.swift
@@ -1,0 +1,30 @@
+//
+//  HTMLRenderingTests.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 14/07/2024.
+//
+
+import XCTest
+import TootSDK
+
+final class HTMLRenderingTests: XCTestCase {
+
+    func testExtractAsPlainText() throws {
+        let html = "<p>Hello, World!</p>"
+        let plain = TootHTML.extractAsPlainText(html: html)
+        XCTAssertEqual(plain, "Hello, World!")
+    }
+
+    func testMultipleParagraphs() throws {
+        let html = "<p>Hello, World!</p><p>Second paragraph</p>"
+        let plain = TootHTML.extractAsPlainText(html: html)
+        XCTAssertEqual(plain, "Hello, World!\nSecond paragraph")
+    }
+
+    func testLineBreaks() throws {
+        let html = "<p>Hello, World!<br>with<br />Line breaks</p>"
+        let plain = TootHTML.extractAsPlainText(html: html)
+        XCTAssertEqual(plain, "Hello, World!\nwith\nLine breaks")
+    }
+}

--- a/Tests/TootSDKTests/HTMLRenderingTests.swift
+++ b/Tests/TootSDKTests/HTMLRenderingTests.swift
@@ -5,8 +5,8 @@
 //  Created by Łukasz Rutkowski on 14/07/2024.
 //
 
-import XCTest
 import TootSDK
+import XCTest
 
 final class HTMLRenderingTests: XCTestCase {
 


### PR DESCRIPTION
While adding post editing I noticed that plain text always included trailing new line. This happened because `</p>` tag was always converted to a new line.

Fix makes it so the trailing `</p>` is skipped when converting to new lines.