### PR TITLE
Fix rawValue of user notification timeline

### DIFF
--- a/Sources/TootSDK/Models/Streaming/StreamingTimeline.swift
+++ b/Sources/TootSDK/Models/Streaming/StreamingTimeline.swift
@@ -75,7 +75,7 @@ extension StreamingTimeline: RawRepresentable {
         case .hashtag(let tag): ["hashtag", tag]
         case .localHashtag(let tag): ["hashtag:local", tag]
         case .user: ["user"]
-        case .userNotification: ["userNotification"]
+        case .userNotification: ["user:notification"]
         case .list(let listID): ["list", listID]
         case .direct: ["direct"]
         }


### PR DESCRIPTION
Fixes #304 - the rawValue of the .userNotification timeline was `userNotification` when it should have been `user:notification`