### PR TITLE
Add methods to get privacy policy and terms of service for an instance

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetPrivacyPolicy.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetPrivacyPolicy.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct GetInstancePrivacyPolicy: AsyncParsableCommand {
+
+    @Option(name: .shortAndLong, help: "URL to the instance to connect to")
+    var url: String
+
+    mutating func run() async throws {
+        let client = TootClient(instanceURL: URL(string: url)!)
+        try await client.connect()
+        let instance = try await client.getPrivacyPolicy()
+        print(instance)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetTermsOfService.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetTermsOfService.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct GetInstanceTermsOfService: AsyncParsableCommand {
+
+    @Option(name: .shortAndLong, help: "URL to the instance to connect to")
+    var url: String
+
+    mutating func run() async throws {
+        let client = TootClient(instanceURL: URL(string: url)!)
+        try await client.connect()
+        let instance = try await client.getTermsOfService()
+        print(instance)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -36,6 +36,8 @@ struct SwiftyAdmin: AsyncParsableCommand {
             GetPostContext.self,
             GetConversations.self,
             GetInstance.self,
+            GetInstancePrivacyPolicy.self,
+            GetInstanceTermsOfService.self,
             GetMarkers.self,
             UpdateMarkers.self,
             GetPendingFollowRequests.self,

--- a/Sources/TootSDK/Models/PrivacyPolicy.swift
+++ b/Sources/TootSDK/Models/PrivacyPolicy.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// The privacy policy or terms of service of an instance.
+public struct PrivacyPolicy: Codable, Hashable, Sendable {
+
+    /// A timestamp of when the policy was last updated.
+    /// Note: this is not optional in the Mastodon spec but in practice sometimes null
+    public var updatedAt: Date?
+
+    /// The rendered HTML content of the privacy policy.
+    public var content: String
+
+    public init(updatedAt: Date? = nil, content: String = "") {
+        self.updatedAt = updatedAt
+        self.content = content
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -62,6 +62,28 @@ extension TootClient {
         return try await fetch(ExtendedDescription.self, req)
     }
 
+    /// Obtain the content of this server's privacy policy.
+    /// - Returns: A ``PrivacyPolicy`` instance containing the content of the privacy policy.
+    public func getPrivacyPolicy() async throws -> PrivacyPolicy {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "privacy_policy"])
+            $0.method = .get
+        }
+        return try await fetch(PrivacyPolicy.self, req)
+    }
+
+    /// Obtain the content of this server's terms of service, if configured.
+    /// - Returns: A ``PrivacyPolicy`` instance representing the terms of service.
+    ///
+    /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
+    public func getTermsOfService() async throws -> PrivacyPolicy {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "terms_of_service"])
+            $0.method = .get
+        }
+        return try await fetch(PrivacyPolicy.self, req)
+    }
+
     /// Translation language pairs supported by the translation engine used by the server.
     public func getTranslationLanguages() async throws -> [String: [String]] {
         try requireFeature(.translatePost)


### PR DESCRIPTION
The `PrivacyPolicy` struct here is identical to `ExtendedDescription`, but Mastodon defines it as a separate entity type, so this PR follows that.

PrivacyPolicy was added to Mastodon in 4.0.0 but not documented at the time; TermsOfService is upcoming in 4.4.0 but theoretically already supported on mastodon.social, although they haven’t set their terms yet so it currently returns `404`.