### PR TITLE
Add `reason` parameter to `TootSDKError.invalidParameter`

### DIFF
--- a/Sources/TootSDK/Models/ScheduledPostRequest.swift
+++ b/Sources/TootSDK/Models/ScheduledPostRequest.swift
@@ -55,7 +55,10 @@ extension ScheduledPostRequest {
         if scheduledAtDate < Date().addingTimeInterval(TimeInterval(5.0 * 60.0)) {
             // scheduled_at must be at least 5 mins into the future
             // https://github.com/mastodon/mastodon/pull/9706
-            throw TootSDKError.invalidParameter(parameterName: "scheduledAt")
+            throw TootSDKError.invalidParameter(
+                parameterName: "scheduledAt",
+                reason: "The scheduled date must be at least 5 minutes into the future."
+            )
         }
 
         self = ScheduledPostRequest(

--- a/Sources/TootSDK/Models/TootSDKError.swift
+++ b/Sources/TootSDK/Models/TootSDKError.swift
@@ -14,7 +14,7 @@ public enum TootSDKError: Error, LocalizedError, Equatable {
     case invalidStatusCode(data: Data, response: HTTPURLResponse)
     case requiredURLNotSet
     case missingParameter(parameterName: String)
-    case invalidParameter(parameterName: String)
+    case invalidParameter(parameterName: String, reason: String)
     /// The requested operation is not supported by the current server flavour.
     case unsupportedFlavour(current: TootSDKFlavour, required: Set<TootSDKFlavour>)
     case unexpectedError(_ description: String)

--- a/Sources/TootSDK/TootClient/TootClient+Reports.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Reports.swift
@@ -35,7 +35,10 @@ extension TootClient {
 
     private func pixelfedReport(_ params: ReportParams) async throws {
         guard ReportCategory.pixelfedSupported.contains(params.category) else {
-            throw TootSDKError.invalidParameter(parameterName: "category")
+            throw TootSDKError.invalidParameter(
+                parameterName: "category",
+                reason: "Unsupported category."
+            )
         }
         let postId = params.postIds.first
         let pixelfedParams = PixelfedReportParams(

--- a/Tests/TootSDKTests/ScheduledPostTests.swift
+++ b/Tests/TootSDKTests/ScheduledPostTests.swift
@@ -23,7 +23,7 @@ final class ScheduledPostTests: XCTestCase {
 
         // act
         XCTAssertThrowsError(try ScheduledPostRequest(from: params)) { error in
-            XCTAssertEqual(error as? TootSDKError, TootSDKError.invalidParameter(parameterName: "scheduledAt"))
+            XCTAssertEqual(error as? TootSDKError, TootSDKError.invalidParameter(parameterName: "scheduledAt", reason: "The scheduled date must be at least 5 minutes into the future."))
         }
     }
 


### PR DESCRIPTION
Fixes #334 

As [discussed on the 'don](https://toot.iamkonstantin.eu/@konstantin/113996972469397165), hope that helps!