### PR TITLE
Provide default value for `language` in `Card` initializer

### DIFF
--- a/Sources/TootSDK/Models/Card.swift
+++ b/Sources/TootSDK/Models/Card.swift
@@ -9,7 +9,7 @@ public struct Card: Codable, Hashable, Sendable {
         url: String,
         title: String,
         description: String,
-        language: String?,
+        language: String? = nil,
         type: Card.CardType,
         authorName: String? = nil,
         authorUrl: String? = nil,


### PR DESCRIPTION
Whoops! I didn’t catch this before I submitted #297 