### PR TITLE
Add instance domain blocks and peers endpoints

### DIFF
--- a/Sources/TootSDK/Models/DomainBlock.swift
+++ b/Sources/TootSDK/Models/DomainBlock.swift
@@ -7,7 +7,7 @@ import Foundation
 ///   - silence = Account posts from this domain will be hidden by default
 ///   - suspend = All incoming data from this domain will be rejected
 ///   - noop = Do nothing. Allows for rejecting media or reports
-public enum DomainBlockSeverity: String, Codable, Hashable {
+public enum DomainBlockSeverity: String, Codable, Hashable, Sendable {
     case silence
     ///
     case suspend
@@ -15,7 +15,7 @@ public enum DomainBlockSeverity: String, Codable, Hashable {
 }
 
 /// Represents a domain limited from federating.
-public struct DomainBlock: Codable, Hashable {
+public struct DomainBlock: Codable, Hashable, Sendable {
     /// The ID of the DomainBlock in the database.
     public var id: String?
 

--- a/Sources/TootSDK/Models/Instance/InstanceDomainBlock.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceDomainBlock.swift
@@ -1,0 +1,27 @@
+//
+//  InstanceDomainBlock.swift
+//  TootSDK
+//
+//  Created by Dale Price on 5/12/25.
+//
+
+import Foundation
+
+/// Represents a domain that is blocked by the instance.
+public struct InstanceDomainBlock: Codable, Hashable, Sendable {
+    /// The domain that is blocked. This may be obfuscated or partially censored.
+    public var domain: String
+    /// The SHA256 hash digest of the domain string.
+    public var digest: String?
+    /// The level to which the domain is blocked.
+    public var severity: DomainBlockSeverity
+    /// An optional reason for the domain block.
+    public var comment: String?
+
+    public init(domain: String, digest: String? = nil, severity: DomainBlockSeverity, comment: String? = nil) {
+        self.domain = domain
+        self.digest = digest
+        self.severity = severity
+        self.comment = comment
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -116,6 +116,8 @@ extension TootClient {
     }
 
     /// Obtain a list of domains that have been blocked.
+    ///
+    /// Expected to return `401` if the admin has chosen to require authorization and none is provided, or `404` if the admin has chosen to hide domain blocks entirely.
     public func getDomainBlocks() async throws -> [InstanceDomainBlock] {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "domain_blocks"])

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -103,6 +103,27 @@ extension TootClient {
         return try await fetch([InstanceLanguage].self, req)
     }
 
+    /// Get the list of domains that this instance is aware of.
+    /// - Returns: Array of domains.
+    ///
+    /// Expected to return `401` if called without a user token if the instance is in limited federation mode.
+    public func getPeers() async throws -> [String] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "peers"])
+            $0.method = .get
+        }
+        return try await fetch([String].self, req)
+    }
+
+    /// Obtain a list of domains that have been blocked.
+    public func getDomainBlocks() async throws -> [InstanceDomainBlock] {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "domain_blocks"])
+            $0.method = .get
+        }
+        return try await fetch([InstanceDomainBlock].self, req)
+    }
+
     /// Get node info.
     public func getNodeInfo() async throws -> NodeInfo {
         let wellKnownReq = HTTPRequestBuilder {


### PR DESCRIPTION
Adds support for `api/v1/instance/peers` (list of connected servers) and `api/v1/instance/domain_blocks` (publicly viewable list of moderated servers).

I called the new struct `InstanceDomainBlock` because TootSDK already used `DomainBlock` for what Mastodon calls `Admin:DomainBlock`. Let me know if you’d rather shuffle the names around to match those used by the Mastodon documentation (i.e. rename TootSDK’s existing `DomainBlock` to `AdminDomainBlock` and the new `InstanceDomainBlock` to just plain `DomainBlock`).