### PR TITLE
Fix: Use preferred clientName for web socket connections, debugOn() now also prints raw socket events

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -86,6 +86,7 @@ let package = Package(
                 .copy("Resources/streaming_delete.json"),
                 .copy("Resources/streaming_filters_changed.json"),
                 .copy("Resources/streaming_update.json"),
+                .copy("Resources/streaming_error.json"),
                 .copy("Resources/tag.json"),
                 .copy("Resources/translation_attachment.json"),
                 .copy("Resources/translation_poll.json"),

--- a/Sources/TootSDK/Models/Streaming/StreamingEvent.swift
+++ b/Sources/TootSDK/Models/Streaming/StreamingEvent.swift
@@ -26,23 +26,21 @@ public struct StreamingEvent: Sendable {
 extension StreamingEvent: Decodable {
     public init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        
+
         func throwStreamingError(_ fallback: String) -> TootSDKError {
             let error = try? values.decodeIfPresent(String.self, forKey: .error)
             if let status = try? values.decodeIfPresent(Int.self, forKey: .status) {
                 return TootSDKError.streamingError(status: status, error: error ?? "Unknwon")
-            }
-            else if let error = error {
+            } else if let error = error {
                 return TootSDKError.streamingError(status: 400, error: error)
-            }
-            else {
+            } else {
                 return TootSDKError.decodingError(fallback)
             }
         }
-        
+
         guard let stream = try values.decodeIfPresent([String].self, forKey: .stream),
-              let timeline = StreamingTimeline(rawValue: stream) else
-        {
+            let timeline = StreamingTimeline(rawValue: stream)
+        else {
             throw throwStreamingError("timeline")
         }
         self.timeline = timeline
@@ -52,8 +50,7 @@ extension StreamingEvent: Decodable {
         do {
             eventName = try values.decode(String.self, forKey: .event)
             payload = try values.decodeIfPresent(String.self, forKey: .payload)
-        }
-        catch {
+        } catch {
             throw throwStreamingError("event or payload")
         }
         guard let event = EventContent(eventName, payload: payload) else {

--- a/Sources/TootSDK/Models/TootSDKError.swift
+++ b/Sources/TootSDK/Models/TootSDKError.swift
@@ -69,7 +69,7 @@ public enum TootSDKError: Error, LocalizedError, Equatable {
             return "The remote instance does not provide a streaming endpoint."
         case .streamingEndpointUnhealthy:
             return "The streaming endpoint is not alive."
-            case .streamingError(status: let status, error: let error):
+        case .streamingError(let status, let error):
             return "The streaming event could not be decoded, status: \(status), error: \(error)."
         case .noSubscriptions:
             return "Cannot start streaming because there are no subscriptions to any streaming timelines."

--- a/Tests/TootSDKTests/Resources/streaming_error.json
+++ b/Tests/TootSDKTests/Resources/streaming_error.json
@@ -1,0 +1,4 @@
+{
+  "error": "Something went wrong",
+  "status": 400
+}

--- a/Tests/TootSDKTests/StreamingTests.swift
+++ b/Tests/TootSDKTests/StreamingTests.swift
@@ -60,6 +60,17 @@ final class StreamingTests: XCTestCase {
         XCTAssertEqual(result.event, .filtersChanged)
     }
 
+    func testDecodingServerError() throws {
+        // arrange
+        let json = localContent("streaming_error")
+        let decoder = TootDecoder()
+
+        // act
+        XCTAssertThrowsError(try decoder.decode(StreamingEvent.self, from: json)) { error in
+            XCTAssertEqual(error as! TootSDKError, TootSDKError.streamingError(status: 400, error: "Something went wrong"))
+        }
+    }
+
     func testEncodingQuery() throws {
         let target = "{\"type\":\"subscribe\",\"stream\":\"user\"}"
         let alternateTarget = "{\"stream\":\"user\",\"type\":\"subscribe\"}"


### PR DESCRIPTION
This PR adds some improvements in relation to #304:

- Extends debugOn() from TootClient so event payloads may be printed in console
- Adds support for handling server sent errors as events. For now it simply gets retrown as a `TootSDKError.unexpectedError` with the server message as a description

