### PR TITLE
Expose HTTP response headers from API calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ TootSDK is a Swift Package Manager library that provides a unified SDK for inter
 - PagedResult<T> for paginated responses with built-in navigation
 - Optional parameters via dedicated parameter structs
 - Comprehensive error handling with TootSDKError types
+- Raw method pattern: Each API method should have a corresponding `*Raw()` variant that returns `TootResponse<T>` containing the decoded data along with HTTP metadata (headers, status code, URL, raw body). The standard method calls the Raw method and returns just the data for backward compatibility. See PR #360 for details.
 
 ### Development Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Building and Testing
+
+- **Build**: `make build` or `swift build`
+- **Test**: `make test` or `swift test`
+- **Auto-format**: `make lint` - applies formatting and fixes lint issues across Sources, Tests, and Examples
+
+### Single Test Execution
+
+Run individual test files using:
+
+```bash
+swift test --filter TestClassName
+swift test --filter TestClassName.testMethodName
+```
+
+## Architecture
+
+### Core Structure
+
+TootSDK is a Swift Package Manager library that provides a unified SDK for interacting with Mastodon-compatible Fediverse servers. The architecture follows these key patterns:
+
+**TootClient** (`Sources/TootSDK/TootClient/TootClient.swift`) - Main entry point and HTTP client
+
+- Handles authentication, server communication, and API calls
+- Contains flavour detection for different server types (Mastodon, Pleroma, Pixelfed, etc.)
+- Manages access tokens and session state
+- Provides both async/await and traditional completion handler APIs
+
+**Multi-server Support** (`Sources/TootSDK/Models/TootSDKFlavour.swift`)
+
+- Supports 10+ Fediverse server implementations (Mastodon, Pleroma, Pixelfed, Friendica, Akkoma, Firefish, Catodon, Iceshrimp, Sharkey, GoToSocial)
+- Automatic server flavour detection to handle API differences
+- Unified data models that work across server types
+
+**Data Models** (`Sources/TootSDK/Models/`)
+
+- Rich set of models for Posts, Accounts, Timelines, Notifications, etc.
+- Consistent naming (uses "Post" terminology instead of Mastodon's "Status")
+- Handles pagination with `PagedResult<T>` and `PagedInfo` structures
+- Support for server-specific features through optional properties
+
+**Client Extensions** (`Sources/TootSDK/TootClient/TootClient+*.swift`)
+
+- Functionality is split across multiple extensions by feature area:
+  - Account management, Posts, Timelines, Notifications
+  - Lists, Filters, Media, Streaming, etc.
+- Each extension focuses on a specific API domain
+
+**Streaming Support** (`Sources/TootSDK/TootClient/Streaming/`)
+
+- WebSocket-based real-time streaming for timelines and notifications
+- Async sequence support for event processing
+- Handles connection management and reconnection
+
+**HTML Rendering** (`Sources/TootSDK/HTMLRendering/`)
+
+- Cross-platform HTML to AttributedString conversion
+- Platform-specific renderers for AppKit, UIKit, and universal contexts
+- Handles Mastodon's HTML content formatting
+
+### Platform Support
+
+- **Platforms**: iOS 14+, macOS 12+, watchOS 7+, tvOS 14+, Linux
+- **Authentication**: ASWebAuthenticationSession on Apple platforms, manual OAuth flow on others
+- **Networking**: Foundation URLSession with async/await support
+
+### Testing Strategy
+
+- Comprehensive unit tests with JSON fixtures for different server responses
+- Test data anonymized (example.com domains, Lorem Ipsum content)
+- Server-specific test cases for API variations
+- Resource files in `Tests/TootSDKTests/Resources/` for realistic server responses
+- New resource files need to be registered in the Package.swift for the test target e.g. `.copy("Resources/account.json")`
+
+## Code Style and Conventions
+
+### Swift Format Configuration
+
+- Uses swift-format with custom `.swift-format` configuration
+- 4-space indentation, 150 character line length
+- File-scoped declaration privacy preferred
+- Specific formatting rules defined in `.swift-format`
+
+### Naming Conventions
+
+- Use "Post" terminology throughout (not "Status" or "Note")
+- Parameter structs as separate objects (e.g., `RegisterAccountParams`)
+- Consistent async/await method naming
+- Flavour-agnostic naming in public APIs
+
+### API Design Patterns
+
+- Async/await first, with @Sendable conformance where needed
+- PagedResult<T> for paginated responses with built-in navigation
+- Optional parameters via dedicated parameter structs
+- Comprehensive error handling with TootSDKError types
+
+### Development Guidelines
+
+- Avoid new dependencies without strong justification
+- Test data must be anonymized before inclusion
+- All public methods require documentation
+- Maintain cross-platform compatibility
+- Follow Swift API Design Guidelines

--- a/Sources/TootSDK/Models/TootResponse.swift
+++ b/Sources/TootSDK/Models/TootResponse.swift
@@ -19,19 +19,19 @@ import Foundation
 public struct TootResponse<T> {
     /// The decoded response data (original return type)
     public let data: T
-    
+
     /// HTTP response headers as key-value pairs
     public let headers: [String: String]
-    
+
     /// HTTP status code
     public let statusCode: Int
-    
+
     /// Response URL
     public let url: URL?
-    
+
     /// Raw response body as Data (for debugging/fallback parsing)
     public let rawBody: Data
-    
+
     /// Creates a new TootResponse with the provided data and metadata
     ///
     /// - Parameters:
@@ -56,12 +56,12 @@ extension TootResponse {
     public var rateLimitLimit: Int? {
         headers["X-RateLimit-Limit"].flatMap(Int.init)
     }
-    
+
     /// Rate limit remaining requests in current window (X-RateLimit-Remaining)
     public var rateLimitRemaining: Int? {
         headers["X-RateLimit-Remaining"].flatMap(Int.init)
     }
-    
+
     /// Rate limit window reset time as Unix timestamp (X-RateLimit-Reset)
     public var rateLimitReset: Date? {
         headers["X-RateLimit-Reset"]
@@ -86,12 +86,12 @@ extension TootResponse {
     public var contentType: String? {
         headers["Content-Type"]
     }
-    
+
     /// Response content length (Content-Length)
     public var contentLength: Int? {
         headers["Content-Length"].flatMap(Int.init)
     }
-    
+
     /// Response content encoding (Content-Encoding)
     public var contentEncoding: String? {
         headers["Content-Encoding"]
@@ -105,12 +105,12 @@ extension TootResponse {
     public var cacheControl: String? {
         headers["Cache-Control"]
     }
-    
+
     /// Entity tag for caching (ETag)
     public var etag: String? {
         headers["ETag"]
     }
-    
+
     /// Last modified timestamp (Last-Modified)
     public var lastModified: Date? {
         headers["Last-Modified"].flatMap { dateString in
@@ -129,12 +129,12 @@ extension TootResponse {
     public var server: String? {
         headers["Server"]
     }
-    
+
     /// Request ID for debugging (X-Request-Id, X-Request-ID)
     public var requestId: String? {
         headers["X-Request-Id"] ?? headers["X-Request-ID"]
     }
-    
+
     /// Response time information (X-Response-Time)
     public var responseTime: String? {
         headers["X-Response-Time"]
@@ -148,27 +148,27 @@ extension TootResponse {
     public var mastodonVersion: String? {
         headers["Mastodon-Version"]
     }
-    
+
     /// Instance name (X-Instance-Name)
     public var instanceName: String? {
         headers["X-Instance-Name"]
     }
-    
+
     /// Instance software type (X-Software-Name)
     public var softwareName: String? {
         headers["X-Software-Name"]
     }
-    
+
     /// Instance software version (X-Software-Version)
     public var softwareVersion: String? {
         headers["X-Software-Version"]
     }
-    
+
     /// Deprecated API endpoint warning (Deprecation)
     public var deprecationWarning: String? {
         headers["Deprecation"]
     }
-    
+
     /// Sunset warning for API endpoint (Sunset)
     public var sunsetWarning: String? {
         headers["Sunset"]
@@ -182,17 +182,17 @@ extension TootResponse {
     public var contentSecurityPolicy: String? {
         headers["Content-Security-Policy"]
     }
-    
+
     /// Strict Transport Security (Strict-Transport-Security)
     public var strictTransportSecurity: String? {
         headers["Strict-Transport-Security"]
     }
-    
+
     /// X-Frame-Options header (X-Frame-Options)
     public var xFrameOptions: String? {
         headers["X-Frame-Options"]
     }
-    
+
     /// X-Content-Type-Options header (X-Content-Type-Options)
     public var xContentTypeOptions: String? {
         headers["X-Content-Type-Options"]
@@ -206,22 +206,22 @@ extension TootResponse {
     public var isSuccessful: Bool {
         (200...299).contains(statusCode)
     }
-    
+
     /// Indicates if the response was a redirection (status code 3xx)
     public var isRedirection: Bool {
         (300...399).contains(statusCode)
     }
-    
+
     /// Indicates if the response was a client error (status code 4xx)
     public var isClientError: Bool {
         (400...499).contains(statusCode)
     }
-    
+
     /// Indicates if the response was a server error (status code 5xx)
     public var isServerError: Bool {
         (500...599).contains(statusCode)
     }
-    
+
     /// Get header value with case-insensitive lookup
     ///
     /// - Parameter name: Header name (case-insensitive)
@@ -235,7 +235,7 @@ extension TootResponse {
         }
         return nil
     }
-    
+
     /// Get all headers matching a prefix (case-insensitive)
     ///
     /// - Parameter prefix: Header name prefix (case-insensitive)
@@ -243,13 +243,13 @@ extension TootResponse {
     public func headers(withPrefix prefix: String) -> [String: String] {
         let lowercasePrefix = prefix.lowercased()
         var matchingHeaders: [String: String] = [:]
-        
+
         for (key, value) in headers {
             if key.lowercased().hasPrefix(lowercasePrefix) {
                 matchingHeaders[key] = value
             }
         }
-        
+
         return matchingHeaders
     }
 }

--- a/Sources/TootSDK/Models/TootResponse.swift
+++ b/Sources/TootSDK/Models/TootResponse.swift
@@ -1,0 +1,255 @@
+// ABOUTME: TootResponse wrapper type that exposes HTTP response metadata alongside decoded data
+// ABOUTME: Provides access to headers, status codes, URLs, and raw response bodies for debugging
+
+import Foundation
+
+/// A wrapper type that contains both the decoded response data and HTTP response metadata
+///
+/// This type allows access to HTTP headers, status codes, and other response metadata
+/// alongside the decoded API response data. It's used by "Raw" methods to provide
+/// complete access to the HTTP response while maintaining backward compatibility.
+///
+/// Example usage:
+/// ```swift
+/// let response = try await client.getListsRaw()
+/// let lists = response.data
+/// let rateLimit = response.rateLimitRemaining
+/// let linkHeader = response.linkHeader
+/// ```
+public struct TootResponse<T> {
+    /// The decoded response data (original return type)
+    public let data: T
+    
+    /// HTTP response headers as key-value pairs
+    public let headers: [String: String]
+    
+    /// HTTP status code
+    public let statusCode: Int
+    
+    /// Response URL
+    public let url: URL?
+    
+    /// Raw response body as Data (for debugging/fallback parsing)
+    public let rawBody: Data
+    
+    /// Creates a new TootResponse with the provided data and metadata
+    ///
+    /// - Parameters:
+    ///   - data: The decoded response data
+    ///   - headers: HTTP response headers
+    ///   - statusCode: HTTP status code
+    ///   - url: Response URL
+    ///   - rawBody: Raw response body
+    public init(data: T, headers: [String: String], statusCode: Int, url: URL?, rawBody: Data) {
+        self.data = data
+        self.headers = headers
+        self.statusCode = statusCode
+        self.url = url
+        self.rawBody = rawBody
+    }
+}
+
+// MARK: - Rate Limiting Headers
+
+extension TootResponse {
+    /// Rate limit maximum requests per window (X-RateLimit-Limit)
+    public var rateLimitLimit: Int? {
+        headers["X-RateLimit-Limit"].flatMap(Int.init)
+    }
+    
+    /// Rate limit remaining requests in current window (X-RateLimit-Remaining)
+    public var rateLimitRemaining: Int? {
+        headers["X-RateLimit-Remaining"].flatMap(Int.init)
+    }
+    
+    /// Rate limit window reset time as Unix timestamp (X-RateLimit-Reset)
+    public var rateLimitReset: Date? {
+        headers["X-RateLimit-Reset"]
+            .flatMap(TimeInterval.init)
+            .map(Date.init(timeIntervalSince1970:))
+    }
+}
+
+// MARK: - Pagination Headers
+
+extension TootResponse {
+    /// Link header for pagination navigation (Link)
+    public var linkHeader: String? {
+        headers["Link"]
+    }
+}
+
+// MARK: - Content Headers
+
+extension TootResponse {
+    /// Response content type (Content-Type)
+    public var contentType: String? {
+        headers["Content-Type"]
+    }
+    
+    /// Response content length (Content-Length)
+    public var contentLength: Int? {
+        headers["Content-Length"].flatMap(Int.init)
+    }
+    
+    /// Response content encoding (Content-Encoding)
+    public var contentEncoding: String? {
+        headers["Content-Encoding"]
+    }
+}
+
+// MARK: - Cache Headers
+
+extension TootResponse {
+    /// Cache control directive (Cache-Control)
+    public var cacheControl: String? {
+        headers["Cache-Control"]
+    }
+    
+    /// Entity tag for caching (ETag)
+    public var etag: String? {
+        headers["ETag"]
+    }
+    
+    /// Last modified timestamp (Last-Modified)
+    public var lastModified: Date? {
+        headers["Last-Modified"].flatMap { dateString in
+            let formatter = DateFormatter()
+            formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            return formatter.date(from: dateString)
+        }
+    }
+}
+
+// MARK: - Server Information Headers
+
+extension TootResponse {
+    /// Server software information (Server)
+    public var server: String? {
+        headers["Server"]
+    }
+    
+    /// Request ID for debugging (X-Request-Id, X-Request-ID)
+    public var requestId: String? {
+        headers["X-Request-Id"] ?? headers["X-Request-ID"]
+    }
+    
+    /// Response time information (X-Response-Time)
+    public var responseTime: String? {
+        headers["X-Response-Time"]
+    }
+}
+
+// MARK: - Mastodon/Fediverse Specific Headers
+
+extension TootResponse {
+    /// Mastodon version (Mastodon-Version)
+    public var mastodonVersion: String? {
+        headers["Mastodon-Version"]
+    }
+    
+    /// Instance name (X-Instance-Name)
+    public var instanceName: String? {
+        headers["X-Instance-Name"]
+    }
+    
+    /// Instance software type (X-Software-Name)
+    public var softwareName: String? {
+        headers["X-Software-Name"]
+    }
+    
+    /// Instance software version (X-Software-Version)
+    public var softwareVersion: String? {
+        headers["X-Software-Version"]
+    }
+    
+    /// Deprecated API endpoint warning (Deprecation)
+    public var deprecationWarning: String? {
+        headers["Deprecation"]
+    }
+    
+    /// Sunset warning for API endpoint (Sunset)
+    public var sunsetWarning: String? {
+        headers["Sunset"]
+    }
+}
+
+// MARK: - Security Headers
+
+extension TootResponse {
+    /// Content Security Policy (Content-Security-Policy)
+    public var contentSecurityPolicy: String? {
+        headers["Content-Security-Policy"]
+    }
+    
+    /// Strict Transport Security (Strict-Transport-Security)
+    public var strictTransportSecurity: String? {
+        headers["Strict-Transport-Security"]
+    }
+    
+    /// X-Frame-Options header (X-Frame-Options)
+    public var xFrameOptions: String? {
+        headers["X-Frame-Options"]
+    }
+    
+    /// X-Content-Type-Options header (X-Content-Type-Options)
+    public var xContentTypeOptions: String? {
+        headers["X-Content-Type-Options"]
+    }
+}
+
+// MARK: - Convenience Methods
+
+extension TootResponse {
+    /// Indicates if the response was successful (status code 2xx)
+    public var isSuccessful: Bool {
+        (200...299).contains(statusCode)
+    }
+    
+    /// Indicates if the response was a redirection (status code 3xx)
+    public var isRedirection: Bool {
+        (300...399).contains(statusCode)
+    }
+    
+    /// Indicates if the response was a client error (status code 4xx)
+    public var isClientError: Bool {
+        (400...499).contains(statusCode)
+    }
+    
+    /// Indicates if the response was a server error (status code 5xx)
+    public var isServerError: Bool {
+        (500...599).contains(statusCode)
+    }
+    
+    /// Get header value with case-insensitive lookup
+    ///
+    /// - Parameter name: Header name (case-insensitive)
+    /// - Returns: Header value if found
+    public func header(named name: String) -> String? {
+        let lowercaseName = name.lowercased()
+        for (key, value) in headers {
+            if key.lowercased() == lowercaseName {
+                return value
+            }
+        }
+        return nil
+    }
+    
+    /// Get all headers matching a prefix (case-insensitive)
+    ///
+    /// - Parameter prefix: Header name prefix (case-insensitive)
+    /// - Returns: Dictionary of matching headers
+    public func headers(withPrefix prefix: String) -> [String: String] {
+        let lowercasePrefix = prefix.lowercased()
+        var matchingHeaders: [String: String] = [:]
+        
+        for (key, value) in headers {
+            if key.lowercased().hasPrefix(lowercasePrefix) {
+                matchingHeaders[key] = value
+            }
+        }
+        
+        return matchingHeaders
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -30,16 +30,30 @@ extension TootClient {
     /// A test to make sure that the user token works, and retrieves the account information
     /// - Returns: Returns the current authenticated user's account, or throws an error if unable to retrieve
     public func verifyCredentials() async throws -> Account {
+        let response = try await verifyCredentialsRaw()
+        return response.data
+    }
+
+    /// A test to make sure that the user token works, and retrieves the account information with HTTP response metadata
+    /// - Returns: TootResponse containing the current authenticated user's account and HTTP metadata
+    public func verifyCredentialsRaw() async throws -> TootResponse<Account> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", "verify_credentials"])
             $0.method = .get
         }
-        return try await fetch(Account.self, req)
+        return try await fetchRaw(Account.self, req)
     }
 
-    /// Update the user’s display and preferences.
-    /// - Returns: The user’s own Account with source attribute
+    /// Update the user's display and preferences.
+    /// - Returns: The user's own Account with source attribute
     public func updateCredentials(params: UpdateCredentialsParams) async throws -> Account {
+        let response = try await updateCredentialsRaw(params: params)
+        return response.data
+    }
+
+    /// Update the user's display and preferences with HTTP response metadata
+    /// - Returns: TootResponse containing the user's own Account with source attribute and HTTP metadata
+    public func updateCredentialsRaw(params: UpdateCredentialsParams) async throws -> TootResponse<Account> {
         try requireFeature(.updateCredentials)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", "update_credentials"])
@@ -110,16 +124,23 @@ extension TootClient {
             parts.append(contentsOf: getSourceParts(params))
             $0.body = try .multipart(parts, boundary: UUID().uuidString)
         }
-        return try await fetch(Account.self, req)
+        return try await fetchRaw(Account.self, req)
     }
 
     /// Get preferences defined by the user in their account settings.
     public func getPreferences() async throws -> Preferences {
+        let response = try await getPreferencesRaw()
+        return response.data
+    }
+
+    /// Get preferences defined by the user in their account settings with HTTP response metadata
+    /// - Returns: TootResponse containing user preferences and HTTP metadata
+    public func getPreferencesRaw() async throws -> TootResponse<Preferences> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "preferences"])
             $0.method = .get
         }
-        return try await fetch(Preferences.self, req)
+        return try await fetchRaw(Preferences.self, req)
     }
 
     func getFieldParts(_ params: UpdateCredentialsParams) -> [MultipartPart] {
@@ -166,11 +187,19 @@ extension TootClient {
     /// - Parameter id: the ID of the Account in the instance database.
     /// - Returns: the account requested, or an error if unable to retrieve
     public func getAccount(by id: String) async throws -> Account {
+        let response = try await getAccountRaw(by: id)
+        return response.data
+    }
+
+    /// View information about a profile with HTTP response metadata
+    /// - Parameter id: the ID of the Account in the instance database.
+    /// - Returns: TootResponse containing the account requested and HTTP metadata
+    public func getAccountRaw(by id: String) async throws -> TootResponse<Account> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", id])
             $0.method = .get
         }
-        return try await fetch(Account.self, req)
+        return try await fetchRaw(Account.self, req)
     }
 
     /// Get all accounts which follow the given account, if network is not hidden by the account owner.
@@ -182,13 +211,26 @@ extension TootClient {
     public func getFollowers(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil)
         async throws -> PagedResult<[Account]>
     {
+        let response = try await getFollowersRaw(for: id, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get all accounts which follow the given account, if network is not hidden by the account owner, with HTTP response metadata
+    /// - Parameters
+    ///     - id: the ID of the Account in the instance database.
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: TootResponse containing the accounts requested and HTTP metadata
+    public func getFollowersRaw(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil)
+        async throws -> TootResponse<PagedResult<[Account]>>
+    {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", id, "followers"])
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Get all accounts which the given account is following, if network is not hidden by the account owner.
@@ -200,19 +242,40 @@ extension TootClient {
     public func getFollowing(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil)
         async throws -> PagedResult<[Account]>
     {
+        let response = try await getFollowingRaw(for: id, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get all accounts which the given account is following, if network is not hidden by the account owner, with HTTP response metadata
+    /// - Parameters:
+    ///     - id: the ID of the Account in the instance database.
+    ///     - pageInfo: PagedInfo object for max/min/since
+    ///     - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: TootResponse containing the accounts requested and HTTP metadata
+    public func getFollowingRaw(for id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil)
+        async throws -> TootResponse<PagedResult<[Account]>>
+    {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", id, "following"])
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Attempts to register a user.
     ///
     /// Returns an account access token for the app that initiated the request. The app should save this token for later, and should wait for the user to confirm their account by clicking a link in their email inbox.
     public func registerAccount(params: RegisterAccountParams) async throws -> AccessToken {
+        let response = try await registerAccountRaw(params: params)
+        return response.data
+    }
+
+    /// Attempts to register a user with HTTP response metadata
+    ///
+    /// Returns TootResponse containing an account access token for the app that initiated the request and HTTP metadata. The app should save this token for later, and should wait for the user to confirm their account by clicking a link in their email inbox.
+    public func registerAccountRaw(params: RegisterAccountParams) async throws -> TootResponse<AccessToken> {
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts"])
             $0.method = .post
@@ -220,8 +283,24 @@ extension TootClient {
         }
 
         do {
-            let (data, _) = try await fetch(req: req)
-            return try decode(AccessToken.self, from: data)
+            let (data, response) = try await fetch(req: req)
+            let decodedData = try decode(AccessToken.self, from: data)
+            
+            // Convert HTTPURLResponse headers to [String: String]
+            var headers: [String: String] = [:]
+            for (key, value) in response.allHeaderFields {
+                if let keyString = key as? String, let valueString = value as? String {
+                    headers[keyString] = valueString
+                }
+            }
+            
+            return TootResponse(
+                data: decodedData,
+                headers: headers,
+                statusCode: response.statusCode,
+                url: response.url,
+                rawBody: data
+            )
         } catch {
             if case let TootSDKError.invalidStatusCode(data, _) = error {
                 if let decoded = try? decode(RegisterAccountErrors.self, from: data),
@@ -244,44 +323,81 @@ extension TootClient {
     public func searchAccounts(params: SearchAccountsParams, limit: Int? = nil, offset: Int? = nil)
         async throws -> [Account]
     {
+        let response = try await searchAccountsRaw(params: params, limit: limit, offset: offset)
+        return response.data
+    }
+
+    /// Search for matching accounts by username or display name with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - params: The search parameters.
+    ///   - limit: Maximum number of results to return. Defaults to 40. Max 80 accounts.
+    ///   - offset: Skip the first n results.
+    /// - Returns: TootResponse containing search results and HTTP metadata.
+    public func searchAccountsRaw(params: SearchAccountsParams, limit: Int? = nil, offset: Int? = nil)
+        async throws -> TootResponse<[Account]>
+    {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", "search"])
             $0.method = .get
             $0.query = getQueryParams(limit: limit, offset: offset) + params.queryItems
         }
-        return try await fetch([Account].self, req)
+        return try await fetchRaw([Account].self, req)
     }
 
     /// Retrieve lists in which the given account `id` is present
     public func getListsContainingAccount(id: String) async throws -> [List] {
+        let response = try await getListsContainingAccountRaw(id: id)
+        return response.data
+    }
+
+    /// Retrieve lists in which the given account `id` is present with HTTP response metadata
+    /// - Returns: TootResponse containing lists in which the account is present and HTTP metadata
+    public func getListsContainingAccountRaw(id: String) async throws -> TootResponse<[List]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", id, "lists"])
             $0.method = .get
         }
 
-        return try await fetch([List].self, req)
+        return try await fetchRaw([List].self, req)
     }
 
-    /// Deletes the avatar associated with the user’s profile.
+    /// Deletes the avatar associated with the user's profile.
     @discardableResult
     public func deleteProfileAvatar() async throws -> Account {
+        let response = try await deleteProfileAvatarRaw()
+        return response.data
+    }
+
+    /// Deletes the avatar associated with the user's profile with HTTP response metadata
+    /// - Returns: TootResponse containing the updated account and HTTP metadata
+    @discardableResult
+    public func deleteProfileAvatarRaw() async throws -> TootResponse<Account> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "profile", "avatar"])
             $0.method = .delete
         }
 
-        return try await fetch(Account.self, req)
+        return try await fetchRaw(Account.self, req)
     }
 
-    /// Deletes the header image associated with the user’s profile.
+    /// Deletes the header image associated with the user's profile.
     @discardableResult
     public func deleteProfileHeader() async throws -> Account {
+        let response = try await deleteProfileHeaderRaw()
+        return response.data
+    }
+
+    /// Deletes the header image associated with the user's profile with HTTP response metadata
+    /// - Returns: TootResponse containing the updated account and HTTP metadata
+    @discardableResult
+    public func deleteProfileHeaderRaw() async throws -> TootResponse<Account> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "profile", "header"])
             $0.method = .delete
         }
 
-        return try await fetch(Account.self, req)
+        return try await fetchRaw(Account.self, req)
     }
 
     // TODO: - Lookup account ID from Webfinger address

--- a/Sources/TootSDK/TootClient/TootClient+Account.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Account.swift
@@ -285,7 +285,7 @@ extension TootClient {
         do {
             let (data, response) = try await fetch(req: req)
             let decodedData = try decode(AccessToken.self, from: data)
-            
+
             // Convert HTTPURLResponse headers to [String: String]
             var headers: [String: String] = [:]
             for (key, value) in response.allHeaderFields {
@@ -293,7 +293,7 @@ extension TootClient {
                     headers[keyString] = valueString
                 }
             }
-            
+
             return TootResponse(
                 data: decodedData,
                 headers: headers,

--- a/Sources/TootSDK/TootClient/TootClient+Announcements.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Announcements.swift
@@ -11,6 +11,13 @@ extension TootClient {
 
     /// See all currently active announcements set by admins.
     public func getAnnouncements(params: AnnouncementParams = .init()) async throws -> [Announcement] {
+        let response = try await getAnnouncementsRaw(params: params)
+        return response.data
+    }
+
+    /// See all currently active announcements set by admins with HTTP response metadata
+    /// - Returns: TootResponse containing announcements and HTTP metadata
+    public func getAnnouncementsRaw(params: AnnouncementParams = .init()) async throws -> TootResponse<[Announcement]> {
         try requireFeature(.announcements)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "announcements"])
@@ -18,7 +25,7 @@ extension TootClient {
             $0.query = params.queryItems
         }
 
-        return try await fetch([Announcement].self, req)
+        return try await fetchRaw([Announcement].self, req)
     }
 
     /// Dismiss a single notification from the server.

--- a/Sources/TootSDK/TootClient/TootClient+Conversation.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Conversation.swift
@@ -13,6 +13,15 @@ extension TootClient {
     ///
     /// Direct conversations with other participants. (Currently, just threads containing a post with "direct" visibility.)
     public func getConversations(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Conversation]> {
+        let response = try await getConversationsRaw(pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Return all conversations with HTTP response metadata
+    ///
+    /// Direct conversations with other participants. (Currently, just threads containing a post with "direct" visibility.)
+    /// - Returns: TootResponse containing paginated conversations and HTTP metadata
+    public func getConversationsRaw(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Conversation]>> {
         try requireFeature(.conversations)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "conversations"])
@@ -20,7 +29,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Removes a conversation from your list of conversations.
@@ -36,13 +45,20 @@ extension TootClient {
 
     /// Mark a conversation as read
     public func setConversationAsRead(id: String) async throws -> Conversation {
+        let response = try await setConversationAsReadRaw(id: id)
+        return response.data
+    }
+
+    /// Mark a conversation as read with HTTP response metadata
+    /// - Returns: TootResponse containing the updated conversation and HTTP metadata
+    public func setConversationAsReadRaw(id: String) async throws -> TootResponse<Conversation> {
         try requireFeature(.conversations)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "conversations", id, "read"])
             $0.method = .post
         }
 
-        return try await fetch(Conversation.self, req)
+        return try await fetchRaw(Conversation.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
+++ b/Sources/TootSDK/TootClient/TootClient+DomainBlocks.swift
@@ -12,6 +12,13 @@ extension TootClient {
     /// Show information about all blocked domains.
     /// - Returns: array of blocked domains
     public func adminGetDomainBlocks() async throws -> [DomainBlock] {
+        let response = try await adminGetDomainBlocksRaw()
+        return response.data
+    }
+
+    /// Show information about all blocked domains with HTTP response metadata
+    /// - Returns: TootResponse containing array of blocked domains and HTTP metadata
+    public func adminGetDomainBlocksRaw() async throws -> TootResponse<[DomainBlock]> {
         try requireFeature(.adminDomainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks"])
@@ -19,20 +26,28 @@ extension TootClient {
 
         }
 
-        return try await fetch([DomainBlock].self, req)
+        return try await fetchRaw([DomainBlock].self, req)
     }
 
     /// Show information about a single blocked domain.
     /// - Parameter id: The ID of the DomainBlock in the instance's database
     /// - Returns: DomainBlock (optional)
     public func adminGetDomainBlock(id: String) async throws -> DomainBlock? {
+        let response = try? await adminGetDomainBlockRaw(id: id)
+        return response?.data
+    }
+
+    /// Show information about a single blocked domain with HTTP response metadata
+    /// - Parameter id: The ID of the DomainBlock in the instance's database
+    /// - Returns: TootResponse containing DomainBlock and HTTP metadata
+    public func adminGetDomainBlockRaw(id: String) async throws -> TootResponse<DomainBlock> {
         try requireFeature(.adminDomainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks", id])
             $0.method = .get
         }
 
-        return try? await fetch(DomainBlock.self, req)
+        return try await fetchRaw(DomainBlock.self, req)
     }
 
     /// Blocks a domain on the current instance.
@@ -43,6 +58,19 @@ extension TootClient {
     ///
     /// Note that the call will be successful even if the domain is already blocked, or if the domain does not exist, or if the domain is not a domain.
     public func adminBlockDomain(params: BlockDomainParams) async throws -> DomainBlock {
+        let response = try await adminBlockDomainRaw(params: params)
+        return response.data
+    }
+
+    /// Blocks a domain on the current instance with HTTP response metadata
+    /// * hide all public posts from it
+    /// * hide all notifications from it
+    /// * remove all followers from it
+    /// * prevent following new users from it (but does not remove existing follows)
+    ///
+    /// Note that the call will be successful even if the domain is already blocked, or if the domain does not exist, or if the domain is not a domain.
+    /// - Returns: TootResponse containing the blocked domain and HTTP metadata
+    public func adminBlockDomainRaw(params: BlockDomainParams) async throws -> TootResponse<DomainBlock> {
         try requireFeature(.adminDomainBlocks)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "admin", "domain_blocks"])
@@ -50,7 +78,7 @@ extension TootClient {
             $0.body = try .multipart(params, boundary: UUID().uuidString)
         }
 
-        return try await fetch(DomainBlock.self, req)
+        return try await fetchRaw(DomainBlock.self, req)
     }
 
     /// Lift a block against a domain.
@@ -75,13 +103,23 @@ extension TootClient {
     ///   - limit: Maximum number of results to return. Defaults to 40.
     /// - Returns: Paginated response with an array of sttrings
     public func userGetDomainBlocks(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[String]> {
+        let response = try await userGetDomainBlocksRaw(pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// View domains the user has blocked with HTTP response metadata
+    /// - Parameters:
+    ///   - pageInfo: PagedInfo object for max/min/since ids
+    ///   - limit: Maximum number of results to return. Defaults to 40.
+    /// - Returns: TootResponse containing paginated response with an array of strings and HTTP metadata
+    public func userGetDomainBlocksRaw(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[String]>> {
         try requireFeature(.domainBlocks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "domain_blocks"])
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Blocks a domain on the current instance.

--- a/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FeaturedTags.swift
@@ -14,12 +14,22 @@ extension TootClient {
     /// - Returns: The featured tags or an error if unable to retrieve.
     /// - Note: Requires featured tags feature to be available.
     public func getFeaturedTags(forUser userID: String) async throws -> [FeaturedTag] {
+        let response = try await getFeaturedTagsRaw(forUser: userID)
+        return response.data
+    }
+
+    /// Get tags featured by user with HTTP response metadata
+    ///
+    /// - Parameter userID: ID of user in database.
+    /// - Returns: TootResponse containing the featured tags and HTTP metadata
+    /// - Note: Requires featured tags feature to be available.
+    public func getFeaturedTagsRaw(forUser userID: String) async throws -> TootResponse<[FeaturedTag]> {
         try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "accounts", userID, "featured_tags"])
             $0.method = .get
         }
-        return try await fetch([FeaturedTag].self, req)
+        return try await fetchRaw([FeaturedTag].self, req)
     }
 
     /// List all hashtags featured on your profile.
@@ -27,12 +37,21 @@ extension TootClient {
     /// - Returns: The featured tags or an error if unable to retrieve.
     /// - Note: Requires featured tags feature to be available.
     public func getFeaturedTags() async throws -> [FeaturedTag] {
+        let response = try await getFeaturedTagsRaw()
+        return response.data
+    }
+
+    /// List all hashtags featured on your profile with HTTP response metadata
+    ///
+    /// - Returns: TootResponse containing the featured tags and HTTP metadata
+    /// - Note: Requires featured tags feature to be available.
+    public func getFeaturedTagsRaw() async throws -> TootResponse<[FeaturedTag]> {
         try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
             $0.method = .get
         }
-        return try await fetch([FeaturedTag].self, req)
+        return try await fetchRaw([FeaturedTag].self, req)
     }
 
     /// Shows up to 10 recently-used tags.
@@ -40,13 +59,22 @@ extension TootClient {
     /// - Returns: Array of ``Tag``.
     /// - Note: Requires featured tags feature to be available.
     public func getFeaturedTagsSuggestions() async throws -> [Tag] {
+        let response = try await getFeaturedTagsSuggestionsRaw()
+        return response.data
+    }
+
+    /// Shows up to 10 recently-used tags with HTTP response metadata
+    ///
+    /// - Returns: TootResponse containing array of Tags and HTTP metadata
+    /// - Note: Requires featured tags feature to be available.
+    public func getFeaturedTagsSuggestionsRaw() async throws -> TootResponse<[Tag]> {
         try requireFeature(.featuredTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags", "suggestions"])
             $0.method = .get
         }
 
-        return try await fetch([Tag].self, req)
+        return try await fetchRaw([Tag].self, req)
     }
 
     /// Promote a hashtag on your profile.
@@ -54,6 +82,16 @@ extension TootClient {
     /// - Note: Requires featured tags feature to be available.
     @discardableResult
     public func featureTag(name: String) async throws -> FeaturedTag {
+        let response = try await featureTagRaw(name: name)
+        return response.data
+    }
+
+    /// Promote a hashtag on your profile with HTTP response metadata
+    /// - Parameter name: The hashtag to be featured, without the hash sign.
+    /// - Returns: TootResponse containing the featured tag and HTTP metadata
+    /// - Note: Requires featured tags feature to be available.
+    @discardableResult
+    public func featureTagRaw(name: String) async throws -> TootResponse<FeaturedTag> {
         try requireFeature(.featuredTags)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "featured_tags"])
@@ -63,7 +101,7 @@ extension TootClient {
                 encoder: self.encoder)
         }
 
-        return try await fetch(FeaturedTag.self, req)
+        return try await fetchRaw(FeaturedTag.self, req)
     }
 
     /// Stop promoting a hashtag on your profile.

--- a/Sources/TootSDK/TootClient/TootClient+Filters.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Filters.swift
@@ -13,12 +13,20 @@ extension TootClient {
     ///
     /// - Returns: The filters or an error if unable to retrieve.
     public func getFilters() async throws -> [Filter] {
+        let response = try await getFiltersRaw()
+        return response.data
+    }
+
+    /// Obtain a list of all filter groups for the current user with HTTP response metadata
+    ///
+    /// - Returns: TootResponse containing the filters and HTTP metadata
+    public func getFiltersRaw() async throws -> TootResponse<[Filter]> {
         try requireFeature(.filtersV2)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "filters"])
             $0.method = .get
         }
-        return try await fetch([Filter].self, req)
+        return try await fetchRaw([Filter].self, req)
     }
 
     /// Obtain a single filter group owned by the current user.
@@ -27,12 +35,22 @@ extension TootClient {
     ///   - id: The ID of the Filter in the database.
     /// - Returns: the Filter, if successful, throws an error if not
     public func getFilter(id: String) async throws -> Filter {
+        let response = try await getFilterRaw(id: id)
+        return response.data
+    }
+
+    /// Obtain a single filter group owned by the current user with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the Filter in the database.
+    /// - Returns: TootResponse containing the Filter and HTTP metadata
+    public func getFilterRaw(id: String) async throws -> TootResponse<Filter> {
         try requireFeature(.filtersV2)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "filters", id])
             $0.method = .get
         }
-        return try await fetch(Filter.self, req)
+        return try await fetchRaw(Filter.self, req)
     }
 
     /// Delete a filter
@@ -54,13 +72,23 @@ extension TootClient {
     /// - Returns: The created filter.
     @discardableResult
     public func createFilter(_ params: CreateFilterParams) async throws -> Filter {
+        let response = try await createFilterRaw(params)
+        return response.data
+    }
+
+    /// Create a filter with HTTP response metadata
+    ///
+    /// - Parameter params: Parameters of filter to create.
+    /// - Returns: TootResponse containing the created filter and HTTP metadata
+    @discardableResult
+    public func createFilterRaw(_ params: CreateFilterParams) async throws -> TootResponse<Filter> {
         try requireFeature(.filtersV2)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "filters"])
             $0.method = .post
             $0.body = try .form(queryItems: params.queryItems)
         }
-        return try await fetch(Filter.self, req)
+        return try await fetchRaw(Filter.self, req)
     }
 
     /// Update a filter.
@@ -69,13 +97,23 @@ extension TootClient {
     /// - Returns: The updated filter.
     @discardableResult
     public func updateFilter(_ params: UpdateFilterParams) async throws -> Filter {
+        let response = try await updateFilterRaw(params)
+        return response.data
+    }
+
+    /// Update a filter with HTTP response metadata
+    ///
+    /// - Parameter params: Parameters of filter update.
+    /// - Returns: TootResponse containing the updated filter and HTTP metadata
+    @discardableResult
+    public func updateFilterRaw(_ params: UpdateFilterParams) async throws -> TootResponse<Filter> {
         try requireFeature(.filtersV2)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "filters", params.id])
             $0.method = .put
             $0.body = try .form(queryItems: params.queryItems)
         }
-        return try await fetch(Filter.self, req)
+        return try await fetchRaw(Filter.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
+++ b/Sources/TootSDK/TootClient/TootClient+FollowRequests.swift
@@ -17,13 +17,25 @@ extension TootClient {
     /// - Returns: The accounts that are requesting a follow.
     @available(*, deprecated, renamed: "getFollowRequests")
     public func getPendingFollowRequests(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> [Account] {
+        let response = try await getPendingFollowRequestsRaw(pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get pending follow requests with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///    - pageInfo: PagedInfo object for max/since.
+    ///    - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: TootResponse containing the accounts that are requesting a follow and HTTP metadata
+    @available(*, deprecated, renamed: "getFollowRequestsRaw")
+    public func getPendingFollowRequestsRaw(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<[Account]> {
         try requireFeature(.followRequests)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "follow_requests"])
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
-        return try await fetch([Account].self, req)
+        return try await fetchRaw([Account].self, req)
     }
 
     /// Get pending follow requests.
@@ -33,6 +45,17 @@ extension TootClient {
     ///    - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
     /// - Returns: The accounts that are requesting a follow. Some server flavours may ignore the limit and return all requests.
     public func getFollowRequests(_ pageInfo: PagedInfo? = nil, limit: Int = 40) async throws -> PagedResult<[Account]> {
+        let response = try await getFollowRequestsRaw(pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get pending follow requests with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///    - pageInfo: PagedInfo object for max/since.
+    ///    - limit: Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+    /// - Returns: TootResponse containing the accounts that are requesting a follow and HTTP metadata
+    public func getFollowRequestsRaw(_ pageInfo: PagedInfo? = nil, limit: Int = 40) async throws -> TootResponse<PagedResult<[Account]>> {
         let requestLimit = min(limit, 80)
         try requireFeature(.followRequests)
         let req = HTTPRequestBuilder {
@@ -40,7 +63,7 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: requestLimit)
         }
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Accept a follow request.
@@ -49,12 +72,22 @@ extension TootClient {
     /// - Returns: Relationship with the account.
     @discardableResult
     public func acceptFollowRequest(id: String) async throws -> Relationship {
+        let response = try await acceptFollowRequestRaw(id: id)
+        return response.data
+    }
+
+    /// Accept a follow request with HTTP response metadata
+    ///
+    /// - Parameter id: The id of the account received from ``getPendingFollowRequests``.
+    /// - Returns: TootResponse containing the relationship with the account and HTTP metadata
+    @discardableResult
+    public func acceptFollowRequestRaw(id: String) async throws -> TootResponse<Relationship> {
         try requireFeature(.followRequests)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "follow_requests", id, "authorize"])
             $0.method = .post
         }
-        return try await fetch(Relationship.self, req)
+        return try await fetchRaw(Relationship.self, req)
     }
 
     /// Reject a follow request.
@@ -63,12 +96,22 @@ extension TootClient {
     /// - Returns: Relationship with the account.
     @discardableResult
     public func rejectFollowRequest(id: String) async throws -> Relationship {
+        let response = try await rejectFollowRequestRaw(id: id)
+        return response.data
+    }
+
+    /// Reject a follow request with HTTP response metadata
+    ///
+    /// - Parameter id: The id of the account received from ``getPendingFollowRequests``.
+    /// - Returns: TootResponse containing the relationship with the account and HTTP metadata
+    @discardableResult
+    public func rejectFollowRequestRaw(id: String) async throws -> TootResponse<Relationship> {
         try requireFeature(.followRequests)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "follow_requests", id, "reject"])
             $0.method = .post
         }
-        return try await fetch(Relationship.self, req)
+        return try await fetchRaw(Relationship.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -14,11 +14,34 @@ extension TootClient {
     ///
     /// If you require information that is only provided by a specific version of the Instance API, use ``getInstanceInfoV1()`` or ``getInstanceInfoV2()``.
     public func getInstanceInfo() async throws -> any Instance {
+        let response = try await getInstanceInfoRaw()
+        return response.data
+    }
+
+    /// Obtain general information about the server from the latest supported API version with HTTP response metadata
+    ///
+    /// If the server is known to be a flavour that supports the V2 Instance API, returns an ``InstanceV2``; otherwise, returns an ``InstanceV1``.
+    /// - Returns: TootResponse containing the instance info and HTTP metadata
+    public func getInstanceInfoRaw() async throws -> TootResponse<any Instance> {
         do {
             try requireFeature(.instanceV2)
-            return try await getInstanceInfoV2()
+            let response = try await getInstanceInfoV2Raw()
+            return TootResponse(
+                data: response.data as any Instance,
+                headers: response.headers,
+                statusCode: response.statusCode,
+                url: response.url,
+                rawBody: response.rawBody
+            )
         } catch TootSDKError.unsupportedFlavour(_, _) {
-            return try await getInstanceInfoV1()
+            let response = try await getInstanceInfoV1Raw()
+            return TootResponse(
+                data: response.data as any Instance,
+                headers: response.headers,
+                statusCode: response.statusCode,
+                url: response.url,
+                rawBody: response.rawBody
+            )
         }
     }
 
@@ -26,50 +49,89 @@ extension TootClient {
     ///
     /// This API version was deprecated by Mastodon, but may be used by other instance flavours.
     public func getInstanceInfoV1() async throws -> InstanceV1 {
+        let response = try await getInstanceInfoV1Raw()
+        return response.data
+    }
+
+    /// Obtain general information about the server from the V1 API with HTTP response metadata
+    ///
+    /// This API version was deprecated by Mastodon, but may be used by other instance flavours.
+    /// - Returns: TootResponse containing the instance info V1 and HTTP metadata
+    public func getInstanceInfoV1Raw() async throws -> TootResponse<InstanceV1> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance"])
             $0.method = .get
         }
-        return try await fetch(InstanceV1.self, req)
+        return try await fetchRaw(InstanceV1.self, req)
     }
 
     /// Obtain general information about the server from the V2 API.
     ///
     /// > Important: Not all instance flavours support the V2 API; see ``TootFeature/instanceV2``. Consider checking for support using ``supportsFeature(_:)`` before calling this, otherwise it may fail.
     public func getInstanceInfoV2() async throws -> InstanceV2 {
+        let response = try await getInstanceInfoV2Raw()
+        return response.data
+    }
+
+    /// Obtain general information about the server from the V2 API with HTTP response metadata
+    ///
+    /// > Important: Not all instance flavours support the V2 API; see ``TootFeature/instanceV2``. Consider checking for support using ``supportsFeature(_:)`` before calling this, otherwise it may fail.
+    /// - Returns: TootResponse containing the instance info V2 and HTTP metadata
+    public func getInstanceInfoV2Raw() async throws -> TootResponse<InstanceV2> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "instance"])
             $0.method = .get
         }
-        return try await fetch(InstanceV2.self, req)
+        return try await fetchRaw(InstanceV2.self, req)
     }
 
     public func getInstanceRules() async throws -> [InstanceRule] {
+        let response = try await getInstanceRulesRaw()
+        return response.data
+    }
+
+    /// Get instance rules with HTTP response metadata
+    /// - Returns: TootResponse containing the instance rules and HTTP metadata
+    public func getInstanceRulesRaw() async throws -> TootResponse<[InstanceRule]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "rules"])
             $0.method = .get
         }
-        return try await fetch([InstanceRule].self, req)
+        return try await fetchRaw([InstanceRule].self, req)
     }
 
     /// Obtain an extended description of this server
     public func getExtendedDescription() async throws -> ExtendedDescription {
+        let response = try await getExtendedDescriptionRaw()
+        return response.data
+    }
+
+    /// Obtain an extended description of this server with HTTP response metadata
+    /// - Returns: TootResponse containing the extended description and HTTP metadata
+    public func getExtendedDescriptionRaw() async throws -> TootResponse<ExtendedDescription> {
         try requireFeature(.extendedDescription)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "extended_description"])
             $0.method = .get
         }
-        return try await fetch(ExtendedDescription.self, req)
+        return try await fetchRaw(ExtendedDescription.self, req)
     }
 
     /// Obtain the content of this server's privacy policy.
     /// - Returns: A ``PrivacyPolicy`` instance containing the content of the privacy policy.
     public func getPrivacyPolicy() async throws -> PrivacyPolicy {
+        let response = try await getPrivacyPolicyRaw()
+        return response.data
+    }
+
+    /// Obtain the content of this server's privacy policy with HTTP response metadata
+    /// - Returns: TootResponse containing the privacy policy and HTTP metadata
+    public func getPrivacyPolicyRaw() async throws -> TootResponse<PrivacyPolicy> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "privacy_policy"])
             $0.method = .get
         }
-        return try await fetch(PrivacyPolicy.self, req)
+        return try await fetchRaw(PrivacyPolicy.self, req)
     }
 
     /// Obtain the content of this server's most current terms of service, if configured.
@@ -77,11 +139,20 @@ extension TootClient {
     ///
     /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
     public func getTermsOfService() async throws -> TermsOfService {
+        let response = try await getTermsOfServiceRaw()
+        return response.data
+    }
+
+    /// Obtain the content of this server's most current terms of service with HTTP response metadata
+    /// - Returns: TootResponse containing the terms of service and HTTP metadata
+    ///
+    /// Expected to return `404` if the instance has not configured its optional terms of service, even if it supports this endpoint.
+    public func getTermsOfServiceRaw() async throws -> TootResponse<TermsOfService> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "terms_of_service"])
             $0.method = .get
         }
-        return try await fetch(TermsOfService.self, req)
+        return try await fetchRaw(TermsOfService.self, req)
     }
 
     /// Obtain a specific dated version of this server's terms of service.
