### PR TITLE
Post editing fixes

### DIFF
--- a/Sources/TootSDK/TootClient/TootClient+Media.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Media.swift
@@ -67,13 +67,17 @@ extension TootClient {
             $0.url = getURL(["api", "v1", "media", id])
             $0.method = .put
 
-            let parts = mediaParts(
-                description: params.description,
-                focus: params.focus,
-                thumbnail: params.thumbnail,
-                mimeType: params.thumbnailMimeType
-            )
-            $0.body = try .multipart(parts, boundary: UUID().uuidString)
+            if flavour == .pixelfed {
+                $0.body = try .json(params)
+            } else {
+                let parts = mediaParts(
+                    description: params.description,
+                    focus: params.focus,
+                    thumbnail: params.thumbnail,
+                    mimeType: params.thumbnailMimeType
+                )
+                $0.body = try .multipart(parts, boundary: UUID().uuidString)
+            }
         }
         return try await fetch(MediaAttachment.self, req)
     }

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -22,16 +22,53 @@ extension TootClient {
     }
 
     /// Edit a given post to change its text, sensitivity, media attachments, or poll. Note that editing a poll’s options will reset the votes.
-    /// - Parameter id: the ID of the psot to be changed
-    /// - Parameter params: the updated content of the post to be posted
-    /// - Returns: the post after the update
+    ///
+    /// - Note: For Pixelfed this will first attempt to update media descriptions and then update rest of post details.
+    /// If an error is thrown it is possible for some of the media descriptions to be already successfully updated.
+    ///
+    /// - Parameter id: The ID of the post to be changed.
+    /// - Parameter params: The updated content of the post to be posted.
+    /// - Returns: The post after the update.
     public func editPost(id: String, _ params: EditPostParams) async throws -> Post {
+        if flavour == .pixelfed {
+            // Media attributes change must be sent separately
+            try await updateMediaAttributes(params.mediaAttributes ?? [])
+        }
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id])
             $0.method = .put
-            $0.body = try .multipart(params, boundary: UUID().uuidString)
+            if flavour == .pixelfed {
+                var params = params
+                params.mediaAttributes = nil
+                $0.body = try .json(params)
+            } else {
+                $0.body = try .multipart(params, boundary: UUID().uuidString)
+            }
+        }
+        if flavour == .pixelfed {
+            _ = try await fetch(req: req)
+            // Pixelfed doesn't return edited post, simulate behavior of Mastodon by manually getting post
+            return try await getPost(id: id)
         }
         return try await fetch(Post.self, req)
+    }
+
+    private func updateMediaAttributes(_ mediaAttributes: [EditPostParams.MediaAttribute]) async throws {
+        guard !mediaAttributes.isEmpty else { return }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for mediaAttribute in mediaAttributes {
+                group.addTask {
+                    try await self.updateMedia(
+                        id: mediaAttribute.id,
+                        .init(
+                            description: mediaAttribute.description,
+                            focus: mediaAttribute.focus
+                        )
+                    )
+                }
+            }
+            try await group.waitForAll()
+        }
     }
 
     /// Gets a single post

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -230,8 +230,6 @@ extension TootClient {
 
     /// Obtain the source properties for a post so that it can be edited.
     public func getPostSource(id: String) async throws -> PostSource {
-        try requireFlavour(otherThan: [.friendica])
-
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "source"])
             $0.method = .get

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -230,6 +230,8 @@ extension TootClient {
 
     /// Obtain the source properties for a post so that it can be edited.
     public func getPostSource(id: String) async throws -> PostSource {
+        try requireFlavour(otherThan: [.pixelfed])
+
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "source"])
             $0.method = .get


### PR DESCRIPTION
The changes are tested by running live on account connected to pixey.org and venera.social instances.

For Friendica I've enabled post source endpoint as it is supported.

Pixelfed has more changes:
- Edit starts by concurrently updating media descriptions using separate endpoint since it is not possible to edit them using main endpoint.
- Content is sent as json instead of multipart
- Edited post is not returned from edit endpoint so it is requested manually
- Post source endpoint is marked as not supported