### PR TITLE
Add configurable behavior for retrying idle streaming connection

### DIFF
--- a/Sources/TootSDK/TootClient/Streaming/StreamingClient.swift
+++ b/Sources/TootSDK/TootClient/Streaming/StreamingClient.swift
@@ -67,6 +67,13 @@ public actor StreamingClient {
     /// This limit attempts to prevent excessive handshakes if the connection is available but unreliable.
     public var maxConnectionAttempts = 10
 
+    /// Whether to automatically reconnect or retry after failure if there are no subscribers at the time the connection fails.
+    ///
+    /// If `false`, StreamingClient will only try to reconnect if there are active subscribers (i.e. awaiting values from a stream returned by ``subscribe(to:bufferingPolicy:)``) when a connection fails.
+    ///
+    /// If `true`, it will automatically attempt to reconnect (if allowed by ``maxRetries`` and ``maxConnectionAttempts``) even if the connection is currently unused at the time.
+    public var retryIfNoSubscribers = false
+
     /// Is the connection currently active?
     ///
     /// The state of this property matches ``Event/connectionUp`` and ``Event/connectionDown`` events being sent to subscribers.
@@ -347,6 +354,7 @@ public actor StreamingClient {
                 continue
             }
         } while unsuccessfulConnectionAttempts < maxRetries && totalConnectionAttempts < maxConnectionAttempts && !Task.isCancelled
+            && (retryIfNoSubscribers || !subscribers.isEmpty)
     }
 
     deinit {


### PR DESCRIPTION
Currently, if a streaming connection gets disconnected, StreamingClient will automatically retry even if the connection is idle (i.e. there are no subscribers to any streaming feeds). This PR makes the behavior in this case configurable, and by default does not automatically try to reconnect an unused connection.

The previous behavior of always retrying can be achieved by setting `retryIfNoSubscribers` to `true` on the StreamingClient instance.

## Use case

In my client app, I’m leaving the websocket connection open after the user finishes using it (e.g. by leaving whatever view is subscribed to a streaming feed) and just unsubscribing from the feed. This makes it faster and use less resources to resubscribe, **but** if the connection goes down while it’s not being used, having it always automatically reconnect right away is a waste of resources. This PR prevents that by making the default behavior to not reconnect unused connections after failure.