### PR TITLE
Fix `ExpandMedia` expecting camel case when the Mastodon API returns snake case

### DIFF
--- a/Sources/TootSDK/Models/Preferences.swift
+++ b/Sources/TootSDK/Models/Preferences.swift
@@ -31,8 +31,8 @@ public struct Preferences: Codable, Hashable, Sendable {
         /// Hide media marked as sensitive
         case `default`
         /// Always show all media by default, regardless of sensitivity
-        case showAll
+		case showAll = "show_all"
         /// Always hide all media by default, regardless of sensitivity
-        case hideAll
+        case hideAll = "hide_all"
     }
 }

--- a/Sources/TootSDK/Models/Preferences.swift
+++ b/Sources/TootSDK/Models/Preferences.swift
@@ -31,7 +31,7 @@ public struct Preferences: Codable, Hashable, Sendable {
         /// Hide media marked as sensitive
         case `default`
         /// Always show all media by default, regardless of sensitivity
-		case showAll = "show_all"
+        case showAll = "show_all"
         /// Always hide all media by default, regardless of sensitivity
         case hideAll = "hide_all"
     }


### PR DESCRIPTION
Previously, calling `TootClient.getPreferences()` would throw an error if the user had their Mastodon media setting set to “show all” or “hide all”. The API returns the strings `hide_all` or `show_all`, but TootSDK expected `hideAll` or `showAll`