### PR TITLE
Add “blur” filter action

### DIFF
--- a/Sources/TootSDK/Models/Filter.swift
+++ b/Sources/TootSDK/Models/Filter.swift
@@ -22,6 +22,8 @@ public struct Filter: Codable, Hashable, Identifiable {
         case warn
         /// do not show this post if it is received
         case hide
+        /// hide/blur media attachments with a warning identifying the matching filter by ``Filter/title``
+        case blur
     }
 
     /// The ID of the Filter in the database.


### PR DESCRIPTION
This was added in Mastodon 4.4.0 (Mastodon API version 5); see Mastodon/Mastodon#34256

Pending a solution for #343, clients must update ASAP with this fix to avoid errors when making a wide range of API calls if the user has set up any filters with the new option on Mastodon servers running nightlies (e.g. mastodon.social).