### PR TITLE
Feature requirement can target fediverse server flavours by version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -62,6 +62,15 @@
         "revision" : "bba848db50462894e7fc0891d018dfecad4ef11e",
         "version" : "2.8.7"
       }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version.git",
+      "state" : {
+        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
+        "version" : "2.2.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.7"),
         .package(url: "https://github.com/karwa/swift-url.git", from: "0.4.2"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
+        .package(url: "https://github.com/mxcl/Version.git", from: "2.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -45,6 +46,7 @@ let package = Package(
                 .product(name: "WebURL", package: "swift-url"),
                 .product(name: "WebURLFoundationExtras", package: "swift-url"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "Version", package: "Version"),
             ],
             resources: [.copy("PrivacyInfo.xcprivacy")]
         ),

--- a/Sources/TootSDK/Models/TootFeature.swift
+++ b/Sources/TootSDK/Models/TootFeature.swift
@@ -1,8 +1,139 @@
 import Foundation
+import Version
 
 /// Represents a feature that is not supported by all flavours.
-public struct TootFeature {
+public struct TootFeature: Equatable {
 
-    /// Flavours that support this feature.
-    public let supportedFlavours: Set<TootSDKFlavour>
+    /// Represents a flavour requirement with optional version constraints
+    public struct FlavourRequirement: Equatable {
+        let flavour: TootSDKFlavour
+        let minVersion: Version?
+        let maxVersion: Version?
+
+        /// Create a requirement for any version of a flavour
+        public static func any(_ flavour: TootSDKFlavour) -> FlavourRequirement {
+            FlavourRequirement(flavour: flavour, minVersion: nil, maxVersion: nil)
+        }
+
+        /// Create a requirement for a minimum version
+        public static func from(_ flavour: TootSDKFlavour, version: String) -> FlavourRequirement {
+            FlavourRequirement(flavour: flavour, minVersion: Version(tolerant: version), maxVersion: nil)
+        }
+
+        /// Create a requirement for a version range
+        public static func range(_ flavour: TootSDKFlavour, from: String, to: String) -> FlavourRequirement {
+            FlavourRequirement(
+                flavour: flavour,
+                minVersion: Version(tolerant: from),
+                maxVersion: Version(tolerant: to)
+            )
+        }
+
+        /// Create a requirement for a maximum version
+        public static func until(_ flavour: TootSDKFlavour, version: String) -> FlavourRequirement {
+            FlavourRequirement(flavour: flavour, minVersion: nil, maxVersion: Version(tolerant: version))
+        }
+    }
+
+    /// The requirements for this feature
+    public let requirements: [FlavourRequirement]
+
+    /// Legacy initializer for backward compatibility
+    public init(supportedFlavours: Set<TootSDKFlavour>) {
+        self.requirements = supportedFlavours.map { FlavourRequirement.any($0) }
+    }
+
+    /// New version-aware initializer
+    public init(requirements: [FlavourRequirement]) {
+        self.requirements = requirements
+    }
+
+    /// Initialize with "any flavour except specific version requirements" pattern
+    /// - Parameters:
+    ///   - anyExcept: Flavours that should support any version
+    ///   - versionRequirements: Specific version requirements for certain flavours
+    public init(anyExcept: Set<TootSDKFlavour>, versionRequirements: [FlavourRequirement]) {
+        // Create requirements for "any version" flavours
+        let anyRequirements = anyExcept.map { FlavourRequirement.any($0) }
+        // Combine with specific version requirements
+        self.requirements = anyRequirements + versionRequirements
+    }
+
+    /// Initialize with default support for all flavours except specific version requirements
+    /// Useful for features that are generally available but have version constraints on certain servers
+    /// - Parameter versionRequirements: Specific version requirements for certain flavours
+    public init(allExcept versionRequirements: [FlavourRequirement]) {
+        // Get all flavours not mentioned in version requirements
+        let flavoursWithRequirements = Set(versionRequirements.map { $0.flavour })
+        let anyFlavours = Set(TootSDKFlavour.allCases).subtracting(flavoursWithRequirements)
+
+        // Create requirements for "any version" flavours
+        let anyRequirements = anyFlavours.map { FlavourRequirement.any($0) }
+        // Combine with specific version requirements
+        self.requirements = anyRequirements + versionRequirements
+    }
+
+    /// Check if feature is supported by an instance (for testing)
+    public func isSupported(by instance: any Instance) -> Bool {
+        return isSupported(flavour: instance.flavour, version: instance.version)
+    }
+
+    /// Check if feature is supported by a specific flavour and version string
+    public func isSupported(flavour: TootSDKFlavour, version: String?) -> Bool {
+        // Parse version with fallback to regex extraction
+        let versionObj = version.flatMap { Self.parseVersion(from: $0) }
+        return isSupported(flavour: flavour, version: versionObj)
+    }
+
+    /// Check if feature is supported by a specific flavour and parsed version
+    public func isSupported(flavour: TootSDKFlavour, version: Version?) -> Bool {
+        return requirements.contains { req in
+            guard req.flavour == flavour else { return false }
+
+            if let version = version {
+                if let minVersion = req.minVersion, version < minVersion {
+                    return false
+                }
+                if let maxVersion = req.maxVersion, version > maxVersion {
+                    return false
+                }
+            } else if req.minVersion != nil || req.maxVersion != nil {
+                // Version required but not available
+                return false
+            }
+
+            return true
+        }
+    }
+
+    /// Parse version from string with fallback to regex extraction
+    public static func parseVersion(from versionString: String) -> Version? {
+        // First try the Version library's tolerant parsing
+        if let version = Version(tolerant: versionString) {
+            return version
+        }
+
+        // If that fails, use regex to find the first version-like pattern
+        let pattern = #"\d+\.\d+(?:\.\d+)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return nil
+        }
+
+        let range = NSRange(location: 0, length: versionString.utf16.count)
+        guard let match = regex.firstMatch(in: versionString, options: [], range: range) else {
+            return nil
+        }
+
+        guard let matchRange = Range(match.range, in: versionString) else {
+            return nil
+        }
+
+        let extractedVersion = String(versionString[matchRange])
+        return Version(tolerant: extractedVersion)
+    }
+
+    /// Legacy computed property for backward compatibility
+    public var supportedFlavours: Set<TootSDKFlavour> {
+        Set(requirements.map { $0.flavour })
+    }
 }

