### PR TITLE
Conform OpenEnum to CodingKeyRepresentable

### DIFF
--- a/Sources/TootSDK/HTTP/OpenEnum.swift
+++ b/Sources/TootSDK/HTTP/OpenEnum.swift
@@ -111,3 +111,25 @@ extension OpenEnum: Equatable where Wrapped: Equatable, Wrapped.RawValue: Equata
 
 extension OpenEnum: Hashable where Wrapped: Hashable, Wrapped.RawValue: Hashable {
 }
+
+@available(iOS 15.4, macOS 12.3, tvOS 15.4, watchOS 8.5, *)
+extension OpenEnum: CodingKeyRepresentable where Wrapped: CodingKeyRepresentable, Wrapped.RawValue: CodingKeyRepresentable {
+    public var codingKey: any CodingKey {
+        switch self {
+        case .some(let wrapped):
+            return wrapped.codingKey
+        case .unparsedByTootSDK(let rawValue):
+            return rawValue.codingKey
+        }
+    }
+
+    public init?(codingKey: some CodingKey) {
+        if let wrapped = Wrapped(codingKey: codingKey) {
+            self = .some(wrapped)
+        } else if let rawValue = Wrapped.RawValue(codingKey: codingKey) {
+            self = .unparsedByTootSDK(rawValue: rawValue)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/TootSDKTests/DecodingTests.swift
+++ b/Tests/TootSDKTests/DecodingTests.swift
@@ -34,6 +34,13 @@ final class DecodingTests: XCTestCase {
         try assertDecodes(#""obfuscate""#, as: OpenEnum<Filter.Action>.unparsedByTootSDK(rawValue: "obfuscate"))
     }
 
+    func testDecodeOpenEnumAsDictionaryKey() throws {
+        try assertDecodes(#"{"home": true}"#, as: [Marker.Timeline.home: true])
+        try assertDecodes(#"{"home": true}"#, as: [OpenEnum<Marker.Timeline>.some(.home): true])
+        XCTAssertThrowsError(try decode(#"{"garden": false}"#, as: [Marker.Timeline: Bool].self))
+        try assertDecodes(#"{"garden": false}"#, as: [OpenEnum<Marker.Timeline>.unparsedByTootSDK(rawValue: "garden"): false])
+    }
+
     private func assertDecodes<T: Equatable & Decodable>(_ json: String, as element: T) throws {
         let decodedElement = try decode(json, as: T.self)
         XCTAssertEqual(decodedElement, element)


### PR DESCRIPTION
Missed that `Marker.Timeline` conforms to `CodingKeyRepresentable` for proper decoding. Updated `OpenEnum` to also conform to it where needed.