### PR TITLE
Separate iceshrimp and catodon from firefish

### DIFF
--- a/Sources/TootSDK/Models/Instance.swift
+++ b/Sources/TootSDK/Models/Instance.swift
@@ -224,11 +224,20 @@ extension Instance {
             return .akkoma
         }
         // 3.0.0 (compatible; Firefish 1.0.4-dev5)
-        // 4.2.1 (compatible; Iceshrimp 2023.12-pre3)
-        // 4.2.1 (compatible; Catodon 24.01-dev)
-        if version.lowercased().contains("firefish") || version.lowercased().contains("catodon") || version.lowercased().contains("iceshrimp") {
+        if version.lowercased().contains("firefish") {
             return .firefish
         }
+
+        // 4.2.1 (compatible; Iceshrimp 2023.12-pre3)
+        if version.lowercased().contains("iceshrimp") {
+            return .iceshrimp
+        }
+
+        // 4.2.1 (compatible; Catodon 24.01-dev)
+        if version.lowercased().contains("catodon") {
+            return .catodon
+        }
+
         // 3.0.0 (compatible; Sharkey 2023.12.0.beta3)
         if version.lowercased().contains("sharkey") {
             return .sharkey

--- a/Sources/TootSDK/Models/NodeInfo.swift
+++ b/Sources/TootSDK/Models/NodeInfo.swift
@@ -42,7 +42,9 @@ extension NodeInfo {
         case "pixelfed": return .pixelfed
         case "friendica": return .friendica
         case "akkoma": return .akkoma
-        case "firefish", "catodon", "iceshrimp": return .firefish
+        case "firefish": return .firefish
+        case "catodon": return .catodon
+        case "iceshrimp": return .iceshrimp
         case "sharkey": return .sharkey
         case "gotosocial": return .goToSocial
         default: return .mastodon

--- a/Sources/TootSDK/Models/TootNotification.swift
+++ b/Sources/TootSDK/Models/TootNotification.swift
@@ -73,7 +73,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return [.follow, .mention, .repost, .favourite, .poll]
             case .pixelfed:
                 return [.follow, .mention, .repost, .favourite]
-            case .firefish:
+            case .firefish, .catodon, .iceshrimp:
                 return [.follow, .mention, .repost, .poll, .followRequest]
             case .goToSocial:
                 return [.follow, .followRequest, .mention, .repost, .favourite, .poll, .post, .adminSignUp]
@@ -87,7 +87,7 @@ public struct TootNotification: Codable, Hashable, Identifiable, Sendable {
                 return Set(allCases)
             case .pleroma, .akkoma, .friendica, .sharkey:
                 return [.follow, .mention, .repost, .favourite, .poll]
-            case .pixelfed, .firefish, .goToSocial:
+            case .pixelfed, .firefish, .goToSocial, .catodon, .iceshrimp:
                 return []
             }
         }

--- a/Sources/TootSDK/Models/TootSDKFlavour.swift
+++ b/Sources/TootSDK/Models/TootSDKFlavour.swift
@@ -22,6 +22,12 @@ public enum TootSDKFlavour: String, Codable, Sendable, CaseIterable {
     /// Firefish server. Source at https://git.joinfirefish.org/firefish/firefish
     case firefish
 
+    /// Catodon server. Source at https://codeberg.org/catodon/catodon
+    case catodon
+
+    /// Iceshrimpt server. Source at https://iceshrimp.dev/iceshrimp
+    case iceshrimp
+
     /// Sharkey server. Source at https://git.joinsharkey.org/Sharkey/Sharkey
     case sharkey
 

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -282,5 +282,7 @@ extension TootFeature {
 
     /// Ability to edit your profile
     ///
-    public static let updateCredentials = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp])
+    public static let updateCredentials = TootFeature(supportedFlavours: [
+        .mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -282,5 +282,5 @@ extension TootFeature {
 
     /// Ability to edit your profile
     ///
-    public static let updateCredentials = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .goToSocial])
+    public static let updateCredentials = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Announcements.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Announcements.swift
@@ -65,5 +65,7 @@ extension TootFeature {
 
     /// Ability to retrieve announcements
     ///
-    public static let announcements = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .catodon, .iceshrimp])
+    public static let announcements = TootFeature(supportedFlavours: [
+        .mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .catodon, .iceshrimp,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Announcements.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Announcements.swift
@@ -65,5 +65,5 @@ extension TootFeature {
 
     /// Ability to retrieve announcements
     ///
-    public static let announcements = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey])
+    public static let announcements = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .firefish, .sharkey, .catodon, .iceshrimp])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Conversation.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Conversation.swift
@@ -51,6 +51,6 @@ extension TootFeature {
     /// Ability to retrieve conversations.
     ///
     public static let conversations = TootFeature(supportedFlavours: [
-        .mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey, .goToSocial,
+        .mastodon, .pleroma, .friendica, .akkoma, .pixelfed, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp,
     ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
@@ -76,6 +76,6 @@ extension TootFeature {
 
     /// Ability to view and manage follow requests.
     public static let followRequests = TootFeature(supportedFlavours: [
-        .mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey, .goToSocial,
+        .mastodon, .pleroma, .pixelfed, .friendica, .akkoma, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp,
     ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -109,5 +109,7 @@ extension TootFeature {
 
     /// Ability to create lists.
     ///
-    public static let lists = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp])
+    public static let lists = TootFeature(supportedFlavours: [
+        .mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -109,5 +109,5 @@ extension TootFeature {
 
     /// Ability to create lists.
     ///
-    public static let lists = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey, .goToSocial])
+    public static let lists = TootFeature(supportedFlavours: [.mastodon, .pleroma, .friendica, .akkoma, .firefish, .sharkey, .goToSocial, .catodon, .iceshrimp])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -202,5 +202,7 @@ extension TootFeature {
 
     /// Ability to dismiss (or mark as read) a single notification
     ///
-    public static let dismissNotification = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .catodon, .iceshrimp])
+    public static let dismissNotification = TootFeature(supportedFlavours: [
+        .mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .catodon, .iceshrimp,
+    ])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -202,5 +202,5 @@ extension TootFeature {
 
     /// Ability to dismiss (or mark as read) a single notification
     ///
-    public static let dismissNotification = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish])
+    public static let dismissNotification = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .catodon, .iceshrimp])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -260,14 +260,14 @@ extension TootFeature {
 
     /// Ability to bookmark posts
     ///
-    public static let bookmark = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial])
+    public static let bookmark = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp])
 }
 
 extension TootFeature {
 
     /// Ability to mute a conversation that mentions you
     ///
-    public static let mutePost = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial])
+    public static let mutePost = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp])
 }
 
 extension TootFeature {

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -260,14 +260,18 @@ extension TootFeature {
 
     /// Ability to bookmark posts
     ///
-    public static let bookmark = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp])
+    public static let bookmark = TootFeature(supportedFlavours: [
+        .mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp,
+    ])
 }
 
 extension TootFeature {
 
     /// Ability to mute a conversation that mentions you
     ///
-    public static let mutePost = TootFeature(supportedFlavours: [.mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp])
+    public static let mutePost = TootFeature(supportedFlavours: [
+        .mastodon, .akkoma, .pleroma, .pixelfed, .friendica, .firefish, .goToSocial, .catodon, .iceshrimp,
+    ])
 }
 
 extension TootFeature {

--- a/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
@@ -39,5 +39,5 @@ extension TootFeature {
 
     /// Ability to query and remove suggestions
     ///
-    public static let suggestions = TootFeature(supportedFlavours: [.mastodon, .firefish, .sharkey])
+    public static let suggestions = TootFeature(supportedFlavours: [.mastodon, .firefish, .sharkey, .catodon, .iceshrimp])
 }

--- a/Sources/TootSDK/TootClient/TootClient+Trends.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Trends.swift
@@ -66,14 +66,14 @@ extension TootFeature {
     @available(*, deprecated)
     /// Ability to query trends
     ///
-    public static let trends = TootFeature(supportedFlavours: [.mastodon, .firefish])
+    public static let trends = TootFeature(supportedFlavours: [.mastodon, .firefish, .catodon, .iceshrimp])
 }
 
 extension TootFeature {
 
     /// Ability to query trending posts
     ///
-    public static let trendingPosts = TootFeature(supportedFlavours: [.mastodon, .firefish])
+    public static let trendingPosts = TootFeature(supportedFlavours: [.mastodon, .firefish, .catodon, .iceshrimp])
 }
 
 extension TootFeature {

--- a/Tests/TootSDKTests/FlavourTests.swift
+++ b/Tests/TootSDKTests/FlavourTests.swift
@@ -39,14 +39,14 @@ final class FlavourTests: XCTestCase {
         XCTAssertEqual(instance.flavour, .firefish)
     }
 
-    func testDetectsCatodonAsFirefish() throws {
+    func testDetectsCatodon() throws {
         let instance = try localObject(Instance.self, "instance_catodon_contact_removed")
-        XCTAssertEqual(instance.flavour, .firefish)
+        XCTAssertEqual(instance.flavour, .catodon)
     }
 
-    func testDetectsIceshrimpAsFirefish() throws {
+    func testDetectsIceshrimp() throws {
         let instance = try localObject(Instance.self, "instance_iceshrimp_contact_removed")
-        XCTAssertEqual(instance.flavour, .firefish)
+        XCTAssertEqual(instance.flavour, .iceshrimp)
     }
 
     func testDetectsSharkey() throws {
@@ -63,7 +63,7 @@ final class FlavourTests: XCTestCase {
 
     func testDetectsNodeInfoCatodon() throws {
         let nodeInfo = try localObject(NodeInfo.self, "nodeinfo_catodon")
-        XCTAssertEqual(nodeInfo.flavour, .firefish)
+        XCTAssertEqual(nodeInfo.flavour, .catodon)
     }
 
     func testDetectsNodeInfoFirefish() throws {
@@ -78,7 +78,7 @@ final class FlavourTests: XCTestCase {
 
     func testDetectsNodeInfoIceshrimp() throws {
         let nodeInfo = try localObject(NodeInfo.self, "nodeinfo_iceshrimp")
-        XCTAssertEqual(nodeInfo.flavour, .firefish)
+        XCTAssertEqual(nodeInfo.flavour, .iceshrimp)
     }
 
     func testDetectsNodeInfoMastodon() throws {


### PR DESCRIPTION
This allows end clients to distinguish between these flavours. In my case I need this do display different icons and instance suggestions.