--- a/Sources/TootSDK/Models/TootSDKError.swift
+++ b/Sources/TootSDK/Models/TootSDKError.swift
@@ -17,6 +17,8 @@ public enum TootSDKError: Error, LocalizedError, Equatable {
     case invalidParameter(parameterName: String, reason: String)
     /// The requested operation is not supported by the current server flavour.
     case unsupportedFlavour(current: TootSDKFlavour, required: Set<TootSDKFlavour>)
+    /// The requested feature is not supported by the current server flavour or version.
+    case unsupportedFeature(feature: TootFeature)
     case unexpectedError(_ description: String)
     /// The remote instance did not respond with the expected payload during authorization
     case clientAuthorizationFailed
@@ -57,6 +59,8 @@ public enum TootSDKError: Error, LocalizedError, Equatable {
         case .unsupportedFlavour(let current, let required):
             return
                 "Operation not supported for server flavour \(current), compatible flavours are: \(required.map({"\($0)"}).joined(separator: ", "))."
+        case .unsupportedFeature:
+            return "This feature is not supported by the current server or version."
         case .unexpectedError(let description):
             return "Unexpected error: \(description)"
         case .clientAuthorizationFailed:

--- a/Sources/TootSDK/TootClient/TootClient+Media.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Media.swift
@@ -110,20 +110,22 @@ extension TootClient {
 
     /// Delete a media attachment that is not currently attached to a status.
     ///
-    /// Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher.
+    /// Only supported on Mastodon 4.4 or higher.
     ///
     /// - Parameter id: The ID of the ``MediaAttachment`` in the database.
     public func deleteMedia(id: String) async throws {
+        try requireFeature(.deleteMedia)
         _ = try await deleteMediaRaw(id: id)
     }
 
     /// Delete a media attachment with HTTP response metadata
     ///
-    /// Only supported if ``InstanceV2/apiVersions-swift.property`` includes ``InstanceV2/APIVersions-swift.struct/mastodon`` API version 4 or higher.
+    /// Only supported on Mastodon 4.4 or higher.
     ///
     /// - Parameter id: The ID of the ``MediaAttachment`` in the database.
     /// - Returns: TootResponse containing HTTP metadata (the data field will be Void)
     public func deleteMediaRaw(id: String) async throws -> TootResponse<Void> {
+        try requireFeature(.deleteMedia)
         let req = HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "media", id])
             $0.method = .delete
@@ -223,4 +225,12 @@ extension TootClient {
         }
         return parts
     }
+}
+
+extension TootFeature {
+    /// Delete media attachment feature - requires Mastodon 4.4+
+    /// Only available on Mastodon (4.4+), not on other servers
+    public static let deleteMedia = TootFeature(requirements: [
+        .from(.mastodon, version: "4.4.0")
+    ])
 }

