### PR TITLE
Fix broken pagination if links share the same parameter names

### DIFF
--- a/Sources/TootSDK/HTTP/PagedResult.swift
+++ b/Sources/TootSDK/HTTP/PagedResult.swift
@@ -5,36 +5,22 @@ import Foundation
 
 public struct PagedResult<T: Decodable>: Decodable {
     public let result: T
-    public let info: PagedInfo
+
+    /// Returns pagination object for the next page of results if one is available. A next page contains results newer than the current page.
+    public let nextPage: PagedInfo?
+
+    /// Returns pagination object for the previous page of results if one is available.  A previous page contains results older than the current page.
+    public let previousPage: PagedInfo?
 }
 
 extension PagedResult {
     /// Returns `true` if the paged result has a next page of results. A next page contains results newer than the current page.
     public var hasNext: Bool {
-        info.sinceId != nil || info.minId != nil
+        nextPage != nil
     }
 
-    /// Returns `true` if the paged result has a previous page of results. A next page contains results older than the current page.
+    /// Returns `true` if the paged result has a previous page of results. A previous page contains results older than the current page.
     public var hasPrevious: Bool {
-        info.maxId != nil
-    }
-
-    /// Returns pagination object for the next page of results if one is available
-    public var nextPage: PagedInfo? {
-        if let sinceId = info.sinceId {
-            return PagedInfo(sinceId: sinceId)
-        }
-        if let minId = info.minId {
-            return PagedInfo(minId: minId)
-        }
-        return nil
-    }
-
-    /// Returns pagination object for the previous page of results if one is available
-    public var previousPage: PagedInfo? {
-        if let maxId = info.maxId {
-            return PagedInfo(maxId: maxId)
-        }
-        return nil
+        previousPage != nil
     }
 }

--- a/Sources/TootSDK/HTTP/PagedResult.swift
+++ b/Sources/TootSDK/HTTP/PagedResult.swift
@@ -5,6 +5,7 @@ import Foundation
 
 public struct PagedResult<T: Decodable>: Decodable {
     public let result: T
+    public let info: PagedInfo
 
     /// Returns pagination object for the next page of results if one is available. A next page contains results newer than the current page.
     public let nextPage: PagedInfo?

--- a/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
+++ b/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
@@ -81,17 +81,7 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-        let (data, response) = try await fetch(req: req)
-        let decoded = try decode([String].self, from: data)
-        var pagination: Pagination?
-
-        if let links = response.value(forHTTPHeaderField: "Link") {
-            pagination = Pagination(links: links)
-        }
-
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        return try await fetchPagedResult(req)
     }
 
     /// Blocks a domain on the current instance.

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -269,7 +269,6 @@ extension TootClient {
     ///   - req: the HTTP request to execute
     /// - Returns: the fetched paged array and page info
     internal func fetchPagedResult<T: Decodable>(_ req: HTTPRequestBuilder) async throws -> PagedResult<[T]> {
-
         let (data, response) = try await fetch(req: req)
         let decoded = try decode([T].self, from: data)
         var pagination: Pagination?
@@ -278,9 +277,7 @@ extension TootClient {
             pagination = Pagination(links: links)
         }
 
-        let info = PagedInfo(maxId: pagination?.maxId, minId: pagination?.minId, sinceId: pagination?.sinceId)
-
-        return PagedResult(result: decoded, info: info)
+        return PagedResult(result: decoded, nextPage: pagination?.prev, previousPage: pagination?.next)
     }
 
 }

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -277,7 +277,12 @@ extension TootClient {
             pagination = Pagination(links: links)
         }
 
-        return PagedResult(result: decoded, nextPage: pagination?.prev, previousPage: pagination?.next)
+        // Pagination in TootSDK is opposite to pagination in Mastodon
+        let nextPage = pagination?.prev
+        let previousPage = pagination?.next
+        let info = PagedInfo(maxId: previousPage?.maxId, minId: nextPage?.minId, sinceId: nextPage?.sinceId)
+
+        return PagedResult(result: decoded, info: info, nextPage: nextPage, previousPage: previousPage)
     }
 
 }

--- a/Sources/TootSDK/TootStream/TootStream+Posts.swift
+++ b/Sources/TootSDK/TootStream/TootStream+Posts.swift
@@ -29,7 +29,7 @@ extension TootDataStream {
                 newHolder?.internalContinuation?.yield(items.result)
 
                 // Update `PagedInfo` only if a new `minId` is available.
-                if let minId = items.nextPage?.minId {
+                if let minId = items.info.minId {
                     newHolder?.pageInfo = PagedInfo(minId: minId)
                 }
             }

--- a/Sources/TootSDK/TootStream/TootStream+Posts.swift
+++ b/Sources/TootSDK/TootStream/TootStream+Posts.swift
@@ -29,7 +29,7 @@ extension TootDataStream {
                 newHolder?.internalContinuation?.yield(items.result)
 
                 // Update `PagedInfo` only if a new `minId` is available.
-                if let minId = items.info.minId {
+                if let minId = items.nextPage?.minId {
                     newHolder?.pageInfo = PagedInfo(minId: minId)
                 }
             }


### PR DESCRIPTION
Closes #326 

Fixes incorrect pagination identifiers if there are duplicate parameters in next and prev links.

For compatibility `info` in `PagedResult` is filled with assumption that ids will be in specific places, and `nextPage` with `previousPage` are initialized as inverted variants of next/prev links.