### PR TITLE
Fix user relationship endpoint for sharkey

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,6 +79,7 @@ let package = Package(
                 .copy("Resources/mastodon.json"),
                 .copy("Resources/pleroma.json"),
                 .copy("Resources/relationship.json"),
+                .copy("Resources/relationship_sharkey.json"),
                 .copy("Resources/scheduled_post_sensitive.json"),
                 .copy("Resources/scheduled_post_attachment.json"),
                 .copy("Resources/scheduled_post_multiple_attachments.json"),

--- a/Sources/TootSDK/Models/Relationship.swift
+++ b/Sources/TootSDK/Models/Relationship.swift
@@ -8,16 +8,16 @@ import Foundation
 public struct Relationship: Codable, Hashable, Identifiable, Sendable {
 
     public init(
-        id: String,
-        following: Bool,
-        requested: Bool,
+        id: String? = nil,
+        following: Bool? = nil,
+        requested: Bool?,
         endorsed: Bool? = nil,
-        followedBy: Bool,
-        muting: Bool,
+        followedBy: Bool? = nil,
+        muting: Bool? = nil,
         mutingNotifications: Bool? = nil,
         showingReposts: Bool? = nil,
         notifying: Bool? = nil,
-        blocking: Bool,
+        blocking: Bool? = nil,
         domainBlocking: Bool?,
         blockedBy: Bool? = nil,
         note: String? = nil
@@ -38,17 +38,17 @@ public struct Relationship: Codable, Hashable, Identifiable, Sendable {
     }
 
     /// The account id.
-    public let id: String
+    public let id: String?
     /// Are you following this user?
-    public let following: Bool
+    public let following: Bool?
     /// Do you have a pending follow request for this user?
-    public let requested: Bool
+    public let requested: Bool?
     /// Are you featuring this user on your profile?
     public var endorsed: Bool?
     /// Are you followed by this user?
-    public let followedBy: Bool
+    public let followedBy: Bool?
     /// Are you muting this user?
-    public let muting: Bool
+    public let muting: Bool?
     /// Are you muting notifications from this user?
     public var mutingNotifications: Bool?
     /// Are you receiving this user's posts in your home timeline?
@@ -56,7 +56,7 @@ public struct Relationship: Codable, Hashable, Identifiable, Sendable {
     /// Have you enabled notifications for this user?
     public let notifying: Bool?
     /// Are you blocking this user?
-    public let blocking: Bool
+    public let blocking: Bool?
     /// Are you blocking this user's domain?
     public let domainBlocking: Bool?
     /// Is this user blocking you?

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -26,7 +26,7 @@ extension TootClient {
             // So we use that to then retrieve the relationship
             let account = try await pleromaFollowAccountURI(by: uri)
 
-            if let relationship = try await getRelationships(by: [account.id]).first {
+            if let accountId = account.id, let relationship = try await getRelationships(by: [accountId]).first {
                 return relationship
             } else {
                 throw TootSDKError.unexpectedError("Unable to retrieve relationship")

--- a/Tests/TootSDKTests/RelationshipTests.swift
+++ b/Tests/TootSDKTests/RelationshipTests.swift
@@ -33,6 +33,26 @@ final class RelationshipTests: XCTestCase {
         XCTAssertEqual(result.showingReposts, false)
         XCTAssertEqual(result.endorsed, false)
         XCTAssertEqual(result.note, "")
+    }
 
+    func testSharkeyRelationshipDecode() throws {
+        let json = localContent("relationship_sharkey")
+        let decoder = TootDecoder()
+
+        let result = try decoder.decode(Relationship.self, from: json)
+
+        XCTAssertEqual(result.id, nil)
+        XCTAssertEqual(result.following, nil)
+        XCTAssertEqual(result.requested, nil)
+        XCTAssertEqual(result.endorsed, false)
+        XCTAssertEqual(result.followedBy, nil)
+        XCTAssertEqual(result.muting, nil)
+        XCTAssertEqual(result.mutingNotifications, false)
+        XCTAssertEqual(result.showingReposts, true)
+        XCTAssertEqual(result.notifying, false)
+        XCTAssertEqual(result.blocking, nil)
+        XCTAssertEqual(result.domainBlocking, false)
+        XCTAssertEqual(result.blockedBy, nil)
+        XCTAssertEqual(result.note, nil)
     }
 }

--- a/Tests/TootSDKTests/Resources/relationship_sharkey.json
+++ b/Tests/TootSDKTests/Resources/relationship_sharkey.json
@@ -1,0 +1,8 @@
+{
+    "domain_blocking": false,
+    "endorsed": false,
+    "muting_notifications": false,
+    "note": null,
+    "notifying": false,
+    "showing_reblogs": true
+}


### PR DESCRIPTION
Sharkey returns smaller set of data than Mastodon when fetching user relationship. To properly decode its responses additional fields needed to be marked as optional.

I considered adding default values instead of optional but ultimately decided that it'll be better to leave that up to clients.