### PR TITLE
Decode dates formatted as unix timestamp

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,6 +78,7 @@ let package = Package(
                 .copy("Resources/instancev2_pixelfed.json"),
                 .copy("Resources/instancev2_pleroma.json"),
                 .copy("Resources/list.json"),
+                .copy("Resources/markers_unix_timestamp.json"),
                 .copy("Resources/post_edited.json"),
                 .copy("Resources/post no emojis.json"),
                 .copy("Resources/post with emojis and attachments.json"),

--- a/Sources/TootSDK/HTTP/Decoder.swift
+++ b/Sources/TootSDK/HTTP/Decoder.swift
@@ -12,10 +12,7 @@ public final class TootDecoder: JSONDecoder, @unchecked Sendable {
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            guard
-                let date = Self.dateFormatter.date(from: dateString) ?? Self.dateFormatterWithoutFractionalSeconds.date(from: dateString)
-                    ?? Self.dateFormatterWithFullDate.date(from: dateString)
-            else {
+            guard let date = Self.decodeDate(dateString) else {
                 throw DecodingError.dataCorruptedError(
                     in: container,
                     debugDescription:
@@ -45,4 +42,21 @@ extension TootDecoder {
         dateFormatter.formatOptions = [.withFullDate]
         return dateFormatter
     }()
+
+    private static func decodeDate(_ dateString: String) -> Date? {
+        let dateFromString =
+            Self.dateFormatter.date(from: dateString)
+            ?? Self.dateFormatterWithoutFractionalSeconds.date(from: dateString)
+            ?? Self.dateFormatterWithFullDate.date(from: dateString)
+
+        if let dateFromString {
+            return dateFromString
+        }
+
+        if let seconds = TimeInterval(dateString) {
+            return Date(timeIntervalSince1970: seconds)
+        }
+
+        return nil
+    }
 }

--- a/Tests/TootSDKTests/MarkerTests.swift
+++ b/Tests/TootSDKTests/MarkerTests.swift
@@ -1,0 +1,29 @@
+//
+//  Test.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 23/02/2025.
+//
+
+import Foundation
+import Testing
+
+@testable import TootSDK
+
+@Suite struct MarkerTests {
+    @Test func decodeMarkerWithUnixTimestamp() async throws {
+        let json = localContent("markers_unix_timestamp")
+        let decoder = TootDecoder()
+
+        let result = try decoder.decode([Marker.Timeline: Marker].self, from: json)
+        #expect(
+            result == [
+                .notifications: Marker(
+                    lastReadId: "1736969839000000",
+                    updatedAt: Date(timeIntervalSince1970: 1740308876.000000),
+                    version: 0
+                )
+            ]
+        )
+    }
+}

--- a/Tests/TootSDKTests/Resources/markers_unix_timestamp.json
+++ b/Tests/TootSDKTests/Resources/markers_unix_timestamp.json
@@ -1,0 +1,7 @@
+{
+  "notifications" : {
+    "version" : 0,
+    "updated_at" : "1740308876.000000",
+    "last_read_id" : "1736969839000000"
+  }
+}


### PR DESCRIPTION
This is a fix for instances on https://gblog4.popolon.org/snac/, which appears to be formatting marker update dates as unix timestamp.