### PR TITLE
Properly set clientName in user-agent of fetch

### DIFF
--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -178,7 +178,7 @@ extension TootClient {
         }
 
         if req.headers.index(forKey: "User-Agent") == nil {
-            req.headers["User-Agent"] = "TootSDK"
+            req.headers["User-Agent"] = clientName
         }
 
         if let accessToken = accessToken {


### PR DESCRIPTION
Was still hardcoded, clientName only used in fetch.