### PR TITLE
Support versioned/dated terms of service endpoint

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetTermsOfService.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Instance/GetTermsOfService.swift
@@ -7,10 +7,22 @@ struct GetInstanceTermsOfService: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "URL to the instance to connect to")
     var url: String
 
+    @Option(name: .short, help: "Date (YYYY-MM-DD) of terms of service version to retrieve")
+    var date: String?
+
     mutating func run() async throws {
         let client = TootClient(instanceURL: URL(string: url)!)
         try await client.connect()
-        let instance = try await client.getTermsOfService()
-        print(instance)
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+
+        let terms: TermsOfService
+        if let dateString = date, let date = dateFormatter.date(from: dateString) {
+            terms = try await client.getTermsOfService(effectiveAsOf: date)
+        } else {
+            terms = try await client.getTermsOfService()
+        }
+        print(terms)
     }
 }

--- a/Sources/TootSDK/Models/PrivacyPolicy.swift
+++ b/Sources/TootSDK/Models/PrivacyPolicy.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The privacy policy or terms of service of an instance.
+/// The privacy policy of an instance.
 public struct PrivacyPolicy: Codable, Hashable, Sendable {
 
     /// A timestamp of when the policy was last updated.

--- a/Sources/TootSDK/Models/TermsOfService.swift
+++ b/Sources/TootSDK/Models/TermsOfService.swift
@@ -10,6 +10,8 @@ public struct TermsOfService: Codable, Hashable, Sendable {
     public var effective: Bool
 
     /// If there are newer terms of service, their effective date.
+    ///
+    /// You can get the newer version by passing this date as the parameter for ``TootClient/getTermsOfService(effectiveAsOf:)``.
     public var succeededBy: Date?
 
     /// The rendered HTML content of the terms of service.

--- a/Sources/TootSDK/Models/TermsOfService.swift
+++ b/Sources/TootSDK/Models/TermsOfService.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The terms of service of an instance.
+public struct TermsOfService: Codable, Hashable, Sendable {
+
+    /// The date these terms of service are coming or have come in effect.
+    public var effectiveDate: Date
+
+    /// Whether these terms of service are currently in effect.
+    public var effective: Bool
+
+    /// If there are newer terms of service, their effective date.
+    public var succeededBy: Date?
+
+    /// The rendered HTML content of the terms of service.
+    public var content: String
+
+    public init(effectiveDate: Date, effective: Bool, succeededBy: Date? = nil, content: String = "") {
+        self.effectiveDate = effectiveDate
+        self.effective = effective
+        self.succeededBy = succeededBy
+        self.content = content
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -73,15 +73,29 @@ extension TootClient {
     }
 
     /// Obtain the content of this server's terms of service, if configured.
-    /// - Returns: A ``PrivacyPolicy`` instance representing the terms of service.
+    /// - Returns: A ``TermsOfService`` instance representing the terms of service.
     ///
     /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
-    public func getTermsOfService() async throws -> PrivacyPolicy {
+    public func getTermsOfService() async throws -> TermsOfService {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "terms_of_service"])
             $0.method = .get
         }
-        return try await fetch(PrivacyPolicy.self, req)
+        return try await fetch(TermsOfService.self, req)
+    }
+
+    /// Obtain the content of this server's terms of service as of a specific date.
+    /// - Returns: A ``TermsOfService`` instance representing the terms of service as of the date specified in the `effectiveAsOf` parameter.
+    ///
+    /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
+    public func getTermsOfService(effectiveAsOf effectiveDate: Date) async throws -> TermsOfService {
+        let encodedDate = TootEncoder.dateFormatterWithFullDate.string(from: effectiveDate)
+
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "instance", "terms_of_service", encodedDate])
+            $0.method = .get
+        }
+        return try await fetch(TermsOfService.self, req)
     }
 
     /// Translation language pairs supported by the translation engine used by the server.

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -72,8 +72,8 @@ extension TootClient {
         return try await fetch(PrivacyPolicy.self, req)
     }
 
-    /// Obtain the content of this server's terms of service, if configured.
-    /// - Returns: A ``TermsOfService`` instance representing the terms of service.
+    /// Obtain the content of this server's most current terms of service, if configured.
+    /// - Returns: A ``TermsOfService`` instance representing the most recent effective terms of service, or the most recent version that exists if there is no currently effective version.
     ///
     /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
     public func getTermsOfService() async throws -> TermsOfService {
@@ -84,10 +84,10 @@ extension TootClient {
         return try await fetch(TermsOfService.self, req)
     }
 
-    /// Obtain the content of this server's terms of service as of a specific date.
-    /// - Returns: A ``TermsOfService`` instance representing the terms of service as of the date specified in the `effectiveAsOf` parameter.
+    /// Obtain a specific dated version of this server's terms of service.
+    /// - Returns: A ``TermsOfService`` instance with the effective date specified by the `effectiveAsOf` parameter.
     ///
-    /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
+    /// Expected to return `404` if there is no terms of service with the exact effective date specified, or if the instance has not configured its optional terms of service.
     public func getTermsOfService(effectiveAsOf effectiveDate: Date) async throws -> TermsOfService {
         let encodedDate = TootEncoder.dateFormatterWithFullDate.string(from: effectiveDate)
 


### PR DESCRIPTION
Announced in https://blog.joinmastodon.org/2025/05/legal-features-updates/

`getTermsOfService()` now returns a `TermsOfService` struct instead of `PrivacyPolicy`. This is a breaking change from my previous PR #332 (but only for the terms of service endpoint, not the others) because Mastodon changed what the endpoint returns since then. There shouldn't be any servers in the wild that still return the `PrivacyPolicy` type because that was only ever in nightly builds and not an official release.