@@ -89,32 +160,55 @@ extension TootClient {
     ///
     /// Expected to return `404` if there is no terms of service with the exact effective date specified, or if the instance has not configured its optional terms of service.
     public func getTermsOfService(effectiveAsOf effectiveDate: Date) async throws -> TermsOfService {
+        let response = try await getTermsOfServiceRaw(effectiveAsOf: effectiveDate)
+        return response.data
+    }
+
+    /// Obtain a specific dated version of this server's terms of service with HTTP response metadata
+    /// - Returns: TootResponse containing the terms of service and HTTP metadata
+    ///
+    /// Expected to return `404` if there is no terms of service with the exact effective date specified, or if the instance has not configured its optional terms of service.
+    public func getTermsOfServiceRaw(effectiveAsOf effectiveDate: Date) async throws -> TootResponse<TermsOfService> {
         let encodedDate = TootEncoder.dateFormatterWithFullDate.string(from: effectiveDate)
 
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "terms_of_service", encodedDate])
             $0.method = .get
         }
-        return try await fetch(TermsOfService.self, req)
+        return try await fetchRaw(TermsOfService.self, req)
     }
 
     /// Translation language pairs supported by the translation engine used by the server.
     public func getTranslationLanguages() async throws -> [String: [String]] {
+        let response = try await getTranslationLanguagesRaw()
+        return response.data
+    }
+
+    /// Translation language pairs supported by the translation engine used by the server with HTTP response metadata
+    /// - Returns: TootResponse containing the translation languages and HTTP metadata
+    public func getTranslationLanguagesRaw() async throws -> TootResponse<[String: [String]]> {
         try requireFeature(.translatePost)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "translation_languages"])
             $0.method = .get
         }
