### PR TITLE
Safe decoding of enums

### DIFF
--- a/Examples/swiftyadmin/Package.resolved
+++ b/Examples/swiftyadmin/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "f707b8680cddb96dc1855632340a572ef37bbb98",
-        "version" : "2.5.3"
+        "revision" : "aa85ee96017a730031bafe411cde24a08a17a9c9",
+        "version" : "2.8.8"
       }
     }
   ],

--- a/Sources/TootSDK/HTTP/OpenEnum.swift
+++ b/Sources/TootSDK/HTTP/OpenEnum.swift
@@ -1,0 +1,70 @@
+//
+//  OpenEnum.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 17/06/2025.
+//
+
+import Foundation
+
+/// A generic enum that wraps a known `RawRepresentable` value or an unknown value encountered during decoding.
+@frozen public enum OpenEnum<Wrapped: RawRepresentable & Sendable>: Sendable where Wrapped.RawValue: Sendable {
+    /// Represents a known, successfully parsed value.
+    case some(Wrapped)
+
+    /// Represents a raw value that couldn't be parsed into the known `Wrapped` type.
+    case unparsedByTootSDK(rawValue: Wrapped.RawValue)
+
+    /// Returns the underlying raw value, whether the case is a known or unparsed value.
+    public var rawValue: Wrapped.RawValue {
+        switch self {
+        case .some(let wrapped):
+            return wrapped.rawValue
+        case .unparsedByTootSDK(let rawValue):
+            return rawValue
+        }
+    }
+
+    /// Returns the wrapped enum value if it is recognized, or `nil` if the raw value was not parsed into a known case.
+    public var value: Wrapped? {
+        switch self {
+        case .some(let wrapped):
+            return wrapped
+        case .unparsedByTootSDK:
+            return nil
+        }
+    }
+
+    /// Wraps an optional `Wrapped` value into an optional `OpenEnum`.
+    ///
+    /// - Returns: `.some(value)` if the input is non-nil, or `nil` if the input is nil.
+    public static func optional(_ value: Wrapped?) -> Self? {
+        if let value {
+            return .some(value)
+        }
+        return nil
+    }
+}
+
+extension OpenEnum: Codable where Wrapped.RawValue: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Wrapped.RawValue.self)
+        if let wrapped = Wrapped(rawValue: rawValue) {
+            self = .some(wrapped)
+        } else {
+            self = .unparsedByTootSDK(rawValue: rawValue)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+extension OpenEnum: Equatable where Wrapped: Equatable, Wrapped.RawValue: Equatable {
+}
+
+extension OpenEnum: Hashable where Wrapped: Hashable, Wrapped.RawValue: Hashable {
+}

--- a/Sources/TootSDK/Models/BlockDomainParams.swift
+++ b/Sources/TootSDK/Models/BlockDomainParams.swift
@@ -10,7 +10,7 @@ public struct BlockDomainParams: Codable {
     public var domain: String
 
     /// Whether to apply a silence, suspend, or noop to the domain. Defaults to silence
-    public var severity: DomainBlockSeverity?
+    public var severity: OpenEnum<DomainBlockSeverity>?
 
     /// Whether media attachments should be rejected. Defaults to false
     public var rejectMedia: Bool?
@@ -40,7 +40,7 @@ public struct BlockDomainParams: Codable {
         publicComment: String? = nil, obfuscate: Bool? = nil
     ) {
         self.domain = domain
-        self.severity = severity
+        self.severity = .optional(severity)
         self.rejectMedia = rejectMedia
         self.rejectReports = rejectReports
         self.privateComment = privateComment

--- a/Sources/TootSDK/Models/Card.swift
+++ b/Sources/TootSDK/Models/Card.swift
@@ -29,7 +29,7 @@ public struct Card: Codable, Hashable, Sendable {
         self.title = title
         self.description = description
         self.language = language
-        self.type = type
+        self.type = .some(type)
         self.authorName = authorName
         self.authorUrl = authorUrl
         self.authors = authors
@@ -74,7 +74,7 @@ public struct Card: Codable, Hashable, Sendable {
     /// The language code of the linked resource.
     public var language: String?
     /// The type of preview card.
-    public var type: CardType
+    public var type: OpenEnum<CardType>
     /// The author of the original resource.
     public var authorName: String?
     /// A link to the author of the original resource.
@@ -108,7 +108,7 @@ public struct Card: Codable, Hashable, Sendable {
         self.title = try container.decode(String.self, forKey: .title)
         self.description = try container.decode(String.self, forKey: .description)
         self.language = try container.decodeIfPresent(String.self, forKey: .language)
-        self.type = try container.decode(Card.CardType.self, forKey: .type)
+        self.type = try container.decode(OpenEnum<Card.CardType>.self, forKey: .type)
         self.authorName = try container.decodeIfPresent(String.self, forKey: .authorName)
         self.authorUrl = try container.decodeIfPresent(String.self, forKey: .authorUrl)
         self.authors = try container.decodeIfPresent([Card.Author].self, forKey: .authors)

--- a/Sources/TootSDK/Models/CreateFilterParams.swift
+++ b/Sources/TootSDK/Models/CreateFilterParams.swift
@@ -10,8 +10,8 @@ import Foundation
 /// Parameters to create a new filter.
 public struct CreateFilterParams: Sendable {
     let title: String
-    let context: Set<Filter.Context>
-    let action: Filter.Action
+    let context: Set<OpenEnum<Filter.Context>>
+    let action: OpenEnum<Filter.Action>
     let expiresInSeconds: Int?
     let keywords: [Keyword]
 
@@ -31,8 +31,8 @@ public struct CreateFilterParams: Sendable {
         keywords: [Keyword]
     ) {
         self.title = title
-        self.context = context
-        self.action = action
+        self.context = Set(context.map { OpenEnum.some($0) })
+        self.action = .some(action)
         self.expiresInSeconds = expiresInSeconds
         self.keywords = keywords
     }

--- a/Sources/TootSDK/Models/DomainBlock.swift
+++ b/Sources/TootSDK/Models/DomainBlock.swift
@@ -26,7 +26,7 @@ public struct DomainBlock: Codable, Hashable, Sendable {
     public var createdAt: Date?
 
     /// The policy to be applied by this domain block.
-    public var severity: DomainBlockSeverity?
+    public var severity: OpenEnum<DomainBlockSeverity>?
 
     /// Whether to reject media attachments from this domain
     public var rejectMedia: Bool?
@@ -67,7 +67,7 @@ public struct DomainBlock: Codable, Hashable, Sendable {
         self.id = id
         self.domain = domain
         self.createdAt = createdAt
-        self.severity = severity
+        self.severity = .optional(severity)
         self.rejectMedia = rejectMedia
         self.rejectReports = rejectReports
         self.privateComment = privateComment

--- a/Sources/TootSDK/Models/Filter.swift
+++ b/Sources/TootSDK/Models/Filter.swift
@@ -31,11 +31,11 @@ public struct Filter: Codable, Hashable, Identifiable {
     /// A title given by the user to name the filter.
     public var title: String
     /// The contexts in which the filter should be applied.
-    public var context: [Context]
+    public var context: [OpenEnum<Context>]
     /// When the filter should no longer be applied.
     public var expiresAt: Date?
     /// The action to be taken when a post matches this filter.
-    public var filterAction: Action
+    public var filterAction: OpenEnum<Action>
     /// The keywords grouped under this filter.
     public var keywords: [FilterKeyword]
     /// The posts grouped under this filter.
@@ -55,9 +55,9 @@ public struct Filter: Codable, Hashable, Identifiable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(String.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
-        self.context = try container.decode([Context].self, forKey: .context)
+        self.context = try container.decode([OpenEnum<Context>].self, forKey: .context)
         self.expiresAt = try? container.decodeIfPresent(Date.self, forKey: .expiresAt)
-        self.filterAction = try container.decode(Action.self, forKey: .filterAction)
+        self.filterAction = try container.decode(OpenEnum<Action>.self, forKey: .filterAction)
         // not returned when part of FilterResult
         self.keywords = (try? container.decodeIfPresent([FilterKeyword].self, forKey: .keywords)) ?? []
         // not returned when part of FilterResult

--- a/Sources/TootSDK/Models/Instance/InstanceDomainBlock.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceDomainBlock.swift
@@ -14,14 +14,14 @@ public struct InstanceDomainBlock: Codable, Hashable, Sendable {
     /// The SHA256 hash digest of the domain string.
     public var digest: String?
     /// The level to which the domain is blocked.
-    public var severity: DomainBlockSeverity
+    public var severity: OpenEnum<DomainBlockSeverity>
     /// An optional reason for the domain block.
     public var comment: String?
 
     public init(domain: String, digest: String? = nil, severity: DomainBlockSeverity, comment: String? = nil) {
         self.domain = domain
         self.digest = digest
-        self.severity = severity
+        self.severity = .some(severity)
         self.comment = comment
     }
 }

--- a/Sources/TootSDK/Models/List.swift
+++ b/Sources/TootSDK/Models/List.swift
@@ -13,7 +13,7 @@ public struct List: Codable, Hashable, Identifiable, Sendable {
     public var title: String
 
     /// Which replies should be shown in the list.
-    public var repliesPolicy: ListRepliesPolicy?
+    public var repliesPolicy: OpenEnum<ListRepliesPolicy>?
 
     /// Whether members of this list need to get removed from the “Home” feed.
     public var exclusive: Bool?
@@ -21,7 +21,7 @@ public struct List: Codable, Hashable, Identifiable, Sendable {
     public init(id: String, title: String, repliesPolicy: ListRepliesPolicy, exclusive: Bool? = nil) {
         self.id = id
         self.title = title
-        self.repliesPolicy = repliesPolicy
+        self.repliesPolicy = .some(repliesPolicy)
         self.exclusive = exclusive
     }
 }

--- a/Sources/TootSDK/Models/ListParams.swift
+++ b/Sources/TootSDK/Models/ListParams.swift
@@ -8,13 +8,13 @@ public struct ListParams: Codable, Sendable {
     /// The user-defined title of the list.
     public var title: String
     /// The user-defined title of the list.
-    public var repliesPolicy: ListRepliesPolicy?
+    public var repliesPolicy: OpenEnum<ListRepliesPolicy>?
     /// Whether members of this list need to get removed from the “Home” feed
     public var exclusive: Bool?
 
     public init(title: String, repliesPolicy: ListRepliesPolicy? = nil, exclusive: Bool? = nil) {
         self.title = title
-        self.repliesPolicy = repliesPolicy
+        self.repliesPolicy = .optional(repliesPolicy)
         self.exclusive = exclusive
     }
 }

--- a/Sources/TootSDK/Models/Marker.swift
+++ b/Sources/TootSDK/Models/Marker.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// Represents the last read position within a user's timelines.
-public struct Marker: Codable, Hashable {
+public struct Marker: Codable, Hashable, Sendable {
     public init(lastReadId: String, updatedAt: Date, version: Int) {
         self.lastReadId = lastReadId
         self.updatedAt = updatedAt
@@ -19,7 +19,7 @@ public struct Marker: Codable, Hashable {
     public var version: Int
 
     /// Identifies a timeline for which a position can be saved.
-    public enum Timeline: String, Hashable, Codable, CodingKeyRepresentable {
+    public enum Timeline: String, Hashable, Codable, CodingKeyRepresentable, Sendable {
         /// Information about the user's position in the home timeline.
         case home
         /// Information about the user's position in their notifications.

--- a/Sources/TootSDK/Models/MediaAttachment.swift
+++ b/Sources/TootSDK/Models/MediaAttachment.swift
@@ -12,7 +12,7 @@ public struct MediaAttachment: Codable, Hashable, Identifiable, Sendable {
         description: String? = nil, blurhash: String? = nil
     ) {
         self.id = id
-        self.type = type
+        self.type = .some(type)
         self.url = url
         self.remoteUrl = remoteUrl
         self.previewUrl = previewUrl
@@ -25,7 +25,7 @@ public struct MediaAttachment: Codable, Hashable, Identifiable, Sendable {
     /// The ID of the attachment in the database.
     public var id: String
     /// The type of the attachment.
-    public var type: AttachmentType
+    public var type: OpenEnum<AttachmentType>
     /// The location of the original full-size attachment.
     public var url: String
     /// The location of the full-size original attachment on the remote website.

--- a/Sources/TootSDK/Models/PixelfedReportParams.swift
+++ b/Sources/TootSDK/Models/PixelfedReportParams.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct PixelfedReportParams: Codable {
-    var objectType: ObjectType
+    var objectType: OpenEnum<ObjectType>
     var objectId: String
-    var type: ReportCategory
+    var type: OpenEnum<ReportCategory>
 
     enum ObjectType: String, Codable {
         case post

--- a/Sources/TootSDK/Models/Post.swift
+++ b/Sources/TootSDK/Models/Post.swift
@@ -43,7 +43,7 @@ public class Post: Codable, Identifiable, @unchecked Sendable {
         self.createdAt = createdAt
         self.account = account
         self.content = content
-        self.visibility = visibility
+        self.visibility = .some(visibility)
         self.sensitive = sensitive
         self.spoilerText = spoilerText
         self.mediaAttachments = mediaAttachments
@@ -82,7 +82,7 @@ public class Post: Codable, Identifiable, @unchecked Sendable {
     /// HTML-encoded post content.
     public var content: String?
     /// Visibility of this post.
-    public var visibility: Visibility
+    public var visibility: OpenEnum<Visibility>
     /// Is this post marked as sensitive content?
     public var sensitive: Bool
     /// Subject or summary line, below which post content is collapsed until expanded.

--- a/Sources/TootSDK/Models/Preferences.swift
+++ b/Sources/TootSDK/Models/Preferences.swift
@@ -6,13 +6,13 @@ import Foundation
 /// Represents a user's preferences.
 public struct Preferences: Codable, Hashable, Sendable {
     /// Default visibility for new posts. Equivalent to Source#privacy.
-    public var postingDefaultVisibility: Post.Visibility
+    public var postingDefaultVisibility: OpenEnum<Post.Visibility>
     /// Default sensitivity flag for new posts. Equivalent to Source#sensitive.
     public var postingDefaultSensitive: Bool
     /// Default language for new posts. Equivalent to Source#language
     public var postingDefaultLanguage: String?
     /// Whether media attachments should be automatically displayed or blurred/hidden.
-    public var readingExpandMedia: ExpandMedia
+    public var readingExpandMedia: OpenEnum<ExpandMedia>
     /// Whether CWs should be expanded by default.
     public var readingExpandSpoilers: Bool
     /// Whether to automatically play animated GIFs.

--- a/Sources/TootSDK/Models/ProfileDirectoryParams.swift
+++ b/Sources/TootSDK/Models/ProfileDirectoryParams.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct ProfileDirectoryParams: Codable {
 
     /// Use active to sort by most recently posted post (default) or new to sort by most recently created profiles.
-    public var order: Order?
+    public var order: OpenEnum<Order>?
     /// If true, returns only local accounts.
     public var local: Bool?
 
@@ -18,7 +18,7 @@ public struct ProfileDirectoryParams: Codable {
         order: Order? = nil,
         local: Bool? = nil
     ) {
-        self.order = order
+        self.order = .optional(order)
         self.local = local
     }
 

--- a/Sources/TootSDK/Models/PushSubscription.swift
+++ b/Sources/TootSDK/Models/PushSubscription.swift
@@ -9,7 +9,7 @@ public struct PushSubscription: Codable, Sendable {
         self.endpoint = endpoint
         self.alerts = alerts
         self.serverKey = serverKey
-        self.policy = policy
+        self.policy = .some(policy)
     }
 
     /// Where push alerts will be sent to.
@@ -19,5 +19,5 @@ public struct PushSubscription: Codable, Sendable {
     /// The streaming server's VAPID key.
     public var serverKey: String
     /// From who to receive push notifications.
-    public var policy: PushSubscriptionPolicy?
+    public var policy: OpenEnum<PushSubscriptionPolicy>?
 }

--- a/Sources/TootSDK/Models/PushSubscriptionParams.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionParams.swift
@@ -62,11 +62,11 @@ public struct PushSubscriptionParams: Codable, Sendable {
         /// Specify which alerts should be received.
         public var alerts: Alerts?
         /// Specify whether to receive push notifications from all, followed, follower, or none users.
-        public var policy: PushSubscriptionPolicy?
+        public var policy: OpenEnum<PushSubscriptionPolicy>?
 
         public init(alerts: Alerts? = nil, policy: PushSubscriptionPolicy? = nil) {
             self.alerts = alerts
-            self.policy = policy
+            self.policy = .optional(policy)
         }
     }
 

--- a/Sources/TootSDK/Models/RelationshipSeveranceEvent.swift
+++ b/Sources/TootSDK/Models/RelationshipSeveranceEvent.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct RelationshipSeveranceEvent: Codable, Sendable, Hashable, Identifiable {
     public let id: String
-    public let type: EventType
+    public let type: OpenEnum<EventType>
     public let purged: Bool
     public let targetName: String
     public let relationshipsCount: Int?

--- a/Sources/TootSDK/Models/ReportParams.swift
+++ b/Sources/TootSDK/Models/ReportParams.swift
@@ -22,7 +22,7 @@ public struct ReportParams {
     public var forward: Bool?
 
     /// Specify if the report is due to spam, violation of enumerated instance rules, or some other reason. Will be set to `violation` if `ruleIds` is provided (regardless of any category value you provide).
-    public var category: ReportCategory
+    public var category: OpenEnum<ReportCategory>
 
     /// For violation category reports, specify the ID of the exact rules broken.
     public var ruleIds: [Int]
@@ -39,7 +39,7 @@ public struct ReportParams {
         self.postIds = postIds
         self.comment = comment
         self.forward = forward
-        self.category = category
+        self.category = .some(category)
         self.ruleIds = ruleIds
     }
 }

--- a/Sources/TootSDK/Models/ScheduledPostParams.swift
+++ b/Sources/TootSDK/Models/ScheduledPostParams.swift
@@ -33,7 +33,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
         self.mediaIds = mediaIds
         self.sensitive = sensitive
         self.spoilerText = spoilerText
-        self.visibility = visibility
+        self.visibility = .some(visibility)
         self.language = language
         self.scheduledAt = scheduledAt
         self.poll = poll
@@ -52,7 +52,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
     /// Mark post and attached media as sensitive? Defaults to false.
     public var spoilerText: String?
     /// Sets the visibility of the posted post to public, unlisted, private, direct.
-    public var visibility: Post.Visibility
+    public var visibility: OpenEnum<Post.Visibility>
     /// ISO 639 language code for this post.
     public var language: String?
     /// UTC Datetime at which to schedule a post.
@@ -98,7 +98,7 @@ public struct ScheduledPostParams: Codable, Equatable, Hashable, Sendable {
         // Mastodon incorrectly returns sensitive as a string
         self.sensitive = try? container.decodeBoolFromString(forKey: .sensitive)
         self.spoilerText = try? container.decodeIfPresent(String.self, forKey: .spoilerText)
-        self.visibility = try container.decode(Post.Visibility.self, forKey: .visibility)
+        self.visibility = try container.decode(OpenEnum<Post.Visibility>.self, forKey: .visibility)
         self.language = try? container.decodeIfPresent(String.self, forKey: .language)
         self.idempotency = try? container.decodeIfPresent(String.self, forKey: .idempotency)
         self.scheduledAt = try? container.decodeIfPresent(Date.self, forKey: .scheduledAt)

--- a/Sources/TootSDK/Models/ScheduledPostRequest.swift
+++ b/Sources/TootSDK/Models/ScheduledPostRequest.swift
@@ -14,7 +14,7 @@ internal struct ScheduledPostRequest: Codable {
     /// Mark post and attached media as sensitive? Defaults to false.
     public var spoilerText: String?
     /// Sets the visibility of the posted post to public, unlisted, private, direct.
-    public var visibility: Post.Visibility
+    public var visibility: OpenEnum<Post.Visibility>
     /// ISO 639 language code for this post.
     public var language: String?
     /// UTC Datetime at which to schedule a post in ISO 8601 format

--- a/Sources/TootSDK/Models/Suggestion.swift
+++ b/Sources/TootSDK/Models/Suggestion.swift
@@ -10,12 +10,12 @@ import Foundation
 /// An account suggested by the server.
 public struct Suggestion: Codable, Hashable, Sendable {
     public init(source: Source, account: Account) {
-        self.source = source
+        self.source = .some(source)
         self.account = account
     }
 
     /// The reason this account is being suggested.
-    public var source: Source
+    public var source: OpenEnum<Source>
     /// The account being recommended to follow.
     public var account: Account
 

--- a/Sources/TootSDK/Models/TootSource.swift
+++ b/Sources/TootSDK/Models/TootSource.swift
@@ -11,7 +11,7 @@ public struct TootSource: Codable, Hashable, Sendable {
     ) {
         self.note = note
         self.fields = fields
-        self.privacy = privacy
+        self.privacy = .optional(privacy)
         self.sensitive = sensitive
         self.language = language
         self.followRequestsCount = followRequestsCount
@@ -25,7 +25,7 @@ public struct TootSource: Codable, Hashable, Sendable {
     /// Metadata about the account.
     public var fields: [TootField]
     /// The default post privacy to be used for new posts.
-    public var privacy: Post.Visibility?
+    public var privacy: OpenEnum<Post.Visibility>?
     /// Whether new posts should be marked sensitive by default.
     public var sensitive: Bool?
     ///  The default posting language for new posts.

--- a/Sources/TootSDK/Models/UpdateCredentialsParams.swift
+++ b/Sources/TootSDK/Models/UpdateCredentialsParams.swift
@@ -70,12 +70,12 @@ public struct UpdateCredentialsParams: Codable {
 
     public struct Source: Codable, Hashable, Sendable {
         public init(privacy: Post.Visibility? = nil, sensitive: Bool? = nil, language: String? = nil) {
-            self.privacy = privacy
+            self.privacy = .optional(privacy)
             self.sensitive = sensitive
             self.language = language
         }
         /// The default post privacy to be used for new posts.
-        public var privacy: Post.Visibility?
+        public var privacy: OpenEnum<Post.Visibility>?
         /// Whether new posts should be marked sensitive by default.
         public var sensitive: Bool?
         ///  The default posting language for new posts.

--- a/Sources/TootSDK/Models/UpdateFilterParams.swift
+++ b/Sources/TootSDK/Models/UpdateFilterParams.swift
@@ -14,9 +14,9 @@ public struct UpdateFilterParams: Sendable, Hashable {
     /// New name for the filter.
     public let title: String?
     /// New contexts for the filter.
-    public let context: Set<Filter.Context>?
+    public let context: Set<OpenEnum<Filter.Context>>?
     /// New action of the filter.
-    public let action: Filter.Action?
+    public let action: OpenEnum<Filter.Action>?
     /// New expiry time of the filter.
     public let expiry: Expiry?
     /// Keyword changes to perform.
@@ -49,8 +49,10 @@ public struct UpdateFilterParams: Sendable, Hashable {
     ) {
         self.id = id
         self.title = title
-        self.context = context
-        self.action = action
+        self.context = context.map { context in
+            Set(context.map { OpenEnum.some($0) })
+        }
+        self.action = .optional(action)
         self.expiry = expiry
         self.keywords = keywords
     }

--- a/Sources/TootSDK/TootClient/TootClient+Markers.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Markers.swift
@@ -11,14 +11,14 @@ extension TootClient {
     /// Get saved timeline positions
     ///
     /// - Parameter timelines: The timeline(s) for which markers should be fetched.
-    public func getMarkers(for timelines: Set<Marker.Timeline>) async throws -> [Marker.Timeline: Marker] {
+    public func getMarkers(for timelines: Set<Marker.Timeline>) async throws -> [OpenEnum<Marker.Timeline>: Marker] {
         try requireFeature(.markers)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "markers"])
             $0.method = .get
             $0.query = createQuery(timelines: timelines)
         }
-        return try await fetch([Marker.Timeline: Marker].self, req)
+        return try await fetch([OpenEnum<Marker.Timeline>: Marker].self, req)
     }
 
     /// Save your position in a timeline
@@ -30,7 +30,7 @@ extension TootClient {
     public func updateMarkers(
         homeLastReadId: String? = nil,
         notificationsLastReadId: String? = nil
-    ) async throws -> [Marker.Timeline: Marker] {
+    ) async throws -> [OpenEnum<Marker.Timeline>: Marker] {
         try requireFeature(.markers)
         var queryItems: [URLQueryItem] = []
         if let homeLastReadId {
@@ -45,7 +45,7 @@ extension TootClient {
             $0.body = try .form(queryItems: queryItems)
         }
 
-        return try await fetch([Marker.Timeline: Marker].self, req)
+        return try await fetch([OpenEnum<Marker.Timeline>: Marker].self, req)
     }
 
     private func createQuery(timelines: Set<Marker.Timeline>) -> [URLQueryItem] {

--- a/Sources/TootSDK/TootClient/TootClient+Reports.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Reports.swift
@@ -34,7 +34,7 @@ extension TootClient {
     }
 
     private func pixelfedReport(_ params: ReportParams) async throws {
-        guard ReportCategory.pixelfedSupported.contains(params.category) else {
+        guard let category = params.category.value, ReportCategory.pixelfedSupported.contains(category) else {
             throw TootSDKError.invalidParameter(
                 parameterName: "category",
                 reason: "Unsupported category."
@@ -42,7 +42,7 @@ extension TootClient {
         }
         let postId = params.postIds.first
         let pixelfedParams = PixelfedReportParams(
-            objectType: postId != nil ? .post : .user,
+            objectType: .some(postId != nil ? .post : .user),
             objectId: postId ?? params.accountId,
             type: params.category
         )
@@ -69,7 +69,7 @@ extension TootClient {
         if let forward = params.forward {
             queryItems.append(.init(name: "forward", value: String(forward).lowercased()))
         }
-        if ReportCategory.mastodonSupported.contains(params.category) {
+        if let category = params.category.value, ReportCategory.mastodonSupported.contains(category) {
             queryItems.append(.init(name: "category", value: params.category.rawValue))
         }
         for ruleId in params.ruleIds {

--- a/Tests/TootSDKTests/AccountTests.swift
+++ b/Tests/TootSDKTests/AccountTests.swift
@@ -116,7 +116,7 @@ final class AccountTests: XCTestCase {
         XCTAssertEqual(result.source?.sensitive, false)
         XCTAssertEqual(result.source?.note, "Lorem ipsum")
         XCTAssertEqual(result.source?.indexable, true)
-        XCTAssertEqual(result.source?.privacy, .public)
+        XCTAssertEqual(result.source?.privacy, .some(.public))
         XCTAssertEqual(result.source?.hideCollections, true)
         XCTAssertEqual(result.source?.language, "en")
         XCTAssertEqual(result.source?.followRequestsCount, 0)

--- a/Tests/TootSDKTests/DecodingTests.swift
+++ b/Tests/TootSDKTests/DecodingTests.swift
@@ -27,11 +27,22 @@ final class DecodingTests: XCTestCase {
         try assertDecodes(#"{}"#, as: OptionalElement(nil))
     }
 
+    func testDecodeOpenEnum() throws {
+        try assertDecodes(#""blur""#, as: Filter.Action.blur)
+        try assertDecodes(#""blur""#, as: OpenEnum<Filter.Action>.some(.blur))
+        XCTAssertThrowsError(try decode(#""obfuscate""#, as: Filter.Action.self))
+        try assertDecodes(#""obfuscate""#, as: OpenEnum<Filter.Action>.unparsedByTootSDK(rawValue: "obfuscate"))
+    }
+
     private func assertDecodes<T: Equatable & Decodable>(_ json: String, as element: T) throws {
+        let decodedElement = try decode(json, as: T.self)
+        XCTAssertEqual(decodedElement, element)
+    }
+
+    private func decode<T: Equatable & Decodable>(_ json: String, as: T.Type) throws -> T {
         let decoder = JSONDecoder()
         let data = Data(json.utf8)
-        let decodedElement = try decoder.decode(T.self, from: data)
-        XCTAssertEqual(decodedElement, element)
+        return try decoder.decode(T.self, from: data)
     }
 
     struct Element: Decodable, Equatable {

--- a/Tests/TootSDKTests/ListTests.swift
+++ b/Tests/TootSDKTests/ListTests.swift
@@ -23,7 +23,7 @@ final class ListTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(result.id, "3309")
         XCTAssertEqual(result.title, "tech")
-        XCTAssertEqual(result.repliesPolicy, .followed)
+        XCTAssertEqual(result.repliesPolicy, .some(.followed))
         XCTAssertEqual(result.exclusive, false)
     }
 

--- a/Tests/TootSDKTests/OpenEnumTests.swift
+++ b/Tests/TootSDKTests/OpenEnumTests.swift
@@ -1,0 +1,27 @@
+//
+//  OpenEnumTests.swift
+//  TootSDK
+//
+//  Created by Łukasz Rutkowski on 19/06/2025.
+//
+
+import Testing
+import TootSDK
+
+struct OpenEnumTests {
+
+    @Test func rawValue() async throws {
+        #expect(OpenEnum<Filter.Action>.some(.blur).rawValue == "blur")
+        #expect(OpenEnum<Filter.Action>.unparsedByTootSDK(rawValue: "obfuscate").rawValue == "obfuscate")
+    }
+
+    @Test func value() async throws {
+        #expect(OpenEnum<Filter.Action>.some(.blur).value == Filter.Action.blur)
+        #expect(OpenEnum<Filter.Action>.unparsedByTootSDK(rawValue: "obfuscate").value == nil)
+    }
+
+    @Test func optional() async throws {
+        #expect(OpenEnum<Filter.Action>.optional(.blur) == OpenEnum<Filter.Action>.some(.blur))
+        #expect(OpenEnum<Filter.Action>.optional(nil) == nil)
+    }
+}

--- a/Tests/TootSDKTests/PostEditedTests.swift
+++ b/Tests/TootSDKTests/PostEditedTests.swift
@@ -42,7 +42,7 @@ final class PostTests: XCTestCase {
         XCTAssertNotNil(result.url)
         XCTAssertEqual(result.spoilerText, "")
         XCTAssertEqual(result.language, "en")
-        XCTAssertEqual(result.visibility, .public)
+        XCTAssertEqual(result.visibility, .some(.public))
         XCTAssertEqual(result.pinned, false)
         XCTAssertEqual(result.muted, false)
         XCTAssertEqual(result.favouritesCount, 1)

--- a/Tests/TootSDKTests/ScheduledPostTests.swift
+++ b/Tests/TootSDKTests/ScheduledPostTests.swift
@@ -61,7 +61,7 @@ final class ScheduledPostTests: XCTestCase {
         XCTAssertNil(result.params.idempotency)
         XCTAssertEqual(result.params.spoilerText, "Warn")
         XCTAssertEqual(result.params.language, "en")
-        XCTAssertEqual(result.params.visibility, .direct)
+        XCTAssertEqual(result.params.visibility, .some(.direct))
     }
 
     func testScheduledPostMediaIds() throws {
@@ -87,7 +87,7 @@ final class ScheduledPostTests: XCTestCase {
         XCTAssertNil(result.params.idempotency)
         XCTAssertNil(result.params.spoilerText)
         XCTAssertEqual(result.params.language, "en")
-        XCTAssertEqual(result.params.visibility, .private)
+        XCTAssertEqual(result.params.visibility, .some(.private))
     }
 
     func testScheduledPostMultipleMedias() throws {
@@ -113,7 +113,7 @@ final class ScheduledPostTests: XCTestCase {
         XCTAssertNil(result.params.idempotency)
         XCTAssertNil(result.params.spoilerText)
         XCTAssertEqual(result.params.language, "en")
-        XCTAssertEqual(result.params.visibility, .private)
+        XCTAssertEqual(result.params.visibility, .some(.private))
         XCTAssertEqual(result.params.mediaIds, ["111892073708535727", "111892073823106369"])
         XCTAssertEqual(result.params.mediaIds, result.mediaAttachments.map(\.id))
     }
@@ -141,6 +141,6 @@ final class ScheduledPostTests: XCTestCase {
         XCTAssertNil(result.params.idempotency)
         XCTAssertNil(result.params.spoilerText)
         XCTAssertEqual(result.params.language, "en")
-        XCTAssertEqual(result.params.visibility, .unlisted)
+        XCTAssertEqual(result.params.visibility, .some(.unlisted))
     }
 }


### PR DESCRIPTION
Implemented as `OpenEnum`. The `UnknownDecodable` protocol didn't work due to incompatibility of enums with raw value and enums with associated parameters.

For convenience, added the `value` property that allows accessing the underlying enum as an optional value. It returns nil if enum was decoded to an unknown value.

Only enums that are decoded are wrapped in `OpenEnum`. Initializers and enums used only in sent parameters are not affected. In situations where there would be a new known case for them, they should be contributed to TootSDK instead of using the unparsed case.

Closes #343