--- a/Tests/TootSDKTests/FlavourTests.swift
+++ b/Tests/TootSDKTests/FlavourTests.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2023. All rights reserved.
 
 import Foundation
+import Version
 import XCTest
 
 @testable import TootSDK
@@ -146,5 +147,223 @@ final class FlavourTests: XCTestCase {
     func testDetectsNodeInfoGoToSocial() throws {
         let instance = try localObject(NodeInfo.self, "nodeinfo_gotosocial")
         XCTAssertEqual(instance.flavour, .goToSocial)
+    }
+
+    // MARK: - Version requirement tests
+
+    func testDeleteMediaRequiresMastodon44() throws {
+        // Load a real Mastodon instance and modify version for testing
+        var mastodonBase = try localObject(InstanceV1.self, "mastodon")
+
+        // Test with Mastodon 4.4.0 - should pass
+        mastodonBase.version = "4.4.0"
+        XCTAssertTrue(TootFeature.deleteMedia.isSupported(by: mastodonBase))
+
+        // Test with Mastodon 4.3.0 - should fail
+        mastodonBase.version = "4.3.0"
+        XCTAssertFalse(TootFeature.deleteMedia.isSupported(by: mastodonBase))
+
+        // Test with Mastodon 4.5.0 - should pass
+        mastodonBase.version = "4.5.0"
+        XCTAssertTrue(TootFeature.deleteMedia.isSupported(by: mastodonBase))
+
+        // Test with pre-release version - pre-release is considered less than release
+        // So 4.4.0-rc1 < 4.4.0, thus should fail
+        mastodonBase.version = "4.4.0-rc1"
+        XCTAssertFalse(TootFeature.deleteMedia.isSupported(by: mastodonBase))
+
+        // But 4.4.1 should pass
+        mastodonBase.version = "4.4.1"
+        XCTAssertTrue(TootFeature.deleteMedia.isSupported(by: mastodonBase))
+    }
+
+    func testDeleteMediaNotSupportedOnOtherFlavours() throws {
+        // Load a real Pleroma instance to test - should fail even with high version
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertFalse(TootFeature.deleteMedia.isSupported(by: pleromaInstance))
+
+        // Load a real Pixelfed instance - should also fail
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        XCTAssertFalse(TootFeature.deleteMedia.isSupported(by: pixelfedInstance))
+    }
+
+    func testBackwardCompatibilityWithoutVersion() throws {
+        // Test existing features without version requirements still work
+        let feature = TootFeature(supportedFlavours: [.mastodon, .pleroma])
+
+        let mastodonInstance = try localObject(InstanceV1.self, "mastodon")
+        XCTAssertTrue(feature.isSupported(by: mastodonInstance))
+
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertTrue(feature.isSupported(by: pleromaInstance))
+
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        XCTAssertFalse(feature.isSupported(by: pixelfedInstance))
+    }
+
+    // MARK: - "All Except" Pattern Tests
+
+    func testUploadMediaAllExceptPattern() throws {
+        // Test feature: supported on all servers, but Mastodon requires 3.0+
+        // This demonstrates the "allExcept" pattern
+        let feature = TootFeature(allExcept: [
+            .from(.mastodon, version: "3.0.0")
+        ])
+
+        // Test with Mastodon - needs version 3.0+
+        var mastodonBase = try localObject(InstanceV1.self, "mastodon")
+
+        // Mastodon 3.0.0 - should pass
+        mastodonBase.version = "3.0.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        // Mastodon 2.9.0 - should fail
+        mastodonBase.version = "2.9.0"
+        XCTAssertFalse(feature.isSupported(by: mastodonBase))
+
+        // Mastodon 4.0.0 - should pass
+        mastodonBase.version = "4.0.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        // Test other flavours - should all support any version
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertTrue(feature.isSupported(by: pleromaInstance))
+
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        XCTAssertTrue(feature.isSupported(by: pixelfedInstance))
+
+        let friendicaInstance = try localObject(InstanceV1.self, "instance_friendica_nocontact")
+        XCTAssertTrue(feature.isSupported(by: friendicaInstance))
+
+        let akkomaInstance = try localObject(InstanceV1.self, "instance_akkoma")
+        XCTAssertTrue(feature.isSupported(by: akkomaInstance))
+    }
+
+    // MARK: - "Any Except" Pattern Tests
+
+    func testGetMediaAttachmentAnyExceptPattern() throws {
+        // Test feature: available on specific servers with various requirements
+        // This demonstrates the "anyExcept" pattern
+        let feature = TootFeature(
+            anyExcept: [.pleroma, .akkoma, .friendica],  // These support any version
+            versionRequirements: [
+                .from(.mastodon, version: "3.1.0"),  // Mastodon needs 3.1+
+                .from(.pixelfed, version: "2.0.0"),  // Pixelfed compatibility version needs 2.0+
+            ]
+        )
+
+        // Test Pleroma - supports any version (in anyExcept list)
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertTrue(feature.isSupported(by: pleromaInstance))
+
+        // Test Akkoma - supports any version (in anyExcept list)
+        let akkomaInstance = try localObject(InstanceV1.self, "instance_akkoma")
+        XCTAssertTrue(feature.isSupported(by: akkomaInstance))
+
+        // Test Friendica - supports any version (in anyExcept list)
+        let friendicaInstance = try localObject(InstanceV1.self, "instance_friendica_nocontact")
+        XCTAssertTrue(feature.isSupported(by: friendicaInstance))
+
+        // Test Mastodon - needs 3.1.0+
+        var mastodonBase = try localObject(InstanceV1.self, "mastodon")
+
+        mastodonBase.version = "3.1.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        mastodonBase.version = "3.0.0"
+        XCTAssertFalse(feature.isSupported(by: mastodonBase))
+
+        mastodonBase.version = "4.0.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        // Test Pixelfed - needs 2.0.0+ (Pixelfed reports Mastodon-compatible version)
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        // Actual test data has "2.7.2 (compatible; Pixelfed 0.11.4)" which parses as "2.7.2"
+        XCTAssertTrue(feature.isSupported(by: pixelfedInstance), "Pixelfed with version \(pixelfedInstance.version) should be supported")
+
+        // Test with modified version - keep Pixelfed identifier for flavour detection
+        var pixelfedBase = pixelfedInstance
+        pixelfedBase.version = "1.9.0 (compatible; Pixelfed 0.9.0)"
+        XCTAssertFalse(feature.isSupported(by: pixelfedBase))
+
+        pixelfedBase.version = "2.0.0 (compatible; Pixelfed 0.10.0)"
+        XCTAssertTrue(feature.isSupported(by: pixelfedBase))
+
+        // Test unsupported flavours (not in anyExcept list and not in versionRequirements)
+        let firefishInstance = try localObject(InstanceV1.self, "instance_firefish_contact_removed")
+        XCTAssertFalse(feature.isSupported(by: firefishInstance))
+
+        let sharkeyInstance = try localObject(InstanceV1.self, "instance_sharkey_contact_removed")
+        XCTAssertFalse(feature.isSupported(by: sharkeyInstance))
+    }
+
+    func testFeatureWithNoVersionRequirements() throws {
+        // Test a feature that supports specific flavours without any version requirements
+        let feature = TootFeature(requirements: [
+            .any(.mastodon),
+            .any(.pleroma),
+            .any(.pixelfed),
+        ])
+
+        // All these should work regardless of version
+        let mastodonInstance = try localObject(InstanceV1.self, "mastodon")
+        XCTAssertTrue(feature.isSupported(by: mastodonInstance))
+
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertTrue(feature.isSupported(by: pleromaInstance))
+
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        XCTAssertTrue(feature.isSupported(by: pixelfedInstance))
+
+        // This should not work
+        let friendicaInstance = try localObject(InstanceV1.self, "instance_friendica_nocontact")
+        XCTAssertFalse(feature.isSupported(by: friendicaInstance))
+    }
+
+    func testFeatureWithMixedRequirements() throws {
+        // Test a feature with mixed requirements - some with versions, some without
+        let feature = TootFeature(requirements: [
+            .any(.pleroma),  // Any version of Pleroma
+            .from(.mastodon, version: "3.5.0"),  // Mastodon 3.5+
+            .range(.pixelfed, from: "2.0.0", to: "3.0.0"),  // Pixelfed 2.0 to <3.0 (max exclusive)
+        ])
+
+        // Pleroma should work with any version
+        let pleromaInstance = try localObject(InstanceV1.self, "pleroma")
+        XCTAssertTrue(feature.isSupported(by: pleromaInstance))
+
+        // Mastodon tests
+        var mastodonBase = try localObject(InstanceV1.self, "mastodon")
+        mastodonBase.version = "3.5.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        mastodonBase.version = "3.4.0"
+        XCTAssertFalse(feature.isSupported(by: mastodonBase))
+
+        mastodonBase.version = "4.0.0"
+        XCTAssertTrue(feature.isSupported(by: mastodonBase))
+
+        // Pixelfed tests (uses Mastodon-compatible version numbers)
+        let pixelfedInstance = try localObject(InstanceV1.self, "pixelfed")
+        // Test data has "2.7.2 (compatible; Pixelfed 0.11.4)" which our regex extracts as "2.7.2"
+        // This is within 2.0 to <3.0 range
+        XCTAssertTrue(feature.isSupported(by: pixelfedInstance))
+
+        var pixelfedBase = pixelfedInstance
+        // Keep Pixelfed identifier in version string for flavour detection
+        pixelfedBase.version = "2.0.0 (compatible; Pixelfed 0.10.0)"
+        XCTAssertTrue(feature.isSupported(by: pixelfedBase))
+
+        pixelfedBase.version = "2.9.9 (compatible; Pixelfed 0.11.0)"
+        XCTAssertTrue(feature.isSupported(by: pixelfedBase))
+
+        pixelfedBase.version = "3.0.0 (compatible; Pixelfed 0.12.0)"
+        XCTAssertTrue(feature.isSupported(by: pixelfedBase), "3.0.0 should be included (max is inclusive)")
+
+        pixelfedBase.version = "3.0.1 (compatible; Pixelfed 0.12.1)"
+        XCTAssertFalse(feature.isSupported(by: pixelfedBase), "3.0.1 should be excluded (greater than max)")
+
+        pixelfedBase.version = "1.9.0 (compatible; Pixelfed 0.9.0)"
+        XCTAssertFalse(feature.isSupported(by: pixelfedBase))
     }
 }