-        return try await fetch([String: [String]].self, req)
+        return try await fetchRaw([String: [String]].self, req)
     }
 
     /// Get the human-readable names of the instance's supported languages, localized to the instance's primary language.
     public func getLanguages() async throws -> [InstanceLanguage] {
+        let response = try await getLanguagesRaw()
+        return response.data
+    }
+
+    /// Get the human-readable names of the instance's supported languages with HTTP response metadata
+    /// - Returns: TootResponse containing the instance languages and HTTP metadata
+    public func getLanguagesRaw() async throws -> TootResponse<[InstanceLanguage]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "languages"])
             $0.method = .get
         }
-        return try await fetch([InstanceLanguage].self, req)
+        return try await fetchRaw([InstanceLanguage].self, req)
     }
 
     /// Get the list of domains that this instance is aware of.
@@ -122,26 +216,51 @@ extension TootClient {
     ///
     /// Expected to return `401` if called without a user token if the instance is in limited federation mode.
     public func getPeers() async throws -> [String] {
+        let response = try await getPeersRaw()
+        return response.data
+    }
+
+    /// Get the list of domains that this instance is aware of with HTTP response metadata
+    /// - Returns: TootResponse containing array of domains and HTTP metadata
+    ///
+    /// Expected to return `401` if called without a user token if the instance is in limited federation mode.
+    public func getPeersRaw() async throws -> TootResponse<[String]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "peers"])
             $0.method = .get
         }
