### PR TITLE
Add latest preview card attributes returned by Mastodon

### DIFF
--- a/Sources/TootSDK/Models/Card.swift
+++ b/Sources/TootSDK/Models/Card.swift
@@ -4,35 +4,43 @@
 import Foundation
 
 /// Represents a rich preview card that is generated using OpenGraph tags from a URL.
-public struct Card: Codable, Hashable {
+public struct Card: Codable, Hashable, Sendable {
     public init(
         url: String,
         title: String,
         description: String,
+        language: String?,
         type: Card.CardType,
         authorName: String? = nil,
         authorUrl: String? = nil,
+        authors: [Author]? = nil,
+        publishedAt: Date? = nil,
         providerName: String? = nil,
         providerUrl: String? = nil,
         html: String? = nil,
         width: Int? = nil,
         height: Int? = nil,
         image: String? = nil,
+        imageDescription: String? = nil,
         embedUrl: String? = nil,
         blurhash: String? = nil
     ) {
         self.url = url
         self.title = title
         self.description = description
+        self.language = language
         self.type = type
         self.authorName = authorName
         self.authorUrl = authorUrl
+        self.authors = authors
+        self.publishedAt = publishedAt
         self.providerName = providerName
         self.providerUrl = providerUrl
         self.html = html
         self.width = width
         self.height = height
         self.image = image
+        self.imageDescription = imageDescription
         self.embedUrl = embedUrl
         self.blurhash = blurhash
     }
@@ -41,18 +49,40 @@ public struct Card: Codable, Hashable {
         case link, photo, video, rich
     }
 
+    /// Information about an author of a linked resource.
+    public struct Author: Codable, Hashable, Sendable {
+        /// The author's name.
+        public var name: String?
+        /// The author's URL.
+        public var url: String?
+        /// The author's Fediverse account.
+        public var account: Account?
+
+        public init(name: String? = nil, url: String? = nil, account: Account? = nil) {
+            self.name = name
+            self.url = url
+            self.account = account
+        }
+    }
+
     /// Location of linked resource.
     public var url: String
     /// Title of linked resource.
     public var title: String
     /// Description of preview.
     public var description: String
+    /// The language code of the linked resource.
+    public var language: String?
     /// The type of preview card.
     public var type: CardType
     /// The author of the original resource.
     public var authorName: String?
     /// A link to the author of the original resource.
     public var authorUrl: String?
+    /// A list of authors of the original resource, which may include links to their Fediverse accounts.
+    public var authors: [Author]?
+    /// The date the linked resource was published.
+    public var publishedAt: Date?
     /// The provider of the original resource.
     public var providerName: String?
     /// A link to the provider of the original resource.
@@ -65,6 +95,8 @@ public struct Card: Codable, Hashable {
     public var height: Int?
     /// Preview thumbnail.
     public var image: String?
+    /// Alt text of the preview thumbnail (``image``)
+    public var imageDescription: String?
     /// For ``CardType/photo`` embeds, the URL of the image file on its original server.
     public var embedUrl: String?
     /// A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.


### PR DESCRIPTION
Some recently added Mastodon features for link preview cards:
- article language
- publication date
- image description for article thumbnail
- authors array (in addition to the existing `author_name` and `author_url`) that can reference the author’s Fediverse account

These API additions are, as usual, missing from Mastodon’s documentation as far as I can tell, but were announced in [their blog post](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) and are live on mastodon.social. For example, [this post from the Verge](https://mastodon.social/@theverge_com/112887138012612832) has all of these properties, which you can test with this PR using `swiftyadmin get-post -u https://mastodon.social -i 112887138012612832 -t "[your_api_token]"`

All added properties are optional (they aren’t necessarily present on every post anyway), so there shouldn’t be any issues with servers that don’t send them.