### PR TITLE
Fix configuration.urls not working with the Instance v2 API

### DIFF
--- a/Sources/TootSDK/Models/Instance/Instance.swift
+++ b/Sources/TootSDK/Models/Instance/Instance.swift
@@ -27,7 +27,8 @@ public protocol Instance: Codable, Hashable, Sendable {
     /// Primary languages of the website and its staff as ISO 639-1 two-letter codes.
     var languages: [String]? { get }
 
-    var urls: InstanceConfiguration.URLs? { get }
+    /// Websocket URL for connecting to the streaming API.
+    var streamingURL: String? { get }
 
     /// Whether registrations are enabled.
     var registrationsEnabled: Bool? { get }

--- a/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
@@ -1,7 +1,7 @@
 public struct InstanceConfiguration: Codable, Hashable, Sendable {
     /// URLs of interest for client apps.
     ///
-    /// Only populated by v2 instance API. See ``InstanceV1/urls`` for the same values from the v1 API.
+    /// Only populated by v2 instance API. See ``InstanceV1/InstanceURLs`` for the same values from the v1 API.
     public var urls: URLs?
     /// The instance's VAPID configuration.
     ///
@@ -31,8 +31,11 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
     }
 
     public struct URLs: Codable, Hashable, Sendable {
-        /// Websockets address for push streaming. String (URL).
-        public var streamingApi: String?
+        /// Websockets address for the streaming API. String (URL).
+        public var streaming: String?
+
+        /// The server status page. String (URL).
+        public var status: String?
     }
 
     public struct Accounts: Codable, Hashable, Sendable {

--- a/Sources/TootSDK/Models/Instance/InstanceV1.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceV1.swift
@@ -75,7 +75,11 @@ public struct InstanceV1: Codable, Hashable {
     public var rules: [InstanceRule]?
 
     public typealias Configuration = InstanceConfiguration
-    public typealias InstanceURLs = InstanceConfiguration.URLs
+
+    public struct InstanceURLs: Codable, Hashable, Sendable {
+        /// Websockets address for push streaming. String (URL).
+        public var streamingApi: String?
+    }
 
     public struct Stats: Codable, Hashable, Sendable {
         /// Users registered on this instance. Number.
@@ -150,6 +154,7 @@ extension InstanceV1: Instance {
     public var domain: String? { uri }
     public var thumbnailURL: String? { thumbnail }
     public var registrationsEnabled: Bool? { registrations }
+    public var streamingURL: String? { urls?.streamingApi }
 }
 
 extension InstanceV1 {
@@ -172,10 +177,10 @@ extension InstanceV1 {
         var v2Configuration: InstanceConfiguration?
         if let configuration {
             var config = configuration
-            config.urls = self.urls
+            config.urls = .init(streaming: self.urls?.streamingApi)
             v2Configuration = config
         } else if let urls {
-            v2Configuration = .init(urls: urls)
+            v2Configuration = .init(urls: .init(streaming: self.urls?.streamingApi))
         } else {
             v2Configuration = nil
         }

--- a/Sources/TootSDK/Models/Instance/InstanceV2.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceV2.swift
@@ -191,7 +191,7 @@ public struct InstanceV2: Codable, Hashable, Sendable {
 
 extension InstanceV2: Instance {
     public var thumbnailURL: String? { thumbnail?.url }
-    public var urls: InstanceConfiguration.URLs? { configuration?.urls }
+    public var streamingURL: String? { configuration?.urls?.streaming }
     public var registrationsEnabled: Bool? { registrations.enabled }
     public var approvalRequired: Bool? { registrations.approvalRequired }
     public var email: String? { contact?.email }

--- a/Sources/TootSDK/TootClient/TootClient+Streaming.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Streaming.swift
@@ -136,7 +136,7 @@ extension TootClient {
         try requireFeature(.streaming)
 
         // get streaming endpoint URL from instance info
-        async let streamingEndpoint = getInstanceInfo().urls?.streamingApi
+        async let streamingEndpoint = getInstanceInfo().streamingURL
         async let streamingHealthy = getStreamingHealth()
 
         guard let streamingEndpoint = try await streamingEndpoint,


### PR DESCRIPTION
Somehow I missed that the instance v2 API uses a different property name for the streaming URL. The result was that you couldn’t start streaming if TootSDK used v2 to get the instance info. This fixes that by using a separate type for the URLs struct for v1 and v2. That means this fix is a breaking change.

For consistency, I also replaced the `Instance` protocol’s `urls` property with a `streamingURL` property that returns the appropriate value from either version, and in v2 I added Mastodon's undocumented `status` property that returns the URL of the server status page.