### PR TITLE
Attributed string renderer

### DIFF
--- a/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
@@ -1,0 +1,73 @@
+//
+//  AttributedString+Util.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 06/11/2024.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+    import UIKit
+
+    typealias _Font = UIFont
+#elseif canImport(AppKit)
+    import AppKit
+
+    typealias _Font = NSFont
+#endif
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString {
+    mutating func insertInlinePresentationIntent(_ intent: InlinePresentationIntent) {
+        for run in runs {
+            if let intents = run.inlinePresentationIntent {
+                self[run.range].inlinePresentationIntent = intents.union(intent)
+            } else {
+                self[run.range].inlinePresentationIntent = intent
+            }
+        }
+    }
+
+    #if canImport(UIKit) || canImport(AppKit)
+        mutating func applyFontKeepingSymbolicTraits(_ font: _Font) {
+            for run in runs {
+                if let existingFontTraits = run.font?.fontDescriptor.symbolicTraits {
+                    if let updatedFont = try? font.asTraits(existingFontTraits) {
+                        self[run.range].font = updatedFont
+                    }
+                } else {
+                    self[run.range].font = font
+                }
+            }
+        }
+    #endif
+
+    mutating func trimWhitespaceAndNewlines() {
+        var startIndex = startIndex
+        while startIndex < endIndex && characters[startIndex].isWhitespaceOrNewline {
+            startIndex = index(afterCharacter: startIndex)
+        }
+
+        var endIndex = endIndex
+        while endIndex > startIndex && characters[index(beforeCharacter: endIndex)].isWhitespaceOrNewline {
+            endIndex = index(beforeCharacter: endIndex)
+        }
+
+        self = AttributedString(self[startIndex..<endIndex])
+    }
+
+    var endsWithNewline: Bool {
+        characters.last?.isNewline == true
+    }
+
+    var string: String {
+        String(characters[...])
+    }
+}
+
+extension Character {
+    var isWhitespaceOrNewline: Bool {
+        isWhitespace || isNewline
+    }
+}

--- a/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
@@ -5,31 +5,31 @@
 //  Created by Łukasz Rutkowski on 06/11/2024.
 //
 
-import Foundation
+#if canImport(UIKit) || canImport(AppKit)
+    import Foundation
 
-#if canImport(UIKit)
-    import UIKit
+    #if canImport(UIKit)
+        import UIKit
 
-    typealias _Font = UIFont
-#elseif canImport(AppKit)
-    import AppKit
+        typealias _Font = UIFont
+    #elseif canImport(AppKit)
+        import AppKit
 