-        return try await fetch([String].self, req)
+        return try await fetchRaw([String].self, req)
     }
 
     /// Obtain a list of domains that have been blocked.
     ///
     /// Expected to return `401` if the admin has chosen to require authorization and none is provided, or `404` if the admin has chosen to hide domain blocks entirely.
     public func getDomainBlocks() async throws -> [InstanceDomainBlock] {
+        let response = try await getDomainBlocksRaw()
+        return response.data
+    }
+
+    /// Obtain a list of domains that have been blocked with HTTP response metadata
+    /// - Returns: TootResponse containing the domain blocks and HTTP metadata
+    ///
+    /// Expected to return `401` if the admin has chosen to require authorization and none is provided, or `404` if the admin has chosen to hide domain blocks entirely.
+    public func getDomainBlocksRaw() async throws -> TootResponse<[InstanceDomainBlock]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "instance", "domain_blocks"])
             $0.method = .get
         }
-        return try await fetch([InstanceDomainBlock].self, req)
+        return try await fetchRaw([InstanceDomainBlock].self, req)
     }
 
     /// Get node info.
     public func getNodeInfo() async throws -> NodeInfo {
+        let response = try await getNodeInfoRaw()
+        return response.data
+    }
+
+    /// Get node info with HTTP response metadata
+    /// - Returns: TootResponse containing the node info and HTTP metadata
+    public func getNodeInfoRaw() async throws -> TootResponse<NodeInfo> {
         let wellKnownReq = HTTPRequestBuilder {
             $0.url = getURL([".well-known", "nodeinfo"])
             $0.method = .get
@@ -154,7 +273,7 @@ extension TootClient {
             $0.url = URL(string: nodeInfo)
             $0.method = .get
         }
-        return try await fetch(NodeInfo.self, req)
+        return try await fetchRaw(NodeInfo.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+Lists.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Lists.swift
@@ -7,13 +7,20 @@ extension TootClient {
 
     /// Fetch all lists that the user owns.
     public func getLists() async throws -> [List] {
+        let response = try await getListsRaw()
+        return response.data
+    }
+
+    /// Fetch all lists that the user owns with HTTP response metadata
+    /// - Returns: TootResponse containing the lists and HTTP metadata
+    public func getListsRaw() async throws -> TootResponse<[List]> {
         try requireFeature(.lists)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "lists"])
             $0.method = .get
         }
 
-        return try await fetch([List].self, req)
+        return try await fetchRaw([List].self, req)
     }
 
     /// Fetch the list with the given ID. Used for verifying the title of a list, and which replies to show within that list.
@@ -21,18 +28,34 @@ extension TootClient {
     ///     - id: The ID of the List in the database.
     /// - Returns: the List, if successful, throws an error if not
     public func getList(id: String) async throws -> List {
+        let response = try await getListRaw(id: id)
+        return response.data
+    }
+
+    /// Fetch the list with the given ID with HTTP response metadata
+    /// - Parameters:
+    ///     - id: The ID of the List in the database.
+    /// - Returns: TootResponse containing the list and HTTP metadata
+    public func getListRaw(id: String) async throws -> TootResponse<List> {
         try requireFeature(.lists)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "lists", id])
             $0.method = .get
         }
 
-        return try await fetch(List.self, req)
+        return try await fetchRaw(List.self, req)
     }
 
     /// Create a new list.
     /// - Returns: the List created, if successful, throws an error if not
     public func createList(params: ListParams) async throws -> List {
+        let response = try await createListRaw(params: params)
+        return response.data
+    }
+
+    /// Create a new list with HTTP response metadata
+    /// - Returns: TootResponse containing the created list and HTTP metadata
+    public func createListRaw(params: ListParams) async throws -> TootResponse<List> {
         try requireFeature(.lists)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "lists"])
@@ -40,12 +63,19 @@ extension TootClient {
             $0.body = try .json(params, encoder: self.encoder)
         }
 
-        return try await fetch(List.self, req)
+        return try await fetchRaw(List.self, req)
     }
 
     /// Change the title of a list, or which replies to show.
     /// - Returns: the List created, if successful, throws an error if not
     public func createList(id: String, params: ListParams) async throws -> List {
+        let response = try await createListRaw(id: id, params: params)
+        return response.data
+    }
+
+    /// Change the title of a list, or which replies to show with HTTP response metadata
+    /// - Returns: TootResponse containing the updated list and HTTP metadata
+    public func createListRaw(id: String, params: ListParams) async throws -> TootResponse<List> {
         try requireFeature(.lists)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "lists", id])
@@ -53,7 +83,7 @@ extension TootClient {
             $0.body = try .json(params, encoder: self.encoder)
         }
 
-        return try await fetch(List.self, req)
+        return try await fetchRaw(List.self, req)
     }
 
     /// Delete a list
@@ -70,6 +100,13 @@ extension TootClient {
     /// View accounts in a list
     /// - Returns: a PagedResult with an array of accounts if successful, throws an error if not
     public func getListAccounts(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
+        let response = try await getListAccountsRaw(id: id, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// View accounts in a list with HTTP response metadata
+    /// - Returns: TootResponse containing paginated accounts and HTTP metadata
+    public func getListAccountsRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Account]>> {
         try requireFeature(.lists)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "lists", id, "accounts"])
@@ -77,7 +114,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Add accounts to a list

--- a/Sources/TootSDK/TootClient/TootClient+Markers.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Markers.swift
@@ -12,13 +12,22 @@ extension TootClient {
     ///
     /// - Parameter timelines: The timeline(s) for which markers should be fetched.
     public func getMarkers(for timelines: Set<Marker.Timeline>) async throws -> [OpenEnum<Marker.Timeline>: Marker] {
+        let response = try await getMarkersRaw(for: timelines)
+        return response.data
+    }
+
+    /// Get saved timeline positions with HTTP response metadata
+    ///
+    /// - Parameter timelines: The timeline(s) for which markers should be fetched.
+    /// - Returns: TootResponse containing the markers and HTTP metadata
+    public func getMarkersRaw(for timelines: Set<Marker.Timeline>) async throws -> TootResponse<[OpenEnum<Marker.Timeline>: Marker]> {
         try requireFeature(.markers)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "markers"])
             $0.method = .get
             $0.query = createQuery(timelines: timelines)
         }
