### PR TITLE
Support Mastodon Instance additions

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/RegisterAccount.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/RegisterAccount.swift
@@ -19,6 +19,12 @@ struct RegisterAccount: AsyncParsableCommand {
     @Option(name: .short, help: "Password")
     var password: String
 
+    @Option(name: .short, help: "Reason")
+    var reason: String?
+
+    @Option(name: .short, help: "Date of Birth (YYYY-MM-DD)")
+    var dateOfBirth: String?
+
     mutating func run() async throws {
         guard let registerToken = try await login() else {
             return
@@ -33,10 +39,18 @@ struct RegisterAccount: AsyncParsableCommand {
             return
         }
 
+        if instance.v2Representation().registrations.reasonRequired == true && (reason == nil || reason!.isEmpty) {
+            print("Registration requires a reason, please provide one")
+        }
+
+        if instance.v2Representation().registrations.minAge != nil && dateOfBirth == nil {
+            print("Registration requires date of birth (YYYY-MM-DD)")
+        }
+
         print("register account")
         client.debugOn()
         let params = RegisterAccountParams(
-            username: name, email: email, password: password, agreement: true, locale: "en")
+            username: name, email: email, password: password, agreement: true, locale: "en", reason: reason, dateOfBirth: dateOfBirth)
         let token = try await client.registerAccount(params: params)
         print("Registration success, access token: (\(token.accessToken ?? "nil"))")
     }

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetLanguages.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetLanguages.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct GetInstanceLanguages: AsyncParsableCommand {
+
+    @Option(name: .shortAndLong, help: "URL to the instance to connect to")
+    var url: String
+
+    mutating func run() async throws {
+        let client = TootClient(instanceURL: URL(string: url)!)
+        try await client.connect()
+        let instance = try await client.getLanguages()
+        print(instance)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -38,6 +38,7 @@ struct SwiftyAdmin: AsyncParsableCommand {
             GetInstance.self,
             GetInstancePrivacyPolicy.self,
             GetInstanceTermsOfService.self,
+            GetInstanceLanguages.self,
             GetMarkers.self,
             UpdateMarkers.self,
             GetPendingFollowRequests.self,

--- a/Sources/TootSDK/HTTP/Encoder.swift
+++ b/Sources/TootSDK/HTTP/Encoder.swift
@@ -32,4 +32,10 @@ extension TootEncoder {
 
         return dateFormatter
     }()
+
+    static let dateFormatterWithFullDate: ISO8601DateFormatter = {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+        return dateFormatter
+    }()
 }

--- a/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
@@ -36,6 +36,25 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
 
         /// The server status page. String (URL).
         public var status: String?
+
+        /// The server's about page. String (URL).
+        public var about: String?
+
+        /// The server's privacy policy webpage. String (URL).
+        public var privacyPolicy: String?
+
+        /// The server's terms of service webpage. String (URL).
+        public var termsOfService: String?
+
+        public init(
+            streaming: String? = nil, status: String? = nil, about: String? = nil, privacyPolicy: String? = nil, termsOfService: String? = nil
+        ) {
+            self.streaming = streaming
+            self.status = status
+            self.about = about
+            self.privacyPolicy = privacyPolicy
+            self.termsOfService = termsOfService
+        }
     }
 
     public struct Accounts: Codable, Hashable, Sendable {

--- a/Sources/TootSDK/Models/Instance/InstanceLanguage.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceLanguage.swift
@@ -1,0 +1,19 @@
+//
+//  InstanceLanguage.swift
+//  TootSDK
+//
+//  Created by Dale Price on 5/1/25.
+//
+
+/// Represents a supported locale.
+public struct InstanceLanguage: Codable, Hashable, Sendable {
+    /// Two-letter language code.
+    public var code: String
+    /// The name of the language localized in the instance's primary language.
+    public var name: String?
+
+    public init(code: String, name: String? = nil) {
+        self.code = code
+        self.name = name
+    }
+}

--- a/Sources/TootSDK/Models/Instance/InstanceV2.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceV2.swift
@@ -182,11 +182,17 @@ public struct InstanceV2: Codable, Hashable, Sendable {
         public var approvalRequired: Bool?
         /// An optional custom message to be shown when registrations are closed.
         public var message: String?
+        /// A minimum age required to register, if configured.
+        public var minAge: Int?
+        /// Whether registrations require the user to provide a reason for joining. Only applicable when ``approvalRequired`` is `true`.
+        public var reasonRequired: Bool?
 
-        public init(enabled: Bool? = nil, approvalRequired: Bool? = nil, message: String? = nil) {
+        public init(enabled: Bool? = nil, approvalRequired: Bool? = nil, message: String? = nil, minAge: Int? = nil, reasonRequired: Bool? = nil) {
             self.enabled = enabled
             self.approvalRequired = approvalRequired
             self.message = message
+            self.minAge = minAge
+            self.reasonRequired = reasonRequired
         }
     }
 

--- a/Sources/TootSDK/Models/RegisterAccountParams.swift
+++ b/Sources/TootSDK/Models/RegisterAccountParams.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct RegisterAccountParams: Codable, Sendable {
     public init(
         username: String, email: String, password: String, agreement: Bool, locale: String,
-        reason: String? = nil, token: String? = nil, fullname: String? = nil,
+        reason: String? = nil, dateOfBirth: String? = nil, token: String? = nil, fullname: String? = nil,
         captchaSolution: String? = nil, captchaToken: String? = nil, captchaAnswerData: String? = nil
     ) {
         self.username = username
@@ -19,6 +19,28 @@ public struct RegisterAccountParams: Codable, Sendable {
         self.agreement = agreement
         self.locale = locale
         self.reason = reason
+        self.dateOfBirth = dateOfBirth
+        self.token = token
+        self.fullname = fullname
+        self.captchaSolution = captchaSolution
+        self.captchaToken = captchaToken
+        self.captchaAnswerData = captchaAnswerData
+    }
+
+    public init(
+        username: String, email: String, password: String, agreement: Bool, locale: String,
+        reason: String? = nil, dateOfBirth: Date? = nil, token: String? = nil, fullname: String? = nil,
+        captchaSolution: String? = nil, captchaToken: String? = nil, captchaAnswerData: String? = nil
+    ) {
+        self.username = username
+        self.email = email
+        self.password = password
+        self.agreement = agreement
+        self.locale = locale
+        self.reason = reason
+        if let dateOfBirth {
+            self.dateOfBirth = TootEncoder.dateFormatterWithFullDate.string(from: dateOfBirth)
+        }
         self.token = token
         self.fullname = fullname
         self.captchaSolution = captchaSolution
@@ -42,7 +64,12 @@ public struct RegisterAccountParams: Codable, Sendable {
     public var locale: String
 
     /// If registrations require manual approval, this text will be reviewed by moderators.
+    ///
+    /// ``InstanceV2/Registrations-swift.struct/reasonRequired`` specifies whether this field is required.
     public var reason: String?
+
+    /// String in `YYYY-MM-DD` format; required if the server specifies a minimum age requirement using ``InstanceV2/Registrations-swift.struct/minAge``.
+    public var dateOfBirth: String?
 
     /// Invite token required when the registrations aren't public. Only supported by Pleroma and Akkoma
     public var token: String?

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -94,6 +94,15 @@ extension TootClient {
         return try await fetch([String: [String]].self, req)
     }
 
+    /// Get the human-readable names of the instance's supported languages, localized to the instance's primary language.
+    public func getLanguages() async throws -> [InstanceLanguage] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "languages"])
+            $0.method = .get
+        }
+        return try await fetch([InstanceLanguage].self, req)
+    }
+
     /// Get node info.
     public func getNodeInfo() async throws -> NodeInfo {
         let wellKnownReq = HTTPRequestBuilder {


### PR DESCRIPTION
- [x] Age verification (`InstanceV2.Registrations.minAge`, `RegisterAccountParams.dateOfBirth`)
- [X] Signup reason requirement (`InstanceV2.Registrations.reasonRequired`)
- [X] Additional Instance URLs (`InstanceConfiguration.URLs.about`, `InstanceConfiguration.URLs.privacyPolicy`, `InstanceConfiguration.URLs.termsOfService`)
- [X] Supported locales with localized language names (`TootClient.getLanguages`)
- [X] swiftyadmin support for all of the above