### PR TITLE
Get account preferences and gif autoplay setting

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/GetPreferences.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/GetPreferences.swift
@@ -1,0 +1,19 @@
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct GetPreferences: AsyncParsableCommand {
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    mutating func run() async throws {
+        print("Getting account preferences")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        let preferences = try await client.getPreferences()
+        print(preferences)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -48,6 +48,7 @@ struct SwiftyAdmin: AsyncParsableCommand {
             CreateFilter.self,
             UpdateFilter.self,
             GetNodeInfo.self,
+            GetPreferences.self,
             StreamEvents.self,
         ])
 }

--- a/Sources/TootSDK/Models/Preferences.swift
+++ b/Sources/TootSDK/Models/Preferences.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// Represents a user's preferences.
-public struct Preferences: Codable, Hashable {
+public struct Preferences: Codable, Hashable, Sendable {
     /// Default visibility for new posts. Equivalent to Source#privacy.
     public var postingDefaultVisibility: Post.Visibility
     /// Default sensitivity flag for new posts. Equivalent to Source#sensitive.
@@ -27,7 +27,7 @@ public struct Preferences: Codable, Hashable {
         case readingAutoplayGifs = "reading:autoplay:gifs"
     }
 
-    public enum ExpandMedia: String, Codable {
+    public enum ExpandMedia: String, Codable, Sendable {
         /// Hide media marked as sensitive
         case `default`
         /// Always show all media by default, regardless of sensitivity

--- a/Sources/TootSDK/Models/Preferences.swift
+++ b/Sources/TootSDK/Models/Preferences.swift
@@ -15,6 +15,8 @@ public struct Preferences: Codable, Hashable {
     public var readingExpandMedia: ExpandMedia
     /// Whether CWs should be expanded by default.
     public var readingExpandSpoilers: Bool
+    /// Whether to automatically play animated GIFs.
+    public var readingAutoplayGifs: Bool?
 
     enum CodingKeys: String, CodingKey {
         case postingDefaultVisibility = "posting:default:visibility"
@@ -22,6 +24,7 @@ public struct Preferences: Codable, Hashable {
         case postingDefaultLanguage = "posting:default:language"
         case readingExpandMedia = "reading:expand:media"
         case readingExpandSpoilers = "reading:expand:spoilers"
+        case readingAutoplayGifs = "reading:autoplay:gifs"
     }
 
     public enum ExpandMedia: String, Codable {

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -113,6 +113,15 @@ extension TootClient {
         return try await fetch(Account.self, req)
     }
 
+    /// Get preferences defined by the user in their account settings.
+    public func getPreferences() async throws -> Preferences {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "preferences"])
+            $0.method = .get
+        }
+        return try await fetch(Preferences.self, req)
+    }
+
     func getFieldParts(_ params: UpdateCredentialsParams) -> [MultipartPart] {
         var parts = [MultipartPart]()
         if let fields = params.fieldsAttributes {


### PR DESCRIPTION
1. Added Mastodon’s “autoplay gifs” setting to `Preferences` (see mastodon/mastodon#22706 - there’s currently only a way to read this setting but not write it, so its usefulness for clients is questionable, but it still seems important to include since it’s accessibility-related)
2. Added a TootClient method to get the Preferences (I didn’t see an existing method for this)
3. Added `get-preferences` subcommand to swiftyadmin for testing this functionality.