-        return try await fetch([OpenEnum<Marker.Timeline>: Marker].self, req)
+        return try await fetchRaw([OpenEnum<Marker.Timeline>: Marker].self, req)
     }
 
     /// Save your position in a timeline
@@ -31,6 +40,21 @@ extension TootClient {
         homeLastReadId: String? = nil,
         notificationsLastReadId: String? = nil
     ) async throws -> [OpenEnum<Marker.Timeline>: Marker] {
+        let response = try await updateMarkersRaw(homeLastReadId: homeLastReadId, notificationsLastReadId: notificationsLastReadId)
+        return response.data
+    }
+
+    /// Save your position in a timeline with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - homeLastReadId: ID of the last status read in the home timeline.
+    ///   - notificationsLastReadId: ID of the last notification read.
+    /// - Returns: TootResponse containing the updated markers and HTTP metadata
+    @discardableResult
+    public func updateMarkersRaw(
+        homeLastReadId: String? = nil,
+        notificationsLastReadId: String? = nil
+    ) async throws -> TootResponse<[OpenEnum<Marker.Timeline>: Marker]> {
         try requireFeature(.markers)
         var queryItems: [URLQueryItem] = []
         if let homeLastReadId {
@@ -45,7 +69,7 @@ extension TootClient {
             $0.body = try .form(queryItems: queryItems)
         }
 
-        return try await fetch([OpenEnum<Marker.Timeline>: Marker].self, req)
+        return try await fetchRaw([OpenEnum<Marker.Timeline>: Marker].self, req)
     }
 
     private func createQuery(timelines: Set<Marker.Timeline>) -> [URLQueryItem] {

--- a/Sources/TootSDK/TootClient/TootClient+Media.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Media.swift
@@ -38,10 +38,11 @@ extension TootClient {
         }
         let uploadResponse = try await fetchRaw(UploadMediaAttachmentResponse.self, req)
 
-        let uploadedMedia = uploadResponse.data.url != nil
+        let uploadedMedia =
+            uploadResponse.data.url != nil
             ? UploadedMediaAttachment(id: uploadResponse.data.id, state: .uploaded)
             : UploadedMediaAttachment(id: uploadResponse.data.id, state: .serverProcessing)
-        
+
         return TootResponse(
             data: uploadedMedia,
             headers: uploadResponse.headers,
@@ -79,14 +80,14 @@ extension TootClient {
         }
 
         let mediaAttachment = try decode(MediaAttachment.self, from: data)
-        
+
         var headers: [String: String] = [:]
         for (key, value) in response.allHeaderFields {
             if let keyString = key as? String, let valueString = value as? String {
                 headers[keyString] = valueString
             }
         }
-        
+
         return TootResponse(
             data: mediaAttachment,
             headers: headers,

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -15,23 +15,41 @@ extension TootClient {
     public func getNotifications(params: TootNotificationParams = .init(), _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws
         -> PagedResult<[TootNotification]>
     {
+        let response = try await getNotificationsRaw(params: params, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get all notifications concerning the user with HTTP response metadata
+    ///  - Parameters:
+    ///     -  limit: Maximum number of results to return. Defaults to 15 notifications. Max 30 notifications.
+    /// - Returns: TootResponse containing paginated notifications and HTTP metadata
+    public func getNotificationsRaw(params: TootNotificationParams = .init(), _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws
+        -> TootResponse<PagedResult<[TootNotification]>>
+    {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "notifications"])
             $0.method = .get
             $0.query = createQuery(from: params) + getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// Get info about a single notification
     public func getNotification(id: String) async throws -> TootNotification {
+        let response = try await getNotificationRaw(id: id)
+        return response.data
+    }
+
+    /// Get info about a single notification with HTTP response metadata
+    /// - Returns: TootResponse containing the notification and HTTP metadata
+    public func getNotificationRaw(id: String) async throws -> TootResponse<TootNotification> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "notifications", id])
             $0.method = .get
         }
 
-        return try await fetch(TootNotification.self, req)
+        return try await fetchRaw(TootNotification.self, req)
     }
 
     /// Clear all notifications from the server.
@@ -60,6 +78,16 @@ extension TootClient {
     /// If you create a new subscription, the old subscription is deleted.
     @discardableResult
     public func createPushSubscription(params: PushSubscriptionParams) async throws -> PushSubscription {
+        let response = try await createPushSubscriptionRaw(params: params)
+        return response.data
+    }
+
+    /// Add a Web Push API subscription to receive notifications with HTTP response metadata
+    ///
+    /// If you create a new subscription, the old subscription is deleted.
+    /// - Returns: TootResponse containing the push subscription and HTTP metadata
+    @discardableResult
+    public func createPushSubscriptionRaw(params: PushSubscriptionParams) async throws -> TootResponse<PushSubscription> {
         try requireFeature(.pushSubscriptions)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "push", "subscription"])
@@ -67,24 +95,40 @@ extension TootClient {
             $0.body = try .form(queryItems: createQuery(from: params))
         }
 
-        return try await fetch(PushSubscription.self, req)
+        return try await fetchRaw(PushSubscription.self, req)
     }
 
     /// View the PushSubscription currently associated with this access token.
     public func getPushSubscription() async throws -> PushSubscription {
+        let response = try await getPushSubscriptionRaw()
+        return response.data
+    }
+
+    /// View the PushSubscription currently associated with this access token with HTTP response metadata
+    /// - Returns: TootResponse containing the push subscription and HTTP metadata
+    public func getPushSubscriptionRaw() async throws -> TootResponse<PushSubscription> {
         try requireFeature(.pushSubscriptions)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "push", "subscription"])
             $0.method = .get
         }
 
-        return try await fetch(PushSubscription.self, req)
+        return try await fetchRaw(PushSubscription.self, req)
     }
 
     /// Updates the current push subscription. Only the data part can be updated.
     ///
     /// To change fundamentals, a new subscription must be created instead.
     public func changePushSubscription(params: PushSubscriptionUpdateParams) async throws -> PushSubscription {
+        let response = try await changePushSubscriptionRaw(params: params)
+        return response.data
+    }
+
+    /// Updates the current push subscription with HTTP response metadata
+    ///
+    /// To change fundamentals, a new subscription must be created instead.
+    /// - Returns: TootResponse containing the updated push subscription and HTTP metadata
+    public func changePushSubscriptionRaw(params: PushSubscriptionUpdateParams) async throws -> TootResponse<PushSubscription> {
         try requireFeature(.pushSubscriptions)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "push", "subscription"])
@@ -92,7 +136,7 @@ extension TootClient {
             $0.body = try .form(queryItems: createQuery(from: params))
         }
 
-        return try await fetch(PushSubscription.self, req)
+        return try await fetchRaw(PushSubscription.self, req)
     }
 
     /// Removes the current Web Push API subscription.

--- a/Sources/TootSDK/TootClient/TootClient+OauthApps.swift
+++ b/Sources/TootSDK/TootClient/TootClient+OauthApps.swift
@@ -10,6 +10,16 @@ extension TootClient {
     /// * This method requires the `admin:write` scope.
     /// * This method requires the pleroma API flavour.
     public func adminGetOauthApps(_ page: Int = 1, params: ListOauthAppsParams? = nil) async throws -> [PleromaOauthApp]? {
+        let response = try await adminGetOauthAppsRaw(page, params: params)
+        return response.data
+    }
+
+    /// Retrieve a list of OAuth applications with HTTP response metadata
+    ///
+    /// * This method requires the `admin:write` scope.
+    /// * This method requires the pleroma API flavour.
+    /// - Returns: TootResponse containing the OAuth applications and HTTP metadata
+    public func adminGetOauthAppsRaw(_ page: Int = 1, params: ListOauthAppsParams? = nil) async throws -> TootResponse<[PleromaOauthApp]?> {
         try requireFlavour([.pleroma])
 
         let req = HTTPRequestBuilder {
@@ -38,8 +48,16 @@ extension TootClient {
             req.addQueryParameter(name: "admin_token", value: "\(adminToken)")
         }
 
-        let response = try await fetch(PleromaOauthAppsResponse.self, req)
-        return response.apps
+        let response = try await fetchRaw(PleromaOauthAppsResponse.self, req)
+        let apps = response.data.apps
+        
+        return TootResponse(
+            data: apps,
+            headers: response.headers,
+            statusCode: response.statusCode,
+            url: response.url,
+            rawBody: response.rawBody
+        )
     }
 
     /// Delete OAuth application

--- a/Sources/TootSDK/TootClient/TootClient+OauthApps.swift
+++ b/Sources/TootSDK/TootClient/TootClient+OauthApps.swift
@@ -50,7 +50,7 @@ extension TootClient {
 
         let response = try await fetchRaw(PleromaOauthAppsResponse.self, req)
         let apps = response.data.apps
-        
+
         return TootResponse(
             data: apps,
             headers: response.headers,

--- a/Sources/TootSDK/TootClient/TootClient+Poll.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Poll.swift
@@ -11,12 +11,19 @@ extension TootClient {
 
     /// Obtain a poll with the specified `id`.
     public func getPoll(id: Poll.ID) async throws -> Poll {
+        let response = try await getPollRaw(id: id)
+        return response.data
+    }
+
+    /// Obtain a poll with the specified `id` with HTTP response metadata
+    /// - Returns: TootResponse containing the poll and HTTP metadata
+    public func getPollRaw(id: Poll.ID) async throws -> TootResponse<Poll> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "polls", id])
             $0.method = .get
         }
 
-        return try await fetch(Poll.self, req)
+        return try await fetchRaw(Poll.self, req)
     }
 
     /// Vote on a poll.
@@ -27,6 +34,18 @@ extension TootClient {
     /// - Returns: The Poll that was voted on.
     @discardableResult
     public func votePoll(id: Poll.ID, choices: IndexSet) async throws -> Poll {
+        let response = try await votePollRaw(id: id, choices: choices)
+        return response.data
+    }
+
+    /// Vote on a poll with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the Poll.
+    ///   - choices: Set of indices representing votes for each option (starting from 0).
+    /// - Returns: TootResponse containing the poll that was voted on and HTTP metadata
+    @discardableResult
+    public func votePollRaw(id: Poll.ID, choices: IndexSet) async throws -> TootResponse<Poll> {
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "polls", id, "votes"])
             $0.method = .post
@@ -36,7 +55,7 @@ extension TootClient {
                 })
         }
 
-        return try await fetch(Poll.self, req)
+        return try await fetchRaw(Poll.self, req)
     }
 
 }

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -13,6 +13,14 @@ extension TootClient {
     /// - Parameter PostParams:post components to be published
     /// - Returns: the published post, if successful, throws an error if not
     public func publishPost(_ params: PostParams) async throws -> Post {
+        let response = try await publishPostRaw(params)
+        return response.data
+    }
+
+    /// Publishes the post based on the components provided with HTTP response metadata
+    /// - Parameter PostParams:post components to be published
+    /// - Returns: TootResponse containing the published post and HTTP metadata
+    public func publishPostRaw(_ params: PostParams) async throws -> TootResponse<Post> {
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses"])
             $0.method = .post
@@ -22,10 +30,10 @@ extension TootClient {
                 $0.body = try .multipart(params, boundary: UUID().uuidString)
             }
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
-    /// Edit a given post to change its text, sensitivity, media attachments, or poll. Note that editing a poll’s options will reset the votes.
+    /// Edit a given post to change its text, sensitivity, media attachments, or poll. Note that editing a poll's options will reset the votes.
     ///
     /// - Note: For Pixelfed this will first attempt to update media descriptions and then update rest of post details.
     /// If an error is thrown it is possible for some of the media descriptions to be already successfully updated.
@@ -34,6 +42,19 @@ extension TootClient {
     /// - Parameter params: The updated content of the post to be posted.
     /// - Returns: The post after the update.
     public func editPost(id: String, _ params: EditPostParams) async throws -> Post {
+        let response = try await editPostRaw(id: id, params)
+        return response.data
+    }
+
+    /// Edit a given post to change its text, sensitivity, media attachments, or poll with HTTP response metadata
+    ///
+    /// - Note: For Pixelfed this will first attempt to update media descriptions and then update rest of post details.
+    /// If an error is thrown it is possible for some of the media descriptions to be already successfully updated.
+    ///
+    /// - Parameter id: The ID of the post to be changed.
+    /// - Parameter params: The updated content of the post to be posted.
+    /// - Returns: TootResponse containing the post after the update and HTTP metadata
+    public func editPostRaw(id: String, _ params: EditPostParams) async throws -> TootResponse<Post> {
         let updateMediaSeparately = [.pixelfed, .pleroma, .akkoma, .firefish, .catodon, .iceshrimp, .sharkey].contains(flavour)
         if updateMediaSeparately {
             try await updateMediaAttributes(params.mediaAttributes ?? [])
@@ -51,9 +72,9 @@ extension TootClient {
         if flavour == .pixelfed {
             _ = try await fetch(req: req)
             // Pixelfed doesn't return edited post, simulate behavior of Mastodon by manually getting post
-            return try await getPost(id: id)
+            return try await getPostRaw(id: id)
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     private func updateMediaAttributes(_ mediaAttributes: [EditPostParams.MediaAttribute]) async throws {
@@ -78,22 +99,38 @@ extension TootClient {
     /// - Parameter id: the ID of the post to be retrieved
     /// - Returns: the post retrieved, if successful, throws an error if not
     public func getPost(id: String) async throws -> Post {
+        let response = try await getPostRaw(id: id)
+        return response.data
+    }
+
+    /// Gets a single post with HTTP response metadata
+    /// - Parameter id: the ID of the post to be retrieved
+    /// - Returns: TootResponse containing the post and HTTP metadata
+    public func getPostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id])
             $0.method = .get
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     /// View statuses above and below this post in the thread.
     ///
     /// Public for public posts limited to 40 ancestors and 60 descendants with a maximum depth of 20. User token + read:statuses for up to 4,096 ancestors, 4,096 descendants, unlimited depth, and private posts.
     public func getContext(id: String) async throws -> Context {
+        let response = try await getContextRaw(id: id)
+        return response.data
+    }
+
+    /// View statuses above and below this post in the thread with HTTP response metadata
+    ///
+    /// Public for public posts limited to 40 ancestors and 60 descendants with a maximum depth of 20. User token + read:statuses for up to 4,096 ancestors, 4,096 descendants, unlimited depth, and private posts.
+    public func getContextRaw(id: String) async throws -> TootResponse<Context> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "context"])
             $0.method = .get
         }
-        return try await fetch(Context.self, req)
+        return try await fetchRaw(Context.self, req)
     }
 }
 
@@ -104,6 +141,15 @@ extension TootClient {
     /// - Parameter deleteMedia: Whether to immediately delete the post's media attachments. Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher. If supported and this parameter is `nil` or `false`, media attachents may be kept for approximately 24 hours so they can be reused in a new post.
     /// - Returns: the post deleted (for delete and redraft), if successful, throws an error if not
     public func deletePost(id: String, deleteMedia: Bool? = nil) async throws -> Post {
+        let response = try await deletePostRaw(id: id, deleteMedia: deleteMedia)
+        return response.data
+    }
+
+    /// Deletes a single post with HTTP response metadata
+    /// - Parameter id: the ID of the post to be deleted
+    /// - Parameter deleteMedia: Whether to immediately delete the post's media attachments. Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher. If supported and this parameter is `nil` or `false`, media attachents may be kept for approximately 24 hours so they can be reused in a new post.
+    /// - Returns: TootResponse containing the post deleted (for delete and redraft) and HTTP metadata
+    public func deletePostRaw(id: String, deleteMedia: Bool? = nil) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id])
             $0.method = .delete
@@ -111,7 +157,7 @@ extension TootClient {
                 $0.addQueryParameter(name: "delete_media", value: String(deleteMedia))
             }
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
 }