-    typealias _Font = NSFont
-#endif
+        typealias _Font = NSFont
+    #endif
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension AttributedString {
-    mutating func insertInlinePresentationIntent(_ intent: InlinePresentationIntent) {
-        for run in runs {
-            if let intents = run.inlinePresentationIntent {
-                self[run.range].inlinePresentationIntent = intents.union(intent)
-            } else {
-                self[run.range].inlinePresentationIntent = intent
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    extension AttributedString {
+        mutating func insertInlinePresentationIntent(_ intent: InlinePresentationIntent) {
+            for run in runs {
+                if let intents = run.inlinePresentationIntent {
+                    self[run.range].inlinePresentationIntent = intents.union(intent)
+                } else {
+                    self[run.range].inlinePresentationIntent = intent
+                }
             }
         }
-    }
 
-    #if canImport(UIKit) || canImport(AppKit)
         mutating func applyFontKeepingSymbolicTraits(_ font: _Font) {
             for run in runs {
                 if let existingFontTraits = run.font?.fontDescriptor.symbolicTraits {
@@ -41,37 +41,37 @@ extension AttributedString {
                 }
             }
         }
-    #endif
 
-    mutating func trimWhitespaceAndNewlines() {
-        var startIndex = startIndex
-        while startIndex < endIndex && characters[startIndex].isWhitespaceOrNewline {
-            startIndex = index(afterCharacter: startIndex)
+        mutating func trimWhitespaceAndNewlines() {
+            var startIndex = startIndex
+            while startIndex < endIndex && characters[startIndex].isWhitespaceOrNewline {
+                startIndex = index(afterCharacter: startIndex)
+            }
+
+            var endIndex = endIndex
+            while endIndex > startIndex && characters[index(beforeCharacter: endIndex)].isWhitespaceOrNewline {
+                endIndex = index(beforeCharacter: endIndex)
+            }
+
+            self = AttributedString(self[startIndex..<endIndex])
         }
 
-        var endIndex = endIndex
-        while endIndex > startIndex && characters[index(beforeCharacter: endIndex)].isWhitespaceOrNewline {
-            endIndex = index(beforeCharacter: endIndex)
+        var endsWithNewline: Bool {
+            characters.last?.isNewline == true
         }
 
-        self = AttributedString(self[startIndex..<endIndex])
+        var endsWithDoubleNewline: Bool {
+            characters.count >= 2 && characters.suffix(2).allSatisfy(\.isNewline)
+        }
+
+        var string: String {
+            String(characters[...])
+        }
     }
 
-    var endsWithNewline: Bool {
-        characters.last?.isNewline == true
+    extension Character {
+        var isWhitespaceOrNewline: Bool {
+            isWhitespace || isNewline
+        }
     }
-
-    var endsWithDoubleNewline: Bool {
-        characters.count >= 2 && characters.suffix(2).allSatisfy(\.isNewline)
-    }
-
-    var string: String {
-        String(characters[...])
-    }
-}
-
-extension Character {
-    var isWhitespaceOrNewline: Bool {
-        isWhitespace || isNewline
-    }
-}
+#endif

--- a/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
@@ -61,6 +61,10 @@ extension AttributedString {
         characters.last?.isNewline == true
     }
 
+    var endsWithDoubleNewline: Bool {
+        characters.count >= 2 && characters.suffix(2).allSatisfy(\.isNewline)
+    }
+
     var string: String {
         String(characters[...])
     }

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -48,23 +48,16 @@ public class AttributedStringRenderer {
         var attributedString = AttributedString()
 
         for child in element.getChildNodes() {
-            let isBlock = child.isBlockElement
-            if isBlock && !attributedString.endsWithNewline {
+            if child.isBlockElement && child.previousSibling() != nil && !attributedString.endsWithNewline {
+                // Each block element (including ones following inline elements) should start on new line
                 attributedString += "\n"
             }
             attributedString += renderHTMLNode(child)
-            if isBlock && child.nextSibling() != nil {
-                attributedString += "\n"
-            }
         }
 
         switch element.tagName() {
-        case "br", "p":
+        case "br", "p", "pre":
             attributedString += "\n"
-        case "ul", "ol", "pre", "table":
-            if !attributedString.endsWithNewline {
-                attributedString += "\n"
-            }
         case "a":
             applyLink(from: element, to: &attributedString)
         case "em", "i":
@@ -89,6 +82,11 @@ public class AttributedStringRenderer {
 
         default:
             break
+        }
+
+        if element.isBlockElement && !attributedString.endsWithDoubleNewline {
+            // Insert up to 2 new lines after block elements
+            attributedString += "\n"
         }
 
         return attributedString

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -1,0 +1,136 @@
+//
+//  AttributedStringRenderer.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 05/11/2024.
+//
+
+import Foundation
+import SwiftSoup
+import WebURL
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public class AttributedStringRenderer {
+    public static let shared = AttributedStringRenderer()
+
+    public init() {}
+
+    public func render(html: String) -> ParsedContent {
+        guard
+            let document = try? SwiftSoup.parseBodyFragment(html),
+            let body = document.body()
+        else {
+            let plainText = TootHTML.extractAsPlainText(html: html) ?? ""
+            return ParsedContent(rawString: html, plainString: plainText, attributedString: .init(plainText))
+        }
+
+        var attributedString = renderHTMLNode(body)
+        attributedString.trimWhitespaceAndNewlines()
+        return ParsedContent(
+            rawString: html,
+            plainString: attributedString.string,
+            attributedString: attributedString
+        )
+    }
+
+    private func renderHTMLNode(_ node: Node) -> AttributedString {
+        switch node {
+        case let node as TextNode:
+            return AttributedString(node.getWholeText())
+        case let node as Element:
+            return renderHTMLElement(node)
+        default:
+            return ""
+        }
+    }
+
+    private func renderHTMLElement(_ element: Element) -> AttributedString {
+        var attributedString = AttributedString()
+
+        for child in element.getChildNodes() {
+            let isBlock = child.isBlockElement
+            if isBlock && !attributedString.endsWithNewline {
+                attributedString += "\n"
+            }
+            attributedString += renderHTMLNode(child)
+            if isBlock && child.nextSibling() != nil {
+                attributedString += "\n"
+            }
+        }
+
+        switch element.tagName() {
+        case "br", "p":
+            attributedString += "\n"
+        case "ul", "ol", "pre", "table":
+            if !attributedString.endsWithNewline {
+                attributedString += "\n"
+            }
+        case "a":
+            applyLink(from: element, to: &attributedString)
+        case "em", "i":
+            attributedString.insertInlinePresentationIntent(.emphasized)
+        case "strong", "b":
+            attributedString.insertInlinePresentationIntent(.stronglyEmphasized)
+        case "del":
+            attributedString.insertInlinePresentationIntent(.strikethrough)
+        case "li":
+            applyList(from: element, to: &attributedString)
+        case "code":
+            attributedString.insertInlinePresentationIntent(.code)
+
+        #if canImport(UIKit) || canImport(AppKit)
+            case "h1":
+                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title1))
+            case "h2":
+                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title2))
+            case "h3":
+                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title3))
+        #endif
+
+        default:
+            break
+        }
+
+        return attributedString
+    }
+
+    private func applyLink(from element: Element, to attributedString: inout AttributedString) {
+        guard let href = try? element.attr("href") else { return }
+
+        if let webURL = WebURL(href), let url = URL(webURL) {
+            attributedString.link = url
+        } else if let url = URL(string: href) {
+            attributedString.link = url
+        }
+    }
+
+    private func applyList(from element: Element, to attributedString: inout AttributedString) {
+        let level = element.parents().filter({ $0.tagName() == "ul" || $0.tagName() == "ol" }).count
+        guard let parentTag = element.parent()?.tagName() else {
+            return
+        }
+        let bullet: AttributedString
+
+        switch parentTag {
+        case "ol":
+            let index = (try? element.elementSiblingIndex()) ?? 0
+            bullet = AttributedString("\(index + 1).\t")
+        case "ul":
+            bullet = AttributedString("\u{2022}\t")
+        default:
+            bullet = AttributedString()
+        }
+
+        let indent = AttributedString(String(repeating: "\t", count: level - 1))
+        attributedString = indent + bullet + attributedString
+    }
+}
+
+extension Node {
+    var isBlockElement: Bool {
+        guard let element = self as? Element else {
+            return false
+        }
+        return element.isBlock() && element.tagName() != "del"
+    }
+}

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -97,9 +97,9 @@
             guard let href = try? element.attr("href") else { return }
 
             if let webURL = WebURL(href), let url = URL(webURL) {
-                attributedString.link = url
+                attributedString.foundation.link = url
             } else if let url = URL(string: href) {
-                attributedString.link = url
+                attributedString.foundation.link = url
             }
         }
 

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -5,130 +5,132 @@
 //  Created by Łukasz Rutkowski on 05/11/2024.
 //
 
-import Foundation
-import SwiftSoup
-import WebURL
+#if canImport(UIKit) || canImport(AppKit)
+    import Foundation
+    import SwiftSoup
+    import WebURL
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public class AttributedStringRenderer {
-    public static let shared = AttributedStringRenderer()
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public class AttributedStringRenderer {
+        public static let shared = AttributedStringRenderer()
 
-    public init() {}
+        public init() {}
 
-    public func render(html: String) -> ParsedContent {
-        guard
-            let document = try? SwiftSoup.parseBodyFragment(html),
-            let body = document.body()
-        else {
-            let plainText = TootHTML.extractAsPlainText(html: html) ?? ""
-            return ParsedContent(rawString: html, plainString: plainText, attributedString: .init(plainText))
+        public func render(html: String) -> ParsedContent {
+            guard
+                let document = try? SwiftSoup.parseBodyFragment(html),
+                let body = document.body()
+            else {
+                let plainText = TootHTML.extractAsPlainText(html: html) ?? ""
+                return ParsedContent(rawString: html, plainString: plainText, attributedString: .init(plainText))
+            }
+
+            var attributedString = renderHTMLNode(body)
+            attributedString.trimWhitespaceAndNewlines()
+            return ParsedContent(
+                rawString: html,
+                plainString: attributedString.string,
+                attributedString: attributedString
+            )
         }
 
-        var attributedString = renderHTMLNode(body)
-        attributedString.trimWhitespaceAndNewlines()
-        return ParsedContent(
-            rawString: html,
-            plainString: attributedString.string,
-            attributedString: attributedString
-        )
-    }
-
-    private func renderHTMLNode(_ node: Node) -> AttributedString {
-        switch node {
-        case let node as TextNode:
-            return AttributedString(node.getWholeText())
-        case let node as Element:
-            return renderHTMLElement(node)
-        default:
-            return ""
+        private func renderHTMLNode(_ node: Node) -> AttributedString {
+            switch node {
+            case let node as TextNode:
+                return AttributedString(node.getWholeText())
+            case let node as Element:
+                return renderHTMLElement(node)
+            default:
+                return ""
+            }
         }
-    }
 
-    private func renderHTMLElement(_ element: Element) -> AttributedString {
-        var attributedString = AttributedString()
+        private func renderHTMLElement(_ element: Element) -> AttributedString {
+            var attributedString = AttributedString()
 
-        for child in element.getChildNodes() {
-            if child.isBlockElement && child.previousSibling() != nil && !attributedString.endsWithNewline {
-                // Each block element (including ones following inline elements) should start on new line
+            for child in element.getChildNodes() {
+                if child.isBlockElement && child.previousSibling() != nil && !attributedString.endsWithNewline {
+                    // Each block element (including ones following inline elements) should start on new line
+                    attributedString += "\n"
+                }
+                attributedString += renderHTMLNode(child)
+            }
+
+            switch element.tagName() {
+            case "br", "p", "pre":
+                attributedString += "\n"
+            case "a":
+                applyLink(from: element, to: &attributedString)
+            case "em", "i":
+                attributedString.insertInlinePresentationIntent(.emphasized)
+            case "strong", "b":
+                attributedString.insertInlinePresentationIntent(.stronglyEmphasized)
+            case "del":
+                attributedString.insertInlinePresentationIntent(.strikethrough)
+            case "li":
+                applyList(from: element, to: &attributedString)
+            case "code":
+                attributedString.insertInlinePresentationIntent(.code)
+
+            #if canImport(UIKit) || canImport(AppKit)
+                case "h1":
+                    attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title1))
+                case "h2":
+                    attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title2))
+                case "h3":
+                    attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title3))
+            #endif
+
+            default:
+                break
+            }
+
+            if element.isBlockElement && !attributedString.endsWithDoubleNewline {
+                // Insert up to 2 new lines after block elements
                 attributedString += "\n"
             }
-            attributedString += renderHTMLNode(child)
+
+            return attributedString
         }
 
-        switch element.tagName() {
-        case "br", "p", "pre":
-            attributedString += "\n"
-        case "a":
-            applyLink(from: element, to: &attributedString)
-        case "em", "i":
-            attributedString.insertInlinePresentationIntent(.emphasized)
-        case "strong", "b":
-            attributedString.insertInlinePresentationIntent(.stronglyEmphasized)
-        case "del":
-            attributedString.insertInlinePresentationIntent(.strikethrough)
-        case "li":
-            applyList(from: element, to: &attributedString)
-        case "code":
-            attributedString.insertInlinePresentationIntent(.code)
+        private func applyLink(from element: Element, to attributedString: inout AttributedString) {
+            guard let href = try? element.attr("href") else { return }
 
-        #if canImport(UIKit) || canImport(AppKit)
-            case "h1":
-                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title1))
-            case "h2":
-                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title2))
-            case "h3":
-                attributedString.applyFontKeepingSymbolicTraits(.preferredFont(forTextStyle: .title3))
-        #endif
-
-        default:
-            break
+            if let webURL = WebURL(href), let url = URL(webURL) {
+                attributedString.link = url
+            } else if let url = URL(string: href) {
+                attributedString.link = url
+            }
         }
 
-        if element.isBlockElement && !attributedString.endsWithDoubleNewline {
-            // Insert up to 2 new lines after block elements
-            attributedString += "\n"
-        }
+        private func applyList(from element: Element, to attributedString: inout AttributedString) {
+            let level = element.parents().filter({ $0.tagName() == "ul" || $0.tagName() == "ol" }).count
+            guard let parentTag = element.parent()?.tagName() else {
+                return
+            }
+            let bullet: AttributedString
 
-        return attributedString
-    }
+            switch parentTag {
+            case "ol":
+                let index = (try? element.elementSiblingIndex()) ?? 0
+                bullet = AttributedString("\(index + 1).\t")
+            case "ul":
+                bullet = AttributedString("\u{2022}\t")
+            default:
+                bullet = AttributedString()
+            }
 
-    private func applyLink(from element: Element, to attributedString: inout AttributedString) {
-        guard let href = try? element.attr("href") else { return }
-
-        if let webURL = WebURL(href), let url = URL(webURL) {
-            attributedString.link = url
-        } else if let url = URL(string: href) {
-            attributedString.link = url
+            let indent = AttributedString(String(repeating: "\t", count: level - 1))
+            attributedString = indent + bullet + attributedString
         }
     }
 
-    private func applyList(from element: Element, to attributedString: inout AttributedString) {
-        let level = element.parents().filter({ $0.tagName() == "ul" || $0.tagName() == "ol" }).count
-        guard let parentTag = element.parent()?.tagName() else {
-            return
+    extension Node {
+        var isBlockElement: Bool {
+            guard let element = self as? Element else {
+                return false
+            }
+            return element.isBlock() && element.tagName() != "del"
         }
-        let bullet: AttributedString
-
-        switch parentTag {
-        case "ol":
-            let index = (try? element.elementSiblingIndex()) ?? 0
-            bullet = AttributedString("\(index + 1).\t")
-        case "ul":
-            bullet = AttributedString("\u{2022}\t")
-        default:
-            bullet = AttributedString()
-        }
-
-        let indent = AttributedString(String(repeating: "\t", count: level - 1))
-        attributedString = indent + bullet + attributedString
     }
-}
-
-extension Node {
-    var isBlockElement: Bool {
-        guard let element = self as? Element else {
-            return false
-        }
-        return element.isBlock() && element.tagName() != "del"
-    }
-}
+#endif

--- a/Sources/TootSDK/Models/ParsedContent.swift
+++ b/Sources/TootSDK/Models/ParsedContent.swift
@@ -1,0 +1,27 @@
+//
+//  ParsedContent.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 06/11/2024.
+//
+
+import Foundation
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct ParsedContent {
+
+    /// The unprocessed value received from the server.
+    public var rawString: String
+
+    /// A plain text string created by parsing value as HTML and stripping any formatting.
+    public var plainString: String
+
+    /// An attributed text string created by parsing value as HTML,
+    public var attributedString: AttributedString
+
+    public init(rawString: String, plainString: String, attributedString: AttributedString) {
+        self.rawString = rawString
+        self.plainString = plainString
+        self.attributedString = attributedString
+    }
+}

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -5,82 +5,84 @@
 //  Created by Łukasz Rutkowski on 06/11/2024.
 //
 
-import Foundation
-import Testing
-import TootSDK
+#if canImport(UIKit) || canImport(AppKit)
+    import Foundation
+    import Testing
+    import TootSDK
 
-@Suite struct AttributedStringRendererTests {
+    @Suite struct AttributedStringRendererTests {
 
-    @Test func testRendersPostWithoutEmojis() async throws {
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
-        let post = try localObject(Post.self, "post no emojis")
-        let plainString = """
-            Hey fellow #Swift devs 👋!
+        @Test func testRendersPostWithoutEmojis() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let post = try localObject(Post.self, "post no emojis")
+            let plainString = """
+                Hey fellow #Swift devs 👋!
 
-            As some of you may know, @konstantin and @davidgarywood have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
-
-            The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
-            """
-        let attributedString = try AttributedString(
-            markdown: """
-                Hey fellow [#Swift](https://iosdev.space/tags/Swift) devs 👋!
-
-                As some of you may know, [@konstantin](https://m.iamkonstantin.eu/users/konstantin) and [@davidgarywood](https://social.davidgarywood.com/@davidgarywood) have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
+                As some of you may know, @konstantin and @davidgarywood have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
 
                 The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
-                """,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )
+                """
+            let attributedString = try AttributedString(
+                markdown: """
+                    Hey fellow [#Swift](https://iosdev.space/tags/Swift) devs 👋!
 
-        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+                    As some of you may know, [@konstantin](https://m.iamkonstantin.eu/users/konstantin) and [@davidgarywood](https://social.davidgarywood.com/@davidgarywood) have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
 
-        #expect(rendered.rawString == post.content)
-        #expect(rendered.plainString == plainString)
-        #expect(rendered.attributedString == attributedString)
+                    The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
+                    """,
+                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+            )
+
+            let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+            #expect(rendered.rawString == post.content)
+            #expect(rendered.plainString == plainString)
+            #expect(rendered.attributedString == attributedString)
+        }
+
+        @Test func testRendersPostWithEmojis() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let post = try localObject(Post.self, "post with emojis and attachments")
+            let plainString = """
+                I just #love #coffee :heart_cup:  There is no better way to start the day.
+                """
+            let attributedString = try AttributedString(
+                markdown: """
+                    I just [#love](https://m.iamkonstantin.eu/tag/love) [#coffee](https://m.iamkonstantin.eu/tag/coffee) :heart_cup:  There is no better way to start the day.
+                    """,
+                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+            )
+
+            let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+            #expect(rendered.rawString == post.content)
+            #expect(rendered.plainString == plainString)
+            #expect(rendered.attributedString == attributedString)
+        }
+
+        @Test func testParagraphsToLineBreaks() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let post = try localObject(Post.self, "post wordle linebreaks")
+            let plainString = """
+                Wordle 591 X/6*
+
+                🟨⬛🟩🟨⬛
+                🟨⬛🟩⬛🟩
+                🟩🟩🟩⬛🟩
+                🟩🟩🟩⬛🟩
+                🟩🟩🟩⬛🟩
+                🟩🟩🟩⬛🟩
+                """
+            let attributedString = try AttributedString(
+                markdown: plainString,
+                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+            )
+
+            let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+            #expect(rendered.rawString == post.content)
+            #expect(rendered.plainString == plainString)
+            #expect(rendered.attributedString == attributedString)
+        }
     }
-
-    @Test func testRendersPostWithEmojis() async throws {
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
-        let post = try localObject(Post.self, "post with emojis and attachments")
-        let plainString = """
-            I just #love #coffee :heart_cup:  There is no better way to start the day.
-            """
-        let attributedString = try AttributedString(
-            markdown: """
-                I just [#love](https://m.iamkonstantin.eu/tag/love) [#coffee](https://m.iamkonstantin.eu/tag/coffee) :heart_cup:  There is no better way to start the day.
-                """,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )
-
-        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
-
-        #expect(rendered.rawString == post.content)
-        #expect(rendered.plainString == plainString)
-        #expect(rendered.attributedString == attributedString)
-    }
-
-    @Test func testParagraphsToLineBreaks() async throws {
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
-        let post = try localObject(Post.self, "post wordle linebreaks")
-        let plainString = """
-            Wordle 591 X/6*
-
-            🟨⬛🟩🟨⬛
-            🟨⬛🟩⬛🟩
-            🟩🟩🟩⬛🟩
-            🟩🟩🟩⬛🟩
-            🟩🟩🟩⬛🟩
-            🟩🟩🟩⬛🟩
-            """
-        let attributedString = try AttributedString(
-            markdown: plainString,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )
-
-        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
-
-        #expect(rendered.rawString == post.content)
-        #expect(rendered.plainString == plainString)
-        #expect(rendered.attributedString == attributedString)
-    }
-}
+#endif

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -1,0 +1,86 @@
+//
+//  Test.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 06/11/2024.
+//
+
+import Foundation
+import Testing
+import TootSDK
+
+@Suite struct AttributedStringRendererTests {
+
+    @Test func testRendersPostWithoutEmojis() async throws {
+        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+        let post = try localObject(Post.self, "post no emojis")
+        let plainString = """
+            Hey fellow #Swift devs 👋!
+
+            As some of you may know, @konstantin and @davidgarywood have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
+
+            The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
+            """
+        let attributedString = try AttributedString(
+            markdown: """
+                Hey fellow [#Swift](https://iosdev.space/tags/Swift) devs 👋!
+
+                As some of you may know, [@konstantin](https://m.iamkonstantin.eu/users/konstantin) and [@davidgarywood](https://social.davidgarywood.com/@davidgarywood) have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
+
+                The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
+                """,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+
+        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+        #expect(rendered.rawString == post.content)
+        #expect(rendered.plainString == plainString)
+        #expect(rendered.attributedString == attributedString)
+    }
+
+    @Test func testRendersPostWithEmojis() async throws {
+        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+        let post = try localObject(Post.self, "post with emojis and attachments")
+        let plainString = """
+            I just #love #coffee :heart_cup:  There is no better way to start the day.
+            """
+        let attributedString = try AttributedString(
+            markdown: """
+                I just [#love](https://m.iamkonstantin.eu/tag/love) [#coffee](https://m.iamkonstantin.eu/tag/coffee) :heart_cup:  There is no better way to start the day.
+                """,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+
+        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+        #expect(rendered.rawString == post.content)
+        #expect(rendered.plainString == plainString)
+        #expect(rendered.attributedString == attributedString)
+    }
+
+    @Test func testParagraphsToLineBreaks() async throws {
+        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+        let post = try localObject(Post.self, "post wordle linebreaks")
+        let plainString = """
+            Wordle 591 X/6*
+
+            🟨⬛🟩🟨⬛
+            🟨⬛🟩⬛🟩
+            🟩🟩🟩⬛🟩
+            🟩🟩🟩⬛🟩
+            🟩🟩🟩⬛🟩
+            🟩🟩🟩⬛🟩
+            """
+        let attributedString = try AttributedString(
+            markdown: plainString,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+
+        let rendered = AttributedStringRenderer().render(html: post.content ?? "")
+
+        #expect(rendered.rawString == post.content)
+        #expect(rendered.plainString == plainString)
+        #expect(rendered.attributedString == attributedString)
+    }
+}

--- a/Tests/TootSDKTests/Helpers/XCTestCase+LocalContent.swift
+++ b/Tests/TootSDKTests/Helpers/XCTestCase+LocalContent.swift
@@ -10,7 +10,6 @@ import XCTest
 
 @testable import TootSDK
 
-//extension XCTestCase {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 func URLForResource(fileName: String, withExtension: String) -> URL {
     return Bundle.module.url(forResource: fileName, withExtension: withExtension)!
@@ -26,4 +25,3 @@ func localObject<T>(_ type: T.Type, _ filename: String) throws -> T where T: Dec
     let decoder = TootDecoder()
     return try decoder.decode(type, from: json)
 }
-//}

--- a/Tests/TootSDKTests/Helpers/XCTestCase+LocalContent.swift
+++ b/Tests/TootSDKTests/Helpers/XCTestCase+LocalContent.swift
@@ -10,20 +10,20 @@ import XCTest
 
 @testable import TootSDK
 
-extension XCTestCase {
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    func URLForResource(fileName: String, withExtension: String) -> URL {
-        return Bundle.module.url(forResource: fileName, withExtension: withExtension)!
-    }
-
-    func localContent(_ fileName: String, _ fileExtension: String = "json") -> Data {
-        let url = URLForResource(fileName: fileName, withExtension: fileExtension)
-        return try! Data.init(contentsOf: url)
-    }
-
-    func localObject<T>(_ type: T.Type, _ filename: String) throws -> T where T: Decodable {
-        let json = localContent(filename)
-        let decoder = TootDecoder()
-        return try decoder.decode(type, from: json)
-    }
+//extension XCTestCase {
+// swift-format-ignore: AlwaysUseLowerCamelCase
+func URLForResource(fileName: String, withExtension: String) -> URL {
+    return Bundle.module.url(forResource: fileName, withExtension: withExtension)!
 }
+
+func localContent(_ fileName: String, _ fileExtension: String = "json") -> Data {
+    let url = URLForResource(fileName: fileName, withExtension: fileExtension)
+    return try! Data.init(contentsOf: url)
+}
+
+func localObject<T>(_ type: T.Type, _ filename: String) throws -> T where T: Decodable {
+    let json = localContent(filename)
+    let decoder = TootDecoder()
+    return try decoder.decode(type, from: json)
+}
+//}


### PR DESCRIPTION
This is a replacement renderer for `UIKitAttribStringRenderer` and `AppKitAttribStringRenderer` that uses newer `AttributedString` API. 

Changes from old renderers:
- Fixed bold and italic styles
- Added styling of headings
- Improved how new lines are added between paragraphs and inline elements
- Plain string now has consistent new lines with attributed string
- Nested lists have increased indent
- Emojis are ignored for now

This is an initial version that should be good for most of the cases. I'm looking for feedback if anyone decides to use it and encounters posts that would render incorrectly.

Here is an example of a [markdown formatted post](https://poa.st/@pipilo/posts/Ano93ccHOUVMJPq0h6) from pleroma as it appears in my app using this renderer:
![Screenshot 2024-11-07 at 19 12 34](https://github.com/user-attachments/assets/3339463a-f682-4b58-ae0a-e4525740a2ac)