### PR DESCRIPTION
Hi @daprice, this PR addresses the issue you previously raised regarding version checks (fixes #359). You are welcome to share any thoughts and comments!

The idea is that `TootFeature` is now responsible for parsing the flavour version and checking if it meets certain criteria. We now support several kinds of version checks depending on how the feature works (I updated `deleteMedia` as an example):


```swift
// Feature only for specific servers
let customFeature = TootFeature(supportedFlavours: [.mastodon, .pleroma])

// Feature with version requirements for specific servers
let versionedFeature = TootFeature(requirements: [
    .from(.mastodon, version: "4.0.0"),  // Mastodon 4.0+
    .any(.pleroma)                       // Any Pleroma version
])

// Feature supported by ALL servers, but with version requirements for some
let universalFeature = TootFeature(allExcept: [
    .from(.mastodon, version: "3.0.0"),  // Mastodon needs 3.0+
    .from(.pleroma, version: "2.0.0")    // Pleroma needs 2.0+
    // All other servers support any version
])

// Feature supported by specific servers, with version requirements for some
let selectiveFeature = TootFeature(
    anyExcept: [.friendica, .akkoma],    // These support any version
    versionRequirements: [
        .from(.mastodon, version: "3.5.0"),  // Mastodon needs 3.5+
        .from(.pixelfed, version: "2.0.0")   // Pixelfed needs 2.0+
    ]
)

// Check if current server supports it
if client.supportsFeature(customFeature) {
    // Use the feature
}
```