@@ -119,19 +165,29 @@ extension TootClient {
 extension TootClient {
 
     public func favouritePost(id: String) async throws -> Post {
+        let response = try await favouritePostRaw(id: id)
+        return response.data
+    }
+
+    public func favouritePostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "favourite"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     public func unfavouritePost(id: String) async throws -> Post {
+        let response = try await unfavouritePostRaw(id: id)
+        return response.data
+    }
+
+    public func unfavouritePostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "unfavourite"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
 }
@@ -140,20 +196,32 @@ extension TootClient {
 
     /// Reshare a post on your own profile.
     public func boostPost(id: String) async throws -> Post {
+        let response = try await boostPostRaw(id: id)
+        return response.data
+    }
+
+    /// Reshare a post on your own profile with HTTP response metadata.
+    public func boostPostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "reblog"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     /// Undo a reshare of a post.
     public func unboostPost(id: String) async throws -> Post {
+        let response = try await unboostPostRaw(id: id)
+        return response.data
+    }
+
+    /// Undo a reshare of a post with HTTP response metadata.
+    public func unboostPostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "unreblog"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
 }
@@ -162,22 +230,34 @@ extension TootClient {
 
     /// Privately bookmark a post.
     public func bookmarkPost(id: String) async throws -> Post {
+        let response = try await bookmarkPostRaw(id: id)
+        return response.data
+    }
+
+    /// Privately bookmark a post with HTTP response metadata.
+    public func bookmarkPostRaw(id: String) async throws -> TootResponse<Post> {
         try requireFeature(.bookmark)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "bookmark"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     /// Remove a post from your private bookmarks.
     public func unbookmarkPost(id: String) async throws -> Post {
+        let response = try await unbookmarkPostRaw(id: id)
+        return response.data
+    }
+
+    /// Remove a post from your private bookmarks with HTTP response metadata.
+    public func unbookmarkPostRaw(id: String) async throws -> TootResponse<Post> {
         try requireFeature(.bookmark)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "unbookmark"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
 }
@@ -186,22 +266,34 @@ extension TootClient {
 
     /// Do not receive notifications for the thread that this post is part of. Must be a thread in which you are a participant.
     public func mutePost(id: String) async throws -> Post {
+        let response = try await mutePostRaw(id: id)
+        return response.data
+    }
+
+    /// Do not receive notifications for the thread that this post is part of with HTTP response metadata. Must be a thread in which you are a participant.
+    public func mutePostRaw(id: String) async throws -> TootResponse<Post> {
         try requireFeature(.mutePost)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "mute"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     /// Start receiving notifications again for the thread that this post is part of.
     public func unmutePost(id: String) async throws -> Post {
+        let response = try await unmutePostRaw(id: id)
+        return response.data
+    }
+
+    /// Start receiving notifications again for the thread that this post is part of with HTTP response metadata.
+    public func unmutePostRaw(id: String) async throws -> TootResponse<Post> {
         try requireFeature(.mutePost)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "unmute"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 }
 
@@ -209,20 +301,32 @@ extension TootClient {
 
     /// Feature one of your own public posts at the top of your profile.
     public func pinPost(id: String) async throws -> Post {
+        let response = try await pinPostRaw(id: id)
+        return response.data
+    }
+
+    /// Feature one of your own public posts at the top of your profile with HTTP response metadata.
+    public func pinPostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "pin"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 
     /// Unfeature a post from the top of your profile.
     public func unpinPost(id: String) async throws -> Post {
+        let response = try await unpinPostRaw(id: id)
+        return response.data
+    }
+
+    /// Unfeature a post from the top of your profile with HTTP response metadata.
+    public func unpinPostRaw(id: String) async throws -> TootResponse<Post> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "unpin"])
             $0.method = .post
         }
-        return try await fetch(Post.self, req)
+        return try await fetchRaw(Post.self, req)
     }
 }
 
@@ -230,6 +334,12 @@ extension TootClient {
 
     /// View who boosted a given post.
     public func getAccountsBoosted(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
+        let response = try await getAccountsBoostedRaw(id: id, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// View who boosted a given post with HTTP response metadata.
+    public func getAccountsBoostedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Account]>> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "reblogged_by"])
             $0.method = .get
@@ -237,11 +347,17 @@ extension TootClient {
                 $0.query = getQueryParams(pageInfo, limit: limit)
             }
         }
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
     /// View who favourited a given post.
     public func getAccountsFavourited(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Account]> {
+        let response = try await getAccountsFavouritedRaw(id: id, pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// View who favourited a given post with HTTP response metadata.
+    public func getAccountsFavouritedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Account]>> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "favourited_by"])
             $0.method = .get
@@ -250,7 +366,7 @@ extension TootClient {
             }
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 
 }
@@ -259,13 +375,26 @@ extension TootClient {
 
     /// Get all known versions of a post, including the initial and current states.
     public func getHistory(id: String) async throws -> [PostEdit] {
+        let response = try await getHistoryRaw(id: id)
+        return response.data
+    }
+
+    /// Get all known versions of a post, including the initial and current states with HTTP response metadata.
+    public func getHistoryRaw(id: String) async throws -> TootResponse<[PostEdit]> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "history"])
             $0.method = .get
         }
 
-        let postEdits = try await fetch([PostEdit].self, req)
-        return postEdits.compactMap({ $0 })
+        let response = try await fetchRaw([PostEdit].self, req)
+        let filteredPostEdits = response.data.compactMap({ $0 })
+        return TootResponse(
+            data: filteredPostEdits,
+            headers: response.headers,
+            statusCode: response.statusCode,
+            url: response.url,
+            rawBody: response.rawBody
+        )
     }
 
 }
@@ -274,6 +403,12 @@ extension TootClient {
 
     /// Obtain the source properties for a post so that it can be edited.
     public func getPostSource(id: String) async throws -> PostSource {
+        let response = try await getPostSourceRaw(id: id)
+        return response.data
+    }
+
+    /// Obtain the source properties for a post so that it can be edited with HTTP response metadata.
+    public func getPostSourceRaw(id: String) async throws -> TootResponse<PostSource> {
         try requireFlavour(otherThan: [.pixelfed])
 
         let req = HTTPRequestBuilder {
@@ -281,7 +416,7 @@ extension TootClient {
             $0.method = .get
         }
 
-        return try await fetch(PostSource.self, req)
+        return try await fetchRaw(PostSource.self, req)
     }
 
 }
@@ -290,13 +425,19 @@ extension TootClient {
 
     /// Translate the post content into some language.
     public func getPostTranslation(id: String, params: PostTranslationParams? = nil) async throws -> Translation {
+        let response = try await getPostTranslationRaw(id: id, params: params)
+        return response.data
+    }
+
+    /// Translate the post content into some language with HTTP response metadata.
+    public func getPostTranslationRaw(id: String, params: PostTranslationParams? = nil) async throws -> TootResponse<Translation> {
         try requireFeature(.translatePost)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "translate"])
             $0.method = .post
             $0.body = try .json(params, encoder: self.encoder)
         }
-        return try await fetch(Translation.self, req)
+        return try await fetchRaw(Translation.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+Post.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Post.swift
@@ -339,7 +339,9 @@ extension TootClient {
     }
 
     /// View who boosted a given post with HTTP response metadata.
-    public func getAccountsBoostedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Account]>> {
+    public func getAccountsBoostedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<
+        PagedResult<[Account]>
+    > {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "reblogged_by"])
             $0.method = .get
@@ -357,7 +359,9 @@ extension TootClient {
     }
 
     /// View who favourited a given post with HTTP response metadata.
