### PR TITLE
[BREAKING] Add support for Xcode 16, it is no longer possible to run tests on Xcode 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -12,7 +12,7 @@ jobs:
   buildtools:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adopts the `macos-15` build image which comes preinstalled with Xcode 16.0.
This will enable tests to be written using the new Swift Testing framework and addresses the build errors from #323 