### PR TITLE
Add httpUserAgent field setting outgoing User-Agent header

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Posts/GetPost.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Posts/GetPost.swift
@@ -19,7 +19,11 @@ struct GetPost: AsyncParsableCommand {
 
     mutating func run() async throws {
         print("Getting post with local id: \(id)")
-        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+        let client = try await TootClient(
+            connect: URL(string: url)!,
+            clientName: "SwiftyAdminExample",
+            accessToken: token,
+            httpUserAgent: "SwiftyAdminExample 0.0")
 
         let post = try await client.getPost(id: id)
         let json = String.init(data: try TootEncoder().encode(post), encoding: .utf8)

--- a/Sources/TootSDK/TootClient/TootClient+Streaming.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Streaming.swift
@@ -184,7 +184,7 @@ extension TootClient {
     /// - Throws: ``TootSDKError/requiredURLNotSet`` if the request does not have a URL set.
     internal func webSocketTask(_ req: HTTPRequestBuilder) throws -> URLSessionWebSocketTask {
         if req.headers.index(forKey: "User-Agent") == nil {
-            req.headers["User-Agent"] = clientName
+            req.headers["User-Agent"] = httpUserAgent
         }
 
         if let accessToken {

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -38,7 +38,7 @@ public class TootClient: @unchecked Sendable {
 
     /// The User-Agent header string used in outgoing HTTP requests.
     ///
-    /// Use this to identify the app, its version number, and its host operating system for example.
+    /// Use this to identify the app, its version number, and its host operating system, for example.
     /// Changing this is optional, but recommended.
     ///
     /// https://developer.mozilla.org/en-US/docs/Glossary/User_agent


### PR DESCRIPTION
This PR fixes #312 
It is now possible to configure a custom value for the user agent header as [described in the spec](https://developer.mozilla.org/en-US/docs/Glossary/User_agent).

For example:

```
let client = try await TootClient(
            connect: URL(string: url)!,
            clientName: "SwiftyAdminExample",
            accessToken: token,
            httpUserAgent: "SwiftyAdminExample 0.0")
```

When httpUserAgent is not set, it will have the value of clientName.