-    public func getAccountsFavouritedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Account]>> {
+    public func getAccountsFavouritedRaw(id: String, _ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<
+        PagedResult<[Account]>
+    > {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "statuses", id, "favourited_by"])
             $0.method = .get

--- a/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
@@ -17,6 +17,18 @@ extension TootClient {
     ///   - params: Includes order and local parameters.
     /// - Returns: Array of ``Account``.
     public func getProfileDirectory(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> [Account] {
+        let response = try await getProfileDirectoryRaw(params: params, offset: offset, limit: limit)
+        return response.data
+    }
+
+    /// List accounts visible in the directory with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - offset. Skip the first n results.
+    ///   - limit: How many accounts to load. Defaults to 40 accounts. Max 80 accounts.
+    ///   - params: Includes order and local parameters.
+    /// - Returns: TootResponse containing array of Accounts and HTTP metadata
+    public func getProfileDirectoryRaw(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> TootResponse<[Account]> {
         try requireFeature(.profileDirectory)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "directory"])
@@ -24,7 +36,7 @@ extension TootClient {
             $0.query = getQueryParams(limit: limit, offset: offset) + params.queryItems
         }
 
-        return try await fetch([Account].self, req)
+        return try await fetchRaw([Account].self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ProfileDirectory.swift
@@ -28,7 +28,8 @@ extension TootClient {
     ///   - limit: How many accounts to load. Defaults to 40 accounts. Max 80 accounts.
     ///   - params: Includes order and local parameters.
     /// - Returns: TootResponse containing array of Accounts and HTTP metadata
-    public func getProfileDirectoryRaw(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> TootResponse<[Account]> {
+    public func getProfileDirectoryRaw(params: ProfileDirectoryParams, offset: Int? = nil, limit: Int? = nil) async throws -> TootResponse<[Account]>
+    {
         try requireFeature(.profileDirectory)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "directory"])

--- a/Sources/TootSDK/TootClient/TootClient+Search.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Search.swift
@@ -26,7 +26,9 @@ extension TootClient {
     ///   - limit: Maximum number of results to return. Defaults to 40.
     ///   - offset: Skip the first n results.
     /// - Returns: TootResponse containing search results and HTTP metadata
-    public func searchRaw(params: SearchParams, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<Search> {
+    public func searchRaw(params: SearchParams, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<
+        Search
+    > {
         if params.excludeUnreviewed != nil {
             try requireFeature(.searchExcludeUnreviewed)
         }

--- a/Sources/TootSDK/TootClient/TootClient+Search.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Search.swift
@@ -14,6 +14,19 @@ extension TootClient {
     ///   - offset: Skip the first n results.
     /// - Returns: Search results.
     public func search(params: SearchParams, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> Search {
+        let response = try await searchRaw(params: params, pageInfo, limit: limit, offset: offset)
+        return response.data
+    }
+
+    /// Search for content in accounts, posts and hashtags with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - params: The search parameters.
+    ///   - pageInfo: PagedInfo object for max/min/since ids.
+    ///   - limit: Maximum number of results to return. Defaults to 40.
+    ///   - offset: Skip the first n results.
+    /// - Returns: TootResponse containing search results and HTTP metadata
+    public func searchRaw(params: SearchParams, _ pageInfo: PagedInfo? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<Search> {
         if params.excludeUnreviewed != nil {
             try requireFeature(.searchExcludeUnreviewed)
         }
@@ -22,7 +35,7 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit, offset: offset) + params.queryItems
         }
-        return try await fetch(Search.self, req)
+        return try await fetchRaw(Search.self, req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Suggestions.swift
@@ -12,6 +12,16 @@ extension TootClient {
     ///   - limit: Maximum number of results to return. Defaults to 40, max 80.
     /// - Returns: Array of ``Suggestion``.
     public func getSuggestions(limit: Int? = nil) async throws -> [Suggestion] {
+        let response = try await getSuggestionsRaw(limit: limit)
+        return response.data
+    }
+
+    /// Accounts that are promoted by staff, or that the user has had past positive interactions with, but is not yet following with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - limit: Maximum number of results to return. Defaults to 40, max 80.
+    /// - Returns: TootResponse containing array of Suggestions and HTTP metadata
+    public func getSuggestionsRaw(limit: Int? = nil) async throws -> TootResponse<[Suggestion]> {
         try requireFeature(.suggestions)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v2", "suggestions"])
@@ -19,7 +29,7 @@ extension TootClient {
             $0.query = getQueryParams(limit: limit)
         }
 
-        return try await fetch([Suggestion].self, req)
+        return try await fetchRaw([Suggestion].self, req)
     }
 
     /// Remove an account from follow suggestions.

--- a/Sources/TootSDK/TootClient/TootClient+Tags.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Tags.swift
@@ -10,12 +10,20 @@ extension TootClient {
     /// Get a tag.
     /// - Parameter id: Name of the tag.
     public func getTag(_ id: String) async throws -> Tag {
+        let response = try await getTagRaw(id)
+        return response.data
+    }
+
+    /// Get a tag with HTTP response metadata
+    /// - Parameter id: Name of the tag.
+    /// - Returns: TootResponse containing the tag and HTTP metadata
+    public func getTagRaw(_ id: String) async throws -> TootResponse<Tag> {
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "tags", id])
             $0.method = .get
         }
 
-        return try await fetch(Tag.self, req)
+        return try await fetchRaw(Tag.self, req)
     }
 
     /// Follow a tag.
@@ -24,13 +32,24 @@ extension TootClient {
     /// - Note: Requires hashtag following feature to be available.
     @discardableResult
     public func followTag(_ id: String) async throws -> Tag {
+        let response = try await followTagRaw(id)
+        return response.data
+    }
+
+    /// Follow a tag with HTTP response metadata
+    ///
+    /// - Parameter id: Name of the tag.
+    /// - Returns: TootResponse containing the tag and HTTP metadata
+    /// - Note: Requires hashtag following feature to be available.
+    @discardableResult
+    public func followTagRaw(_ id: String) async throws -> TootResponse<Tag> {
         try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "tags", id, "follow"])
             $0.method = .post
         }
 
-        return try await fetch(Tag.self, req)
+        return try await fetchRaw(Tag.self, req)
     }
 
     /// Unfollow a tag.
@@ -39,13 +58,24 @@ extension TootClient {
     /// - Note: Requires hashtag following feature to be available.
     @discardableResult
     public func unfollowTag(_ id: String) async throws -> Tag {
+        let response = try await unfollowTagRaw(id)
+        return response.data
+    }
+
+    /// Unfollow a tag with HTTP response metadata
+    ///
+    /// - Parameter id: Name of the tag.
+    /// - Returns: TootResponse containing the tag and HTTP metadata
+    /// - Note: Requires hashtag following feature to be available.
+    @discardableResult
+    public func unfollowTagRaw(_ id: String) async throws -> TootResponse<Tag> {
         try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "tags", id, "unfollow"])
             $0.method = .post
         }
 
-        return try await fetch(Tag.self, req)
+        return try await fetchRaw(Tag.self, req)
     }
 
     /// Get all tags which the current account is following.
@@ -55,6 +85,17 @@ extension TootClient {
     /// - Returns: the tags requested
     /// - Note: Requires hashtag following feature to be available.
     public func getFollowedTags(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Tag]> {
+        let response = try await getFollowedTagsRaw(pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Get all tags which the current account is following with HTTP response metadata
+    /// - Parameters:
+    ///     - pageInfo: PagedInfo object for max/min/since ids.
+    ///     - limit: Maximum number of results to return. Defaults to 100 tags. Max 200 tags.
+    /// - Returns: TootResponse containing the paginated tags and HTTP metadata
+    /// - Note: Requires hashtag following feature to be available.
+    public func getFollowedTagsRaw(_ pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Tag]>> {
         try requireFeature(.hashtagFollowing)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "followed_tags"])
@@ -62,7 +103,7 @@ extension TootClient {
             $0.query = getQueryParams(pageInfo, limit: limit)
         }
 
-        return try await fetchPagedResult(req)
+        return try await fetchPagedResultRaw(req)
     }
 }
 

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -67,6 +67,17 @@ extension TootClient {
     ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
     /// - Returns: a PagedResult containing the posts retrieved
     public func getTimeline(_ timeline: Timeline, pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> PagedResult<[Post]> {
+        let response = try await getTimelineRaw(timeline, pageInfo: pageInfo, limit: limit)
+        return response.data
+    }
+
+    /// Retrieves a timeline with HTTP response metadata
+    /// - Parameters:
+    ///   - timeline: The timeline being requested
+    ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
+    ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
+    /// - Returns: TootResponse containing the paginated posts and HTTP metadata
+    public func getTimelineRaw(_ timeline: Timeline, pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Post]>> {
         let urlPaths = getURLPaths(timeline: timeline)
         let timelineQuery = getQuery(timeline: timeline)
 
@@ -75,7 +86,7 @@ extension TootClient {
             $0.method = .get
             $0.query = getQueryParams(pageInfo, limit: limit, query: timelineQuery)
         }
-        return try await getPosts(req, pageInfo, limit)
+        return try await fetchPagedResultRaw(req)
     }
 
 }

--- a/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
+++ b/Sources/TootSDK/TootClient/TootClient+TimeLine.swift
@@ -77,7 +77,8 @@ extension TootClient {
     ///   - pageInfo: a PageInfo struct that tells the API how to page the response, typically with a minId set of the highest id you last saw
     ///   - limit: Maximum number of results to return (defaults to 20 on Mastodon with a max of 40)
     /// - Returns: TootResponse containing the paginated posts and HTTP metadata
-    public func getTimelineRaw(_ timeline: Timeline, pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Post]>> {
+    public func getTimelineRaw(_ timeline: Timeline, pageInfo: PagedInfo? = nil, limit: Int? = nil) async throws -> TootResponse<PagedResult<[Post]>>
+    {
         let urlPaths = getURLPaths(timeline: timeline)
         let timelineQuery = getQuery(timeline: timeline)
 

--- a/Sources/TootSDK/TootClient/TootClient+Trends.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Trends.swift
@@ -16,6 +16,17 @@ extension TootClient {
     ///   - offset: Skip the first n results.
     /// - Returns: Array of ``Tag``.
     public func getTrendingTags(limit: Int? = nil, offset: Int? = nil) async throws -> [Tag] {
+        let response = try await getTrendingTagsRaw(limit: limit, offset: offset)
+        return response.data
+    }
+
+    /// Get trending tags with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - limit: Maximum number of results to return. Defaults to 10, max 20.
+    ///   - offset: Skip the first n results.
+    /// - Returns: TootResponse containing array of Tags and HTTP metadata
+    public func getTrendingTagsRaw(limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<[Tag]> {
         try requireFeature(.trendingTags)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "trends", "tags"])
@@ -23,7 +34,7 @@ extension TootClient {
             $0.query = getQueryParams(limit: limit, offset: offset)
         }
 
-        return try await fetch([Tag].self, req)
+        return try await fetchRaw([Tag].self, req)
     }
 
     /// Get trending posts
@@ -33,6 +44,17 @@ extension TootClient {
     ///   - offset: Skip the first n results.
     /// - Returns: Array of ``Post``.
     public func getTrendingPosts(limit: Int? = nil, offset: Int? = nil) async throws -> [Post] {
+        let response = try await getTrendingPostsRaw(limit: limit, offset: offset)
+        return response.data
+    }
+
+    /// Get trending posts with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - limit: Maximum number of results to return. Defaults to 20, max 40.
+    ///   - offset: Skip the first n results.
+    /// - Returns: TootResponse containing array of Posts and HTTP metadata
+    public func getTrendingPostsRaw(limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<[Post]> {
         try requireFeature(.trendingPosts)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "trends", "statuses"])
@@ -40,7 +62,7 @@ extension TootClient {
             $0.query = getQueryParams(limit: limit, offset: offset)
         }
 
-        return try await fetch([Post].self, req)
+        return try await fetchRaw([Post].self, req)
     }
 
     /// Get trending links
@@ -50,6 +72,17 @@ extension TootClient {
     ///   - offset: Skip the first n results.
     /// - Returns: Array of ``TrendingLink``.
     public func getTrendingLinks(limit: Int? = nil, offset: Int? = nil) async throws -> [TrendingLink] {
+        let response = try await getTrendingLinksRaw(limit: limit, offset: offset)
+        return response.data
+    }
+
+    /// Get trending links with HTTP response metadata
+    ///
+    /// - Parameters:
+    ///   - limit: Maximum number of results to return. Defaults to 10, max 20.
+    ///   - offset: Skip the first n results.
+    /// - Returns: TootResponse containing array of TrendingLinks and HTTP metadata
+    public func getTrendingLinksRaw(limit: Int? = nil, offset: Int? = nil) async throws -> TootResponse<[TrendingLink]> {
         try requireFeature(.trendingLinks)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "trends", "links"])
@@ -57,7 +90,7 @@ extension TootClient {
             $0.query = getQueryParams(limit: limit, offset: offset)
         }
 
-        return try await fetch([TrendingLink].self, req)
+        return try await fetchRaw([TrendingLink].self, req)
     }
 }
 

--- a/Tests/TootSDKTests/TootResponseTests.swift
+++ b/Tests/TootSDKTests/TootResponseTests.swift
@@ -5,21 +5,22 @@
 //  Created by Claude on TootSDK Implementation
 //
 
-import XCTest
 import Foundation
+import XCTest
 
 @testable import TootSDK
 
 final class TootResponseTests: XCTestCase {
-    
+
     // MARK: - Test Data
-    
+
     private let sampleHeaders: [String: String] = [
         "Content-Type": "application/json",
         "X-RateLimit-Limit": "300",
         "X-RateLimit-Remaining": "299",
         "X-RateLimit-Reset": "1640995200",
-        "Link": "<https://example.com/api/v1/accounts?limit=40&min_id=109>; rel=\"next\", <https://example.com/api/v1/accounts?limit=40&max_id=108>; rel=\"prev\"",
+        "Link":
+            "<https://example.com/api/v1/accounts?limit=40&min_id=109>; rel=\"next\", <https://example.com/api/v1/accounts?limit=40&max_id=108>; rel=\"prev\"",
         "Cache-Control": "no-cache, no-store",
         "ETag": "\"abc123\"",
         "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
@@ -35,15 +36,15 @@ final class TootResponseTests: XCTestCase {
         "Content-Security-Policy": "default-src 'self'",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Frame-Options": "DENY",
-        "X-Content-Type-Options": "nosniff"
+        "X-Content-Type-Options": "nosniff",
     ]
-    
+
     private let sampleData = ["test": "data"]
     private let sampleURL = URL(string: "https://example.com/api/v1/test")!
     private let sampleRawBody = Data("test response".utf8)
-    
+
     // MARK: - Initialization Tests
-    
+
     func testTootResponseInitialization() throws {
         // arrange & act
         let response = TootResponse(
@@ -53,7 +54,7 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // assert
         XCTAssertEqual(response.data["test"], "data")
         XCTAssertEqual(response.headers.count, sampleHeaders.count)
@@ -61,9 +62,9 @@ final class TootResponseTests: XCTestCase {
         XCTAssertEqual(response.url, sampleURL)
         XCTAssertEqual(response.rawBody, sampleRawBody)
     }
-    
+
     // MARK: - Rate Limiting Header Tests
-    
+
     func testRateLimitHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -73,24 +74,24 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.rateLimitLimit, 300)
         XCTAssertEqual(response.rateLimitRemaining, 299)
         XCTAssertNotNil(response.rateLimitReset)
-        
-        let expectedResetDate = Date(timeIntervalSince1970: 1640995200)
+
+        let expectedResetDate = Date(timeIntervalSince1970: 1_640_995_200)
         XCTAssertEqual(response.rateLimitReset, expectedResetDate)
     }
-    
+
     func testRateLimitHeadersWithInvalidValues() throws {
         // arrange
         let invalidHeaders = [
             "X-RateLimit-Limit": "invalid",
             "X-RateLimit-Remaining": "not-a-number",
-            "X-RateLimit-Reset": "invalid-timestamp"
+            "X-RateLimit-Reset": "invalid-timestamp",
         ]
-        
+
         let response = TootResponse(
             data: sampleData,
             headers: invalidHeaders,
@@ -98,15 +99,15 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertNil(response.rateLimitLimit)
         XCTAssertNil(response.rateLimitRemaining)
         XCTAssertNil(response.rateLimitReset)
     }
-    
+
     // MARK: - Pagination Header Tests
-    
+
     func testPaginationHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -116,15 +117,15 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertNotNil(response.linkHeader)
         XCTAssertTrue(response.linkHeader!.contains("rel=\"next\""))
         XCTAssertTrue(response.linkHeader!.contains("rel=\"prev\""))
     }
-    
+
     // MARK: - Content Header Tests
-    
+
     func testContentHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -134,15 +135,15 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.contentType, "application/json")
-        XCTAssertNil(response.contentLength) // Not included in sample headers
-        XCTAssertNil(response.contentEncoding) // Not included in sample headers
+        XCTAssertNil(response.contentLength)  // Not included in sample headers
+        XCTAssertNil(response.contentEncoding)  // Not included in sample headers
     }
-    
+
     // MARK: - Cache Header Tests
-    
+
     func testCacheHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -152,13 +153,13 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.cacheControl, "no-cache, no-store")
         XCTAssertEqual(response.etag, "\"abc123\"")
         XCTAssertNotNil(response.lastModified)
     }
-    
+
     func testLastModifiedParsing() throws {
         // arrange
         let response = TootResponse(
@@ -168,13 +169,13 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act
         let lastModified = response.lastModified
-        
+
         // assert
         XCTAssertNotNil(lastModified)
-        
+
         // Use UTC calendar to avoid timezone issues
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(abbreviation: "GMT")!
@@ -185,9 +186,9 @@ final class TootResponseTests: XCTestCase {
         XCTAssertEqual(components.hour, 7)
         XCTAssertEqual(components.minute, 28)
     }
-    
+
     // MARK: - Server Information Header Tests
-    
+
     func testServerHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -197,13 +198,13 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.server, "Mastodon/4.0.0")
         XCTAssertEqual(response.requestId, "req-12345")
         XCTAssertEqual(response.responseTime, "0.123s")
     }
-    
+
     func testRequestIdFallback() throws {
         // arrange - test fallback from X-Request-Id to X-Request-ID
         let headersWithFallback = ["X-Request-ID": "fallback-id"]
@@ -214,13 +215,13 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.requestId, "fallback-id")
     }
-    
+
     // MARK: - Mastodon/Fediverse Specific Header Tests
-    
+
     func testFediverseHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -230,7 +231,7 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.mastodonVersion, "4.0.0")
         XCTAssertEqual(response.instanceName, "example.com")
@@ -239,9 +240,9 @@ final class TootResponseTests: XCTestCase {
         XCTAssertEqual(response.deprecationWarning, "true")
         XCTAssertEqual(response.sunsetWarning, "Wed, 11 Nov 2020 23:59:59 GMT")
     }
-    
+
     // MARK: - Security Header Tests
-    
+
     func testSecurityHeaders() throws {
         // arrange
         let response = TootResponse(
@@ -251,16 +252,16 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.contentSecurityPolicy, "default-src 'self'")
         XCTAssertEqual(response.strictTransportSecurity, "max-age=31536000")
         XCTAssertEqual(response.xFrameOptions, "DENY")
         XCTAssertEqual(response.xContentTypeOptions, "nosniff")
     }
-    
+
     // MARK: - Status Code Convenience Tests
-    
+
     func testStatusCodeConvenience() throws {
         // Test successful response
         let successResponse = TootResponse(
@@ -270,12 +271,12 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         XCTAssertTrue(successResponse.isSuccessful)
         XCTAssertFalse(successResponse.isRedirection)
         XCTAssertFalse(successResponse.isClientError)
         XCTAssertFalse(successResponse.isServerError)
-        
+
         // Test redirection response
         let redirectResponse = TootResponse(
             data: sampleData,
@@ -284,12 +285,12 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         XCTAssertFalse(redirectResponse.isSuccessful)
         XCTAssertTrue(redirectResponse.isRedirection)
         XCTAssertFalse(redirectResponse.isClientError)
         XCTAssertFalse(redirectResponse.isServerError)
-        
+
         // Test client error response
         let clientErrorResponse = TootResponse(
             data: sampleData,
@@ -298,12 +299,12 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         XCTAssertFalse(clientErrorResponse.isSuccessful)
         XCTAssertFalse(clientErrorResponse.isRedirection)
         XCTAssertTrue(clientErrorResponse.isClientError)
         XCTAssertFalse(clientErrorResponse.isServerError)
-        
+
         // Test server error response
         let serverErrorResponse = TootResponse(
             data: sampleData,
@@ -312,15 +313,15 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         XCTAssertFalse(serverErrorResponse.isSuccessful)
         XCTAssertFalse(serverErrorResponse.isRedirection)
         XCTAssertFalse(serverErrorResponse.isClientError)
         XCTAssertTrue(serverErrorResponse.isServerError)
     }
-    
+
     // MARK: - Convenience Method Tests
-    
+
     func testCaseInsensitiveHeaderLookup() throws {
         // arrange
         let response = TootResponse(
@@ -330,14 +331,14 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act & assert
         XCTAssertEqual(response.header(named: "content-type"), "application/json")
         XCTAssertEqual(response.header(named: "CONTENT-TYPE"), "application/json")
         XCTAssertEqual(response.header(named: "Content-Type"), "application/json")
         XCTAssertNil(response.header(named: "non-existent-header"))
     }
-    
+
     func testHeadersWithPrefix() throws {
         // arrange
         let response = TootResponse(
@@ -347,33 +348,33 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // act
         let rateLimitHeaders = response.headers(withPrefix: "x-ratelimit")
         let xHeaders = response.headers(withPrefix: "x-")
-        
+
         // assert
         XCTAssertEqual(rateLimitHeaders.count, 3)
         XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Limit"))
         XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Remaining"))
         XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Reset"))
-        
-        XCTAssertTrue(xHeaders.count >= 6) // At least the X- headers we defined
+
+        XCTAssertTrue(xHeaders.count >= 6)  // At least the X- headers we defined
         XCTAssertTrue(xHeaders.keys.contains("X-Request-Id"))
         XCTAssertTrue(xHeaders.keys.contains("X-Response-Time"))
     }
-    
+
     // MARK: - Integration Tests
-    
+
     func testTootResponseWithTypedData() throws {
         // arrange
         struct TestModel: Codable, Equatable {
             let id: String
             let name: String
         }
-        
+
         let testModel = TestModel(id: "123", name: "Test")
-        
+
         // act
         let response = TootResponse(
             data: testModel,
@@ -382,18 +383,18 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // assert
         XCTAssertEqual(response.data, testModel)
         XCTAssertEqual(response.statusCode, 201)
         XCTAssertTrue(response.isSuccessful)
         XCTAssertEqual(response.rateLimitLimit, 300)
     }
-    
+
     func testTootResponseWithArrayData() throws {
         // arrange
         let arrayData = ["item1", "item2", "item3"]
-        
+
         // act
         let response = TootResponse(
             data: arrayData,
@@ -402,14 +403,14 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // assert
         XCTAssertEqual(response.data.count, 3)
         XCTAssertEqual(response.data[0], "item1")
         XCTAssertEqual(response.data[1], "item2")
         XCTAssertEqual(response.data[2], "item3")
     }
-    
+
     func testTootResponseWithEmptyHeaders() throws {
         // arrange & act
         let response = TootResponse(
@@ -419,7 +420,7 @@ final class TootResponseTests: XCTestCase {
             url: sampleURL,
             rawBody: sampleRawBody
         )
-        
+
         // assert
         XCTAssertNil(response.rateLimitLimit)
         XCTAssertNil(response.rateLimitRemaining)

--- a/Tests/TootSDKTests/TootResponseTests.swift
+++ b/Tests/TootSDKTests/TootResponseTests.swift
@@ -1,0 +1,432 @@
+//
+//  TootResponseTests.swift
+//
+//
+//  Created by Claude on TootSDK Implementation
+//
+
+import XCTest
+import Foundation
+
+@testable import TootSDK
+
+final class TootResponseTests: XCTestCase {
+    
+    // MARK: - Test Data
+    
+    private let sampleHeaders: [String: String] = [
+        "Content-Type": "application/json",
+        "X-RateLimit-Limit": "300",
+        "X-RateLimit-Remaining": "299",
+        "X-RateLimit-Reset": "1640995200",
+        "Link": "<https://example.com/api/v1/accounts?limit=40&min_id=109>; rel=\"next\", <https://example.com/api/v1/accounts?limit=40&max_id=108>; rel=\"prev\"",
+        "Cache-Control": "no-cache, no-store",
+        "ETag": "\"abc123\"",
+        "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
+        "Server": "Mastodon/4.0.0",
+        "X-Request-Id": "req-12345",
+        "X-Response-Time": "0.123s",
+        "Mastodon-Version": "4.0.0",
+        "X-Instance-Name": "example.com",
+        "X-Software-Name": "mastodon",
+        "X-Software-Version": "4.0.0",
+        "Deprecation": "true",
+        "Sunset": "Wed, 11 Nov 2020 23:59:59 GMT",
+        "Content-Security-Policy": "default-src 'self'",
+        "Strict-Transport-Security": "max-age=31536000",
+        "X-Frame-Options": "DENY",
+        "X-Content-Type-Options": "nosniff"
+    ]
+    
+    private let sampleData = ["test": "data"]
+    private let sampleURL = URL(string: "https://example.com/api/v1/test")!
+    private let sampleRawBody = Data("test response".utf8)
+    
+    // MARK: - Initialization Tests
+    
+    func testTootResponseInitialization() throws {
+        // arrange & act
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // assert
+        XCTAssertEqual(response.data["test"], "data")
+        XCTAssertEqual(response.headers.count, sampleHeaders.count)
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(response.url, sampleURL)
+        XCTAssertEqual(response.rawBody, sampleRawBody)
+    }
+    
+    // MARK: - Rate Limiting Header Tests
+    
+    func testRateLimitHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.rateLimitLimit, 300)
+        XCTAssertEqual(response.rateLimitRemaining, 299)
+        XCTAssertNotNil(response.rateLimitReset)
+        
+        let expectedResetDate = Date(timeIntervalSince1970: 1640995200)
+        XCTAssertEqual(response.rateLimitReset, expectedResetDate)
+    }
+    
+    func testRateLimitHeadersWithInvalidValues() throws {
+        // arrange
+        let invalidHeaders = [
+            "X-RateLimit-Limit": "invalid",
+            "X-RateLimit-Remaining": "not-a-number",
+            "X-RateLimit-Reset": "invalid-timestamp"
+        ]
+        
+        let response = TootResponse(
+            data: sampleData,
+            headers: invalidHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertNil(response.rateLimitLimit)
+        XCTAssertNil(response.rateLimitRemaining)
+        XCTAssertNil(response.rateLimitReset)
+    }
+    
+    // MARK: - Pagination Header Tests
+    
+    func testPaginationHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertNotNil(response.linkHeader)
+        XCTAssertTrue(response.linkHeader!.contains("rel=\"next\""))
+        XCTAssertTrue(response.linkHeader!.contains("rel=\"prev\""))
+    }
+    
+    // MARK: - Content Header Tests
+    
+    func testContentHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.contentType, "application/json")
+        XCTAssertNil(response.contentLength) // Not included in sample headers
+        XCTAssertNil(response.contentEncoding) // Not included in sample headers
+    }
+    
+    // MARK: - Cache Header Tests
+    
+    func testCacheHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.cacheControl, "no-cache, no-store")
+        XCTAssertEqual(response.etag, "\"abc123\"")
+        XCTAssertNotNil(response.lastModified)
+    }
+    
+    func testLastModifiedParsing() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act
+        let lastModified = response.lastModified
+        
+        // assert
+        XCTAssertNotNil(lastModified)
+        
+        // Use UTC calendar to avoid timezone issues
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(abbreviation: "GMT")!
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: lastModified!)
+        XCTAssertEqual(components.year, 2015)
+        XCTAssertEqual(components.month, 10)
+        XCTAssertEqual(components.day, 21)
+        XCTAssertEqual(components.hour, 7)
+        XCTAssertEqual(components.minute, 28)
+    }
+    
+    // MARK: - Server Information Header Tests
+    
+    func testServerHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.server, "Mastodon/4.0.0")
+        XCTAssertEqual(response.requestId, "req-12345")
+        XCTAssertEqual(response.responseTime, "0.123s")
+    }
+    
+    func testRequestIdFallback() throws {
+        // arrange - test fallback from X-Request-Id to X-Request-ID
+        let headersWithFallback = ["X-Request-ID": "fallback-id"]
+        let response = TootResponse(
+            data: sampleData,
+            headers: headersWithFallback,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.requestId, "fallback-id")
+    }
+    
+    // MARK: - Mastodon/Fediverse Specific Header Tests
+    
+    func testFediverseHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.mastodonVersion, "4.0.0")
+        XCTAssertEqual(response.instanceName, "example.com")
+        XCTAssertEqual(response.softwareName, "mastodon")
+        XCTAssertEqual(response.softwareVersion, "4.0.0")
+        XCTAssertEqual(response.deprecationWarning, "true")
+        XCTAssertEqual(response.sunsetWarning, "Wed, 11 Nov 2020 23:59:59 GMT")
+    }
+    
+    // MARK: - Security Header Tests
+    
+    func testSecurityHeaders() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.contentSecurityPolicy, "default-src 'self'")
+        XCTAssertEqual(response.strictTransportSecurity, "max-age=31536000")
+        XCTAssertEqual(response.xFrameOptions, "DENY")
+        XCTAssertEqual(response.xContentTypeOptions, "nosniff")
+    }
+    
+    // MARK: - Status Code Convenience Tests
+    
+    func testStatusCodeConvenience() throws {
+        // Test successful response
+        let successResponse = TootResponse(
+            data: sampleData,
+            headers: [:],
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        XCTAssertTrue(successResponse.isSuccessful)
+        XCTAssertFalse(successResponse.isRedirection)
+        XCTAssertFalse(successResponse.isClientError)
+        XCTAssertFalse(successResponse.isServerError)
+        
+        // Test redirection response
+        let redirectResponse = TootResponse(
+            data: sampleData,
+            headers: [:],
+            statusCode: 301,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        XCTAssertFalse(redirectResponse.isSuccessful)
+        XCTAssertTrue(redirectResponse.isRedirection)
+        XCTAssertFalse(redirectResponse.isClientError)
+        XCTAssertFalse(redirectResponse.isServerError)
+        
+        // Test client error response
+        let clientErrorResponse = TootResponse(
+            data: sampleData,
+            headers: [:],
+            statusCode: 404,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        XCTAssertFalse(clientErrorResponse.isSuccessful)
+        XCTAssertFalse(clientErrorResponse.isRedirection)
+        XCTAssertTrue(clientErrorResponse.isClientError)
+        XCTAssertFalse(clientErrorResponse.isServerError)
+        
+        // Test server error response
+        let serverErrorResponse = TootResponse(
+            data: sampleData,
+            headers: [:],
+            statusCode: 500,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        XCTAssertFalse(serverErrorResponse.isSuccessful)
+        XCTAssertFalse(serverErrorResponse.isRedirection)
+        XCTAssertFalse(serverErrorResponse.isClientError)
+        XCTAssertTrue(serverErrorResponse.isServerError)
+    }
+    
+    // MARK: - Convenience Method Tests
+    
+    func testCaseInsensitiveHeaderLookup() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act & assert
+        XCTAssertEqual(response.header(named: "content-type"), "application/json")
+        XCTAssertEqual(response.header(named: "CONTENT-TYPE"), "application/json")
+        XCTAssertEqual(response.header(named: "Content-Type"), "application/json")
+        XCTAssertNil(response.header(named: "non-existent-header"))
+    }
+    
+    func testHeadersWithPrefix() throws {
+        // arrange
+        let response = TootResponse(
+            data: sampleData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // act
+        let rateLimitHeaders = response.headers(withPrefix: "x-ratelimit")
+        let xHeaders = response.headers(withPrefix: "x-")
+        
+        // assert
+        XCTAssertEqual(rateLimitHeaders.count, 3)
+        XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Limit"))
+        XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Remaining"))
+        XCTAssertTrue(rateLimitHeaders.keys.contains("X-RateLimit-Reset"))
+        
+        XCTAssertTrue(xHeaders.count >= 6) // At least the X- headers we defined
+        XCTAssertTrue(xHeaders.keys.contains("X-Request-Id"))
+        XCTAssertTrue(xHeaders.keys.contains("X-Response-Time"))
+    }
+    
+    // MARK: - Integration Tests
+    
+    func testTootResponseWithTypedData() throws {
+        // arrange
+        struct TestModel: Codable, Equatable {
+            let id: String
+            let name: String
+        }
+        
+        let testModel = TestModel(id: "123", name: "Test")
+        
+        // act
+        let response = TootResponse(
+            data: testModel,
+            headers: sampleHeaders,
+            statusCode: 201,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // assert
+        XCTAssertEqual(response.data, testModel)
+        XCTAssertEqual(response.statusCode, 201)
+        XCTAssertTrue(response.isSuccessful)
+        XCTAssertEqual(response.rateLimitLimit, 300)
+    }
+    
+    func testTootResponseWithArrayData() throws {
+        // arrange
+        let arrayData = ["item1", "item2", "item3"]
+        
+        // act
+        let response = TootResponse(
+            data: arrayData,
+            headers: sampleHeaders,
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // assert
+        XCTAssertEqual(response.data.count, 3)
+        XCTAssertEqual(response.data[0], "item1")
+        XCTAssertEqual(response.data[1], "item2")
+        XCTAssertEqual(response.data[2], "item3")
+    }
+    
+    func testTootResponseWithEmptyHeaders() throws {
+        // arrange & act
+        let response = TootResponse(
+            data: sampleData,
+            headers: [:],
+            statusCode: 200,
+            url: sampleURL,
+            rawBody: sampleRawBody
+        )
+        
+        // assert
+        XCTAssertNil(response.rateLimitLimit)
+        XCTAssertNil(response.rateLimitRemaining)
+        XCTAssertNil(response.rateLimitReset)
+        XCTAssertNil(response.linkHeader)
+        XCTAssertNil(response.contentType)
+        XCTAssertNil(response.mastodonVersion)
+        XCTAssertTrue(response.isSuccessful)
+    }
+}


### PR DESCRIPTION
This PR fixes #331 by exposing HTTP response headers and metadata from TootSDK API calls while maintaining backward compatibility. 

## Design Approach

### 1. TootResponse<T> Wrapper Type

Create a new generic wrapper type that contains:

- **data**: The decoded response data (existing return type)
- **headers**: HTTP response headers as `[String: String]`
- **statusCode**: HTTP status code
- **url**: Response URL
- **rawBody**: Raw response body as `Data` (for debugging/fallback)

### 2. Backward Compatible Implementation

- **Existing method signatures remain unchanged** - No breaking changes to current API
- **Implementation migration** - Current method implementations will be moved to new `*Raw()` methods
- **Delegation pattern** - Existing methods will be refactored to call Raw methods and extract only the data property

### 3. Method Naming Convention

For each existing method like `getLists()`, add:

- `getListsRaw() async throws -> TootResponse<[List]>`


## Before merging

- [ ] Update CLAUDE.md to reflect the *Raw() method approach for future additions.
