### PR TITLE
Add missing Mastodon properties to InstanceV2

### DIFF
--- a/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
+++ b/Sources/TootSDK/Models/Instance/InstanceConfiguration.swift
@@ -19,6 +19,22 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
     ///
     /// Only populated by v2 instance API.
     public var translation: Translation?
+    /// Whether federation is limited to explicitly allowed domains.
+    public var limitedFederation: Bool?
+
+    public init(
+        urls: URLs? = nil, vapid: VAPID? = nil, accounts: Accounts? = nil, posts: Posts? = nil, mediaAttachments: MediaAttachments? = nil,
+        polls: Polls? = nil, translation: Translation? = nil, limitedFederation: Bool? = nil
+    ) {
+        self.urls = urls
+        self.vapid = vapid
+        self.accounts = accounts
+        self.posts = posts
+        self.mediaAttachments = mediaAttachments
+        self.polls = polls
+        self.translation = translation
+        self.limitedFederation = limitedFederation
+    }
 
     enum CodingKeys: String, CodingKey {
         case urls
@@ -28,6 +44,7 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
         case mediaAttachments
         case polls
         case translation
+        case limitedFederation
     }
 
     public struct URLs: Codable, Hashable, Sendable {
@@ -67,6 +84,11 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
             case maxFeaturedTags
             case maxPinnedPosts = "maxPinnedStatuses"
         }
+
+        public init(maxFeaturedTags: Int? = nil, maxPinnedPosts: Int? = nil) {
+            self.maxFeaturedTags = maxFeaturedTags
+            self.maxPinnedPosts = maxPinnedPosts
+        }
     }
 
     public struct Posts: Codable, Hashable, Sendable {
@@ -76,11 +98,19 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
         public var maxMediaAttachments: Int?
         /// Each URL in a post will be assumed to be exactly this many characters.
         public var charactersReservedPerUrl: Int?
+
+        public init(maxCharacters: Int? = nil, maxMediaAttachments: Int? = nil, charactersReservedPerUrl: Int? = nil) {
+            self.maxCharacters = maxCharacters
+            self.maxMediaAttachments = maxMediaAttachments
+            self.charactersReservedPerUrl = charactersReservedPerUrl
+        }
     }
 
     public struct MediaAttachments: Codable, Hashable, Sendable {
         /// Contains MIME types that can be uploaded.
         public var supportedMimeTypes: [String]?
+        /// The maximum size of a description, in characters.
+        public var descriptionLimit: Int?
         /// The maximum size of any uploaded image, in bytes.
         public var imageSizeLimit: Int?
         /// The maximum number of pixels (width times height) for image uploads.
@@ -91,6 +121,19 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
         public var videoFrameRateLimit: Int?
         /// The maximum number of pixels (width times height) for video uploads.
         public var videoMatrixLimit: Int?
+
+        public init(
+            supportedMimeTypes: [String]? = nil, descriptionLimit: Int? = nil, imageSizeLimit: Int? = nil, imageMatrixLimit: Int? = nil,
+            videoSizeLimit: Int? = nil, videoFrameRateLimit: Int? = nil, videoMatrixLimit: Int? = nil
+        ) {
+            self.supportedMimeTypes = supportedMimeTypes
+            self.descriptionLimit = descriptionLimit
+            self.imageSizeLimit = imageSizeLimit
+            self.imageMatrixLimit = imageMatrixLimit
+            self.videoSizeLimit = videoSizeLimit
+            self.videoFrameRateLimit = videoFrameRateLimit
+            self.videoMatrixLimit = videoMatrixLimit
+        }
     }
 
     public struct Polls: Codable, Hashable, Sendable {
@@ -102,11 +145,22 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
         public var minExpiration: Int?
         /// The longest allowed poll duration, in seconds.
         public var maxExpiration: Int?
+
+        public init(maxOptions: Int? = nil, maxCharactersPerOption: Int? = nil, minExpiration: Int? = nil, maxExpiration: Int? = nil) {
+            self.maxOptions = maxOptions
+            self.maxCharactersPerOption = maxCharactersPerOption
+            self.minExpiration = minExpiration
+            self.maxExpiration = maxExpiration
+        }
     }
 
     public struct Translation: Codable, Hashable, Sendable {
         /// Whether the translation API is available on this instance.
         public var enabled: Bool?
+
+        public init(enabled: Bool? = nil) {
+            self.enabled = enabled
+        }
     }
 
     public struct VAPID: Codable, Hashable, Sendable {
@@ -114,6 +168,10 @@ public struct InstanceConfiguration: Codable, Hashable, Sendable {
         ///
         /// > SeeAlso: This is the same as ``PushSubscription/serverKey``.
         public var publicKey: String?
+
+        public init(publicKey: String? = nil) {
+            self.publicKey = publicKey
+        }
     }
 
 }


### PR DESCRIPTION
- Added limited federation mode & media description limit to InstanceV2 (both optional)
- Added public initializers for InstanceConfiguration and its child structs