### PR TITLE
Support Mastodon 4.4 account management additions

### DIFF
--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/EndorseAccount.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/EndorseAccount.swift
@@ -1,0 +1,30 @@
+//
+//  EndorseAccount.swift
+//  swiftyadmin
+//
+//  Created by Dale Price on 7/17/25.
+//
+
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct EndorseAccount: AsyncParsableCommand {
+
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    @Option(name: .customShort("i"), help: "id of the user to endorse")
+    var userID: String
+
+    mutating func run() async throws {
+        print("Endorsing user with local id: \(userID)")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        let relationship = try await client.endorseAccount(by: userID)
+        print(relationship)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/GetEndorsements.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/GetEndorsements.swift
@@ -1,0 +1,62 @@
+//
+//  GetEndorsements.swift
+//
+
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct GetEndorsements: AsyncParsableCommand {
+
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    @Option(name: .customShort("i"), help: "id of the user")
+    var userID: String
+
+    mutating func run() async throws {
+        print("Getting featured accounts of user with local id: \(userID)")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        var pagedInfo: PagedInfo? = nil
+        var hasMore = true
+
+        while hasMore {
+            let page = try await client.getEndorsements(forAccount: userID, pagedInfo)
+            for endorsedAccount in page.result {
+                print(endorsedAccount.acct)
+            }
+            hasMore = page.hasPrevious
+            pagedInfo = page.previousPage
+        }
+    }
+}
+
+struct GetOwnAccountEndorsements: AsyncParsableCommand {
+
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    mutating func run() async throws {
+        print("Getting featured accounts")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        var pagedInfo: PagedInfo? = nil
+        var hasMore = true
+
+        while hasMore {
+            let page = try await client.getEndorsements(pagedInfo)
+            for endorsedAccount in page.result {
+                print("\(endorsedAccount.id) \(endorsedAccount.acct)")
+            }
+            hasMore = page.hasPrevious
+            pagedInfo = page.previousPage
+        }
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/UnendorseAccount.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/UnendorseAccount.swift
@@ -1,0 +1,30 @@
+//
+//  EndorseAccount.swift
+//  swiftyadmin
+//
+//  Created by Dale Price on 7/17/25.
+//
+
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct UnendorseAccount: AsyncParsableCommand {
+
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    @Option(name: .customShort("i"), help: "id of the user to unendorse")
+    var userID: String
+
+    mutating func run() async throws {
+        print("Unendorsing user with local id: \(userID)")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        let relationship = try await client.unendorseAccount(by: userID)
+        print(relationship)
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/Account/VerifyCredentials.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/Account/VerifyCredentials.swift
@@ -1,0 +1,30 @@
+//
+//  VerifyCredentials.swift
+//  swiftyadmin
+//
+//  Created by Dale Price on 7/17/25.
+//
+
+import ArgumentParser
+import Foundation
+import TootSDK
+
+struct VerifyCredentials: AsyncParsableCommand {
+
+    @Option(name: .short, help: "URL to the instance to connect to")
+    var url: String
+
+    @Option(name: .short, help: "Access token for an account with sufficient permissions.")
+    var token: String
+
+    mutating func run() async throws {
+        print("Verifying account credentials")
+        let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
+
+        let credentialAccount = try await client.verifyCredentials()
+        print(credentialAccount)
+        if let source = credentialAccount.source {
+            print(source)
+        }
+    }
+}

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -57,5 +57,6 @@ struct SwiftyAdmin: AsyncParsableCommand {
             GetOwnAccountEndorsements.self,
             EndorseAccount.self,
             UnendorseAccount.self,
+            VerifyCredentials.self,
         ])
 }

--- a/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/swiftyadmin.swift
@@ -53,5 +53,9 @@ struct SwiftyAdmin: AsyncParsableCommand {
             GetNodeInfo.self,
             GetPreferences.self,
             StreamEvents.self,
+            GetEndorsements.self,
+            GetOwnAccountEndorsements.self,
+            EndorseAccount.self,
+            UnendorseAccount.self,
         ])
 }

--- a/Sources/TootSDK/Models/TootSource.swift
+++ b/Sources/TootSDK/Models/TootSource.swift
@@ -7,7 +7,8 @@ import Foundation
 public struct TootSource: Codable, Hashable, Sendable {
     public init(
         note: String? = nil, fields: [TootField], privacy: Post.Visibility? = nil, sensitive: Bool? = nil, language: String? = nil,
-        followRequestsCount: Int? = nil, indexable: Bool? = nil, hideCollections: Bool? = nil, discoverable: Bool? = nil
+        followRequestsCount: Int? = nil, indexable: Bool? = nil, hideCollections: Bool? = nil, discoverable: Bool? = nil,
+        attributionDomains: [String]? = nil
     ) {
         self.note = note
         self.fields = fields
@@ -18,6 +19,7 @@ public struct TootSource: Codable, Hashable, Sendable {
         self.indexable = indexable
         self.hideCollections = hideCollections
         self.discoverable = discoverable
+        self.attributionDomains = attributionDomains
     }
 
     /// Profile bio.
@@ -38,4 +40,6 @@ public struct TootSource: Codable, Hashable, Sendable {
     public let hideCollections: Bool?
     /// Whether the account has opted into discovery features such as the profile directory
     public let discoverable: Bool?
+    /// Domains of websites allowed to credit the account in link preview cards.
+    public let attributionDomains: [String]?
 }

--- a/Sources/TootSDK/Models/UpdateCredentialsParams.swift
+++ b/Sources/TootSDK/Models/UpdateCredentialsParams.swift
@@ -32,13 +32,18 @@ public struct UpdateCredentialsParams: Codable {
     public let fieldsAttributes: [String: Field]?
     /// An extra entity to be used with API methods to verify credentials and update credentials
     public let source: Source?
+    /// Domains of websites allowed to credit the account in link preview cards.
+    ///
+    /// Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 3 or higher.
+    public let attributionDomains: [String]?
 
     public init(
         displayName: String? = nil, note: String? = nil, avatar: Data? = nil, avatarMimeType: String? = nil, header: Data? = nil,
         headerMimeType: String? = nil, locked: Bool? = nil, bot: Bool? = nil, discoverable: Bool? = nil, hideCollections: Bool? = nil,
         indexable: Bool? = nil,
         fieldsAttributes: [String: Field]? = nil,
-        source: Source? = nil
+        source: Source? = nil,
+        attributionDomains: [String]? = nil
     ) {
         self.displayName = displayName
         self.note = note
@@ -53,6 +58,7 @@ public struct UpdateCredentialsParams: Codable {
         self.indexable = indexable
         self.fieldsAttributes = fieldsAttributes
         self.source = source
+        self.attributionDomains = attributionDomains
     }
 
     /// Represents a profile field as a name-value pair

--- a/Sources/TootSDK/TootClient/TootClient+Relationships.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Relationships.swift
@@ -172,6 +172,9 @@ extension TootClient {
     }
 
     /// Add the given account to the user’s featured profiles. (Featured profiles are currently shown on the user’s own public profile.)
+    ///
+    /// - Warning: Deprecated in Mastodon 4.4 and later in favor of ``endorseAccount(by:)``.
+    ///
     /// - Parameter id: the ID of the Account in the instance database.
     /// - Returns: the relationship to the account requested, or an error if unable to retrieve
     public func pinAccount(by id: String) async throws -> Relationship {
@@ -184,6 +187,9 @@ extension TootClient {
     }
 
     /// Remove the given account from the user’s featured profiles.
+    ///
+    /// - Warning: Deprecated in Mastodon 4.4 and later in favor of ``unendorseAccount(by:)``.
+    ///
     /// - Parameter id: the ID of the Account in the instance database.
     /// - Returns: the relationship to the account requested, or an error if unable to retrieve
     public func unpinAccount(by id: String) async throws -> Relationship {
@@ -195,7 +201,7 @@ extension TootClient {
         return try await fetch(Relationship.self, req)
     }
 
-    /// Accounts that the user is currently featuring on their profile.
+    /// Get accounts that the authenticated user is currently featuring on their own profile.
     /// - Parameters:
     ///     - pageInfo: PagedInfo object for max/min/since
     ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
@@ -208,6 +214,53 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
         return try await fetchPagedResult(req)
+    }
+
+    /// Get accounts that a user is currently featuring on their profile.
+    ///
+    /// Only supported in Mastodon 4.4 and later.
+    ///
+    /// - Parameters:
+    ///     - id: The ID of the account.
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: the accounts requested
+    public func getEndorsements(forAccount id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
+        try requireFeature(.endorsements)
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", id, "endorsements"])
+            $0.method = .get
+            $0.query = getQueryParams(pageInfo, limit: limit)
+        }
+        return try await fetchPagedResult(req)
+    }
+
+    /// Add a given account to the authorized user's featured profiles.
+    ///
+    /// Only supported in Mastodon 4.4 and later.
+    ///
+    /// - Returns: the new ``Relationship``.
+    public func endorseAccount(by id: String) async throws -> Relationship {
+        try requireFeature(.endorsements)
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", id, "endorse"])
+            $0.method = .post
+        }
+        return try await fetch(Relationship.self, req)
+    }
+
+    /// Remove a given account from the authorized user's featured profiles.
+    ///
+    /// Only supported in Mastodon 4.4 and later.
+    ///
+    /// - Returns: the new ``Relationship``.
+    public func unendorseAccount(by id: String) async throws -> Relationship {
+        try requireFeature(.endorsements)
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "accounts", id, "unendorse"])
+            $0.method = .post
+        }
+        return try await fetch(Relationship.self, req)
     }
 
     /// Sets a private note on a user.


### PR DESCRIPTION
#### API support:
- [X] added support for endpoints to endorse (feature), unendorse, and query endorsements (featured accounts) by account ID
- [X] support getting attribution domains using verifyCredentials and setting them using updateCredentials

#### swiftyadmin:
- [X] added EndorseAccount, UnendorseAccount, GetEndorsements, GetOwnAccountEndorsements commands
- [X] added VerifyCredentials command that prints CredentialAccount `source`

#### Notes
- Calling updateCredentials with the `attributionDomains` property is only supported if the server supports Mastodon API version 3 or higher.
- The `endorse` and `unendorse` endpoints are intended to replace the older `pin` and `unpin` which are now deprecated in Mastodon 4.4. The docs don’t give an API version for this change, just the main Mastodon version number.
- Since TootClient doesn’t (currently) track the Mastodon API version or Mastodon version, I didn’t add a version check in any of these methods, I just noted the requirement and deprecation in the DocC comments of each method.
- The [Mastodon 4.4 for developers](https://blog.joinmastodon.org/2025/07/mastodon-4-4-for-devs/) post also notes new endpoints for featuring/unfeaturing hashtags, which seem to be near-duplicates of existing endpoints that TootSDK already supports. (update: in addition to returning a `Tag` instead of a `FeaturedTag`, the new endpoints are intended to be easier to use by not requiring the tag name in form data.) Since TootSDK already has an implementation for the existing endpoints with wider compatibility, I left these alone.