### PR TITLE
Masto 4.4 media deletion

### DIFF
--- a/Sources/TootSDK/TootClient/TootClient+Media.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Media.swift
@@ -56,6 +56,20 @@ extension TootClient {
         return try decode(MediaAttachment.self, from: data)
     }
 
+    /// Delete a media attachment that is not currently attached to a status.
+    ///
+    /// Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher.
+    ///
+    /// - Parameter id: The ID of the ``MediaAttachment`` in the database.
+    public func deleteMedia(id: String) async throws {
+        let req = HTTPRequestBuilder {
+            $0.url = getURL(["api", "v1", "media", id])
+            $0.method = .delete
+        }
+
+        try await fetch(req: req)
+    }
+
     /// Update media parameters, before it is posted.
     ///
     /// - Parameter id: the ID of the media attachment to be changed.

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -101,11 +101,15 @@ extension TootClient {
 
     /// Deletes a single post
     /// - Parameter id: the ID of the post to be deleted
+    /// - Parameter deleteMedia: Whether to immediately delete the post's media attachments. Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher. If supported and this parameter is `nil` or `false`, media attachents may be kept for approximately 24 hours so they can be reused in a new post.
     /// - Returns: the post deleted (for delete and redraft), if successful, throws an error if not
-    public func deletePost(id: String) async throws -> Post {
+    public func deletePost(id: String, deleteMedia: Bool? = nil) async throws -> Post {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id])
             $0.method = .delete
+            if let deleteMedia {
+                $0.addQueryParameter(name: "delete_media", value: String(deleteMedia))
+            }
         }
         return try await fetch(Post.self, req)
     }


### PR DESCRIPTION
- Adds `deleteMedia(id:)` method that calls the [delete media endpoint](https://docs.joinmastodon.org/methods/media/#delete) added in Mastodon 4.4
- Adds optional `deleteMedia` parameter to `deletePost(id:)` method

As with the changes in #356, I noted the API version requirement in the DocC documentation.