### PR TITLE
Add optional parameter for client website

### DIFF
--- a/Sources/TootSDK/Models/CreateAppRequest.swift
+++ b/Sources/TootSDK/Models/CreateAppRequest.swift
@@ -7,5 +7,5 @@ struct CreateAppRequest: Hashable, Codable {
     let clientName: String
     let redirectUris: String
     let scopes: String
-    let website: String
+    let website: String?
 }

--- a/Sources/TootSDK/TootClient/TootClient+Request.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Request.swift
@@ -64,14 +64,14 @@ extension TootClient {
     internal func getAuthorizationInfo(
         callbackURI: String,
         scopes: [String],
-        website: String = "",
         responseType: String = "code"
     ) async throws -> CallbackInfo {
 
         let createAppData = CreateAppRequest(
             clientName: clientName,
             redirectUris: callbackURI,
-            scopes: scopes.joined(separator: " "), website: website)
+            scopes: scopes.joined(separator: " "),
+            website: clientWebsite)
 
         let registerAppReq = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "apps"])

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -39,7 +39,7 @@ public class TootClient: @unchecked Sendable {
     /// The URL of the client's website.
     ///
     /// This URL is used as the hyperlink of the clientName in the details of a toot.
-    public let clientWebsite: String
+    public let clientWebsite: String?
 
     /// The User-Agent header string used in outgoing HTTP requests.
     ///
@@ -73,7 +73,7 @@ public class TootClient: @unchecked Sendable {
     ///   - scopes: An array of authentication scopes, defaults to `"read", "write", "follow", "push"`
     public init(
         clientName: String = "TootSDK",
-        clientWebsite: String = "",
+        clientWebsite: String? = nil,
         session: URLSession = URLSession.shared,
         instanceURL: URL,
         accessToken: String? = nil,
@@ -102,7 +102,7 @@ public class TootClient: @unchecked Sendable {
     public init(
         connect instanceURL: URL,
         clientName: String = "TootSDK",
-        clientWebsite: String = "",
+        clientWebsite: String? = nil,
         session: URLSession = URLSession.shared,
         accessToken: String? = nil,
         scopes: [String] = ["read", "write", "follow", "push"],

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -36,6 +36,11 @@ public class TootClient: @unchecked Sendable {
     /// Changing the value of clientName after authentication will result in your authentication token being invalidated.
     public let clientName: String
 
+    /// The URL of the client's website.
+    ///
+    /// This URL is used as the hyperlink of the clientName in the details of a toot.
+    public let clientWebsite: String
+
     /// The User-Agent header string used in outgoing HTTP requests.
     ///
     /// Use this to identify the app, its version number, and its host operating system, for example.
@@ -61,12 +66,14 @@ public class TootClient: @unchecked Sendable {
     /// After initializing, you need to manually call ``TootClient/connect()`` in order to obtain the correct flavour of the server.
     /// - Parameters:
     ///   - clientName: Name of the client to be used in outgoing HTTP requests. Defaults to `TootSDK`
+    ///   - clientWebsite: A URL to the homepage of your client. Defaults to an empty string.
     ///   - session: the URLSession being used internally, defaults to shared
     ///   - instanceURL: the instance you are connecting to
     ///   - accessToken: the existing access token; if you already have one
     ///   - scopes: An array of authentication scopes, defaults to `"read", "write", "follow", "push"`
     public init(
         clientName: String = "TootSDK",
+        clientWebsite: String = "",
         session: URLSession = URLSession.shared,
         instanceURL: URL,
         accessToken: String? = nil,
@@ -78,6 +85,7 @@ public class TootClient: @unchecked Sendable {
         self.accessToken = accessToken
         self.scopes = scopes
         self.clientName = clientName
+        self.clientWebsite = clientWebsite
         self.httpUserAgent = httpUserAgent ?? clientName
     }
 
@@ -87,12 +95,14 @@ public class TootClient: @unchecked Sendable {
     /// - Parameters:
     ///   - instanceURL: the instance you are connecting to
     ///   - clientName: Name of the client to be used in outgoing HTTP requests. Defaults to `TootSDK`
+    ///   - clientWebsite: A URL to the homepage of your client. Defaults to an empty string.
     ///   - session: the URLSession being used internally, defaults to shared
     ///   - accessToken: the existing access token; if you already have one
     ///   - scopes: An array of authentication scopes, defaults to `"read", "write", "follow", "push"`
     public init(
         connect instanceURL: URL,
         clientName: String = "TootSDK",
+        clientWebsite: String = "",
         session: URLSession = URLSession.shared,
         accessToken: String? = nil,
         scopes: [String] = ["read", "write", "follow", "push"],
@@ -103,6 +113,7 @@ public class TootClient: @unchecked Sendable {
         self.accessToken = accessToken
         self.scopes = scopes
         self.clientName = clientName
+        self.clientWebsite = clientWebsite
         self.httpUserAgent = httpUserAgent ?? clientName
         try await connect()
     }


### PR DESCRIPTION
Clients can provide a URL to their website, which is the link when pressing on the client name in the details of a toot. (https://docs.joinmastodon.org/methods/apps/#form-data-parameters)
This PR exposes this parameter, which has been "" by default and still is the default, to the client.