### PR TITLE
Fix error parsing quote posts from Akkoma

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -87,6 +87,7 @@ let package = Package(
                 .copy("Resources/pixelfed.json"),
                 .copy("Resources/mastodon.json"),
                 .copy("Resources/pleroma.json"),
+                .copy("Resources/post_akkoma_quote.json"),
                 .copy("Resources/quote.json"),
                 .copy("Resources/relationship.json"),
                 .copy("Resources/relationship_sharkey.json"),

--- a/Tests/TootSDKTests/QuoteTests.swift
+++ b/Tests/TootSDKTests/QuoteTests.swift
@@ -19,10 +19,11 @@ final class QuoteTests: XCTestCase {
         let result: Quote = try decoder.decode(Quote.self, from: json)
 
         // assert
-        XCTAssertEqual(result.state.value, Quote.QuoteState.accepted)
+        XCTAssertEqual(result.state?.value, Quote.QuoteState.accepted)
         XCTAssertNotNil(result.quotedPost)
         if case let .post(quotedPost) = result.quotedPost {
             XCTAssertEqual(quotedPost.id, "103270115826048975")
+            XCTAssertNil(quotedPost.quote)
         } else {
             XCTFail("quotedPost should be a .post")
         }
@@ -37,12 +38,35 @@ final class QuoteTests: XCTestCase {
         let result: Quote = try decoder.decode(Quote.self, from: json)
 
         // assert
-        XCTAssertEqual(result.state.value, Quote.QuoteState.accepted)
+        XCTAssertEqual(result.state?.value, Quote.QuoteState.accepted)
         XCTAssertNotNil(result.quotedPost)
         if case let .postID(quotedPostID) = result.quotedPost {
             XCTAssertEqual(quotedPostID, "103270115826048975")
         } else {
             XCTFail("quotedPost should be a .postID")
+        }
+    }
+
+    func testAkkomaQuotePost() throws {
+        // arrange
+        let json = localContent("post_akkoma_quote")
+        let decoder = TootDecoder()
+
+        // act
+        let resultPost: Post = try decoder.decode(Post.self, from: json)
+        guard let resultQuote = resultPost.quote else {
+            XCTFail("quote should not be nil")
+            return
+        }
+
+        // assert
+        XCTAssertNil(resultQuote.state)
+        XCTAssertNotNil(resultQuote.quotedPost)
+        if case let .post(quotedPost) = resultQuote.quotedPost {
+            XCTAssertEqual(quotedPost.id, "Al2KABLN3tuRoeE0A4")
+            XCTAssertNil(quotedPost.quote)
+        } else {
+            XCTFail("quotedPost should be a .post")
         }
     }
 }

--- a/Tests/TootSDKTests/Resources/post_akkoma_quote.json
+++ b/Tests/TootSDKTests/Resources/post_akkoma_quote.json
@@ -1,0 +1,604 @@
+  {
+    "media_attachments" : [
+
+    ],
+    "reblog" : null,
+    "created_at" : "2024-08-17T05:01:49.000Z",
+    "id" : "Al30Y6dIQNzsEKhR5s",
+    "emojis" : [
+
+    ],
+    "card" : {
+      "provider_name" : "universeodon.com",
+      "pleroma" : {
+        "opengraph" : {
+          "description" : "Attached: 1 image\n\ngot a flu shot and fruit tea",
+          "image:type" : "image/jpeg",
+          "image:height" : "3620",
+          "site_name" : "Universeodon Social Media",
+          "image:alt" : "fruit tea next to a pharmacy paper bag of vaccine info",
+          "url" : "https://universeodon.com/@technicat/112973737736509814",
+          "type" : "article",
+          "title" : "technicat (@technicat@universeodon.com)",
+          "image" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg",
+          "card" : "summary_large_image",
+          "published_time" : "2024-08-16T21:07:13Z",
+          "image:width" : "2715"
+        }
+      },
+      "provider_url" : "https://universeodon.com",
+      "title" : "technicat (@technicat@universeodon.com)",
+      "image" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg",
+      "type" : "link",
+      "description" : "Attached: 1 image\n\ngot a flu shot and fruit tea",
+      "url" : "https://universeodon.com/@technicat/112973737736509814"
+    },
+    "sensitive" : false,
+    "pinned" : false,
+    "pleroma" : {
+      "parent_visible" : false,
+      "direct_conversation_id" : null,
+      "emoji_reactions" : [
+
+      ],
+      "context" : "tag:universeodon.com,2024-08-16:objectId=198699402:objectType=Conversation",
+      "expires_at" : null,
+      "thread_muted" : false,
+      "spoiler_text" : {
+        "text/plain" : ""
+      },
+      "conversation_id" : 2057681460,
+      "in_reply_to_account_acct" : null,
+      "local" : true,
+      "pinned_at" : null,
+      "content" : {
+        "text/plain" : "from @technicathttps://universeodon.com/@technicat/112973737736509814"
+      }
+    },
+    "in_reply_to_account_id" : null,
+    "quote_id" : "Al2KABLN3tuRoeE0A4",
+    "text" : null,
+    "url" : "https://miraiverse.xyz/notice/Al30Y6dIQNzsEKhR5s",
+    "account" : {
+      "bot" : false,
+      "avatar_static" : "https://r2.miraiverse.xyz/09e56eeb4a5e1c172c78ef2a4d505eb9c04a0fc5e60a86b7dfdbffcc8ac09b42.avatar",
+      "source" : {
+        "pleroma" : {
+          "no_rich_text" : false,
+          "actor_type" : "Person",
+          "discoverable" : false,
+          "show_role" : true
+        },
+        "fields" : [
+          {
+            "name" : "test",
+            "value" : "vavb"
+          }
+        ],
+        "sensitive" : false,
+        "privacy" : "public",
+        "note" : ""
+      },
+      "locked" : false,
+      "statuses_count" : 8,
+      "url" : "https://miraiverse.xyz/users/technicat",
+      "following_count" : 3,
+      "acct" : "technicat",
+      "emojis" : [
+
+      ],
+      "pleroma" : {
+        "is_suggested" : false,
+        "tags" : [
+
+        ],
+        "also_known_as" : [
+
+        ],
+        "unread_notifications_count" : 0,
+        "hide_favorites" : true,
+        "relationship" : {
+
+        },
+        "ap_id" : "https://miraiverse.xyz/users/technicat",
+        "is_confirmed" : true,
+        "hide_followers_count" : true,
+        "allow_following_move" : true,
+        "hide_follows" : true,
+        "skip_thread_containment" : false,
+        "background_image" : null,
+        "notification_settings" : {
+          "block_from_strangers" : false,
+          "hide_notification_contents" : false
+        },
+        "email" : "pc@pc.cafe",
+        "is_admin" : false,
+        "favicon" : "https://miraiverse.xyz/favicon.png",
+        "is_moderator" : false,
+        "hide_follows_count" : true,
+        "hide_followers" : true,
+        "unread_conversation_count" : 0
+      },
+      "last_status_at" : "2024-08-17",
+      "akkoma" : {
+        "status_ttl_days" : null,
+        "instance" : {
+          "name" : "miraiverse.xyz",
+          "favicon" : "https://miraiverse.xyz/favicon.png",
+          "nodeinfo" : {
+            "services" : {
+              "inbound" : [
+
+              ],
+              "outbound" : [
+
+              ]
+            },
+            "openRegistrations" : true,
+            "protocols" : [
+              "activitypub"
+            ],
+            "version" : "2.1",
+            "usage" : {
+              "users" : {
+                "total" : 745,
+                "activeMonth" : 108,
+                "activeHalfyear" : 201
+              },
+              "localPosts" : 52875
+            },
+            "metadata" : {
+              "nodeName" : "miraiverse",
+              "localBubbleInstances" : [
+                "mastodon.in.th",
+                "pleroma.in.th",
+                "mstdn.in.th"
+              ],
+              "postFormats" : [
+                "text/plain",
+                "text/html",
+                "text/markdown",
+                "text/bbcode",
+                "text/x.misskeymarkdown"
+              ],
+              "accountActivationRequired" : true,
+              "nodeDescription" : "สังคม Fediverse แห่งอนาคตที่เปิดโอกาสให้ทุกคนได้แสดงออกอย่างเต็มที่",
+              "publicTimelineVisibility" : {
+                "local" : true,
+                "bubble" : true,
+                "federated" : true
+              },
+              "private" : false,
+              "suggestions" : {
+                "enabled" : false
+              },
+              "invitesEnabled" : false,
+              "federatedTimelineAvailable" : true,
+              "uploadLimits" : {
+                "background" : 1000000,
+                "avatar" : 1000000,
+                "general" : 25000000,
+                "banner" : 1000000
+              },
+              "privilegedStaff" : false,
+              "federation" : {
+                "mrf_simple_info" : {
+
+                },
+                "mrf_object_age" : {
+                  "actions" : [
+                    "delist",
+                    "strip_followers"
+                  ],
+                  "threshold" : 604800
+                },
+                "enabled" : true,
+                "mrf_simple" : {
+                  "accept" : [
+
+                  ],
+                  "reject" : [
+
+                  ],
+                  "federated_timeline_removal" : [
+
+                  ],
+                  "followers_only" : [
+
+                  ],
+                  "report_removal" : [
+
+                  ],
+                  "media_nsfw" : [
+
+                  ],
+                  "banner_removal" : [
+
+                  ],
+                  "reject_deletes" : [
+
+                  ],
+                  "avatar_removal" : [
+
+                  ],
+                  "media_removal" : [
+
+                  ],
+                  "background_removal" : [
+
+                  ]
+                },
+                "mrf_policies" : [
+                  "ObjectAgePolicy",
+                  "TagPolicy",
+                  "SimplePolicy",
+                  "HashtagPolicy",
+                  "InlineQuotePolicy",
+                  "NormalizeMarkup",
+                  "DirectMessageDisabledPolicy"
+                ],
+                "quarantined_instances" : [
+
+                ],
+                "mrf_hashtag" : {
+                  "federated_timeline_removal" : [
+
+                  ],
+                  "sensitive" : [
+                    "nsfw"
+                  ],
+                  "reject" : [
+
+                  ]
+                },
+                "exclusions" : false,
+                "quarantined_instances_info" : {
+                  "quarantined_instances" : {
+
+                  }
+                }
+              },
+              "pollLimits" : {
+                "max_options" : 20,
+                "min_expiration" : 0,
+                "max_option_chars" : 200,
+                "max_expiration" : 31536000
+              },
+              "mailerEnabled" : true,
+              "staffAccounts" : [
+                "https://miraiverse.xyz/users/veer66",
+                "https://miraiverse.xyz/users/sukino"
+              ],
+              "skipThreadContainment" : true,
+              "features" : [
+                "pleroma_api",
+                "akkoma_api",
+                "mastodon_api",
+                "mastodon_api_streaming",
+                "polls",
+                "v2_suggestions",
+                "pleroma_explicit_addressing",
+                "shareable_emoji_packs",
+                "multifetch",
+                "pleroma:api/v1/notifications:include_types_filter",
+                "quote_posting",
+                "editing",
+                "bubble_timeline",
+                "pleroma_emoji_reactions",
+                "exposable_reactions",
+                "profile_directory",
+                "custom_emoji_reactions",
+                "pleroma:get:main/ostatus"
+              ],
+              "fieldsLimits" : {
+                "maxRemoteFields" : 20,
+                "nameLength" : 512,
+                "valueLength" : 2048,
+                "maxFields" : 10
+              },
+              "restrictedNicknames" : [
+                ".well-known",
+                "~",
+                "about",
+                "activities",
+                "api",
+                "auth",
+                "check_password",
+                "dev",
+                "friend-requests",
+                "inbox",
+                "internal",
+                "main",
+                "media",
+                "nodeinfo",
+                "notice",
+                "oauth",
+                "objects",
+                "ostatus_subscribe",
+                "pleroma",
+                "proxy",
+                "push",
+                "registration",
+                "relay",
+                "settings",
+                "status",
+
+                "tag",
+                "user-search",
+                "user_exists",
+                "users",
+                "web",
+                "verify_credentials",
+                "update_credentials",
+                "relationships",
+                "search",
+                "confirmation_resend",
+                "mfa"
+              ]
+            },
+            "software" : {
+              "name" : "akkoma",
+              "version" : "3.13.2-0-g050bc74",
+              "repository" : "https://akkoma.dev/AkkomaGang/akkoma"
+            }
+          }
+        },
+        "permit_followback" : false
+      },
+      "id" : "AdhbFZfyxZ7BgRaYOO",
+      "header_static" : "https://r2.miraiverse.xyz/9ae492ee4cbca270c9e30612d5685bb98f11b8975c3330ec4a8501beb750b1a8.header",
+      "followers_count" : 1,
+      "accepts_direct_messages_from" : "everybody",
+      "header" : "https://r2.miraiverse.xyz/9ae492ee4cbca270c9e30612d5685bb98f11b8975c3330ec4a8501beb750b1a8.header",
+      "note" : "",
+
+      "display_name" : "technicat",
+      "follow_requests_count" : 0,
+      "created_at" : "2024-01-10T12:04:42.000Z",
+      "fields" : [
+        {
+          "name" : "test",
+          "value" : "vavb"
+        }
+      ],
+      "avatar" : "https://r2.miraiverse.xyz/09e56eeb4a5e1c172c78ef2a4d505eb9c04a0fc5e60a86b7dfdbffcc8ac09b42.avatar",
+      "fqn" : "technicat@miraiverse.xyz",
+      "username" : "technicat"
+    },
+    "reblogs_count" : 0,
+    "edited_at" : null,
+    "in_reply_to_id" : null,
+    "emoji_reactions" : [
+
+    ],
+    "replies_count" : 0,
+    "reblogged" : false,
+    "application" : null,
+    "muted" : false,
+    "bookmarked" : false,
+    "akkoma" : {
+      "source" : {
+        "content" : "from @technicat@universeodon.com\n\nhttps://universeodon.com/@technicat/112973737736509814",
+        "mediaType" : "text/plain"
+      }
+    },
+    "mentions" : [
+      {
+        "username" : "technicat",
+        "id" : "AT7ECsy5VceFhhmhyy",
+        "url" : "https://universeodon.com/@technicat",
+        "acct" : "technicat@universeodon.com"
+      }
+    ],
+    "spoiler_text" : "",
+    "tags" : [
+
+    ],
+    "content" : "from <span class=\"h-card\"><a class=\"u-url mention\" data-user=\"AT7ECsy5VceFhhmhyy\" href=\"https://universeodon.com/@technicat\" rel=\"ugc\">@<span>technicat</span></a></span><br/><br/><a href=\"https://universeodon.com/@technicat/112973737736509814\" rel=\"ugc\">https://universeodon.com/@technicat/112973737736509814</a>",
+    "poll" : null,
+    "favourited" : false,
+    "quote" : {
+      "media_attachments" : [
+        {
+          "preview_url" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg",
+          "text_url" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg",
+          "id" : "1935758025",
+          "pleroma" : {
+            "mime_type" : "image/jpeg"
+          },
+          "blurhash" : "UNIELe01gPXnJ8x_%0Mw.9M|%L%0-o?bENx]",
+          "meta" : {
+            "original" : {
+              "width" : 2715,
+              "aspect" : 0.75,
+              "height" : 3620
+            }
+          },
+          "type" : "image",
+          "description" : "fruit tea next to a pharmacy paper bag of vaccine info",
+          "remote_url" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg",
+          "url" : "https://media.universeodon.com/media_attachments/files/112/973/737/676/311/390/original/6c1d2d680ac4f680.jpeg"
+        }
+      ],
+      "reblog" : null,
+      "created_at" : "2024-08-16T21:07:13.000Z",
+      "id" : "Al2KABLN3tuRoeE0A4",
+      "emojis" : [
+
+      ],
+      "card" : null,
+      "sensitive" : false,
+      "pinned" : false,
+      "pleroma" : {
+        "parent_visible" : false,
+        "direct_conversation_id" : null,
+        "emoji_reactions" : [
+
+        ],
+        "context" : "tag:universeodon.com,2024-08-16:objectId=198699402:objectType=Conversation",
+        "expires_at" : null,
+        "thread_muted" : false,
+        "spoiler_text" : {
+          "text/plain" : ""
+        },
+        "conversation_id" : 2057681460,
+        "in_reply_to_account_acct" : null,
+        "local" : false,
+        "pinned_at" : null,
+        "content" : {
+          "text/plain" : "got a flu shot and fruit tea"
+        }
+      },
+      "in_reply_to_account_id" : null,
+      "quote_id" : null,
+      "text" : null,
+      "url" : "https://universeodon.com/@technicat/112973737736509814",
+      "account" : {
+        "bot" : false,
+        "avatar_static" : "https://media.universeodon.com/accounts/avatars/109/821/003/814/913/641/original/10f40864ae456570.jpeg",
+        "source" : {
+          "pleroma" : {
+            "actor_type" : "Person",
+            "discoverable" : true
+          },
+          "fields" : [
+
+          ],
+          "sensitive" : false,
+          "note" : ""
+        },
+        "locked" : false,
+        "statuses_count" : 2960,
+        "url" : "https://universeodon.com/@technicat",
+        "following_count" : 437,
+        "acct" : "technicat@universeodon.com",
+        "emojis" : [
+
+        ],
+        "pleroma" : {
+          "skip_thread_containment" : false,
+          "also_known_as" : [
+
+          ],
+          "hide_follows_count" : false,
+          "tags" : [
+
+          ],
+          "is_moderator" : false,
+          "hide_follows" : false,
+          "hide_followers_count" : false,
+          "hide_followers" : false,
+          "is_confirmed" : true,
+          "is_suggested" : false,
+          "ap_id" : "https://universeodon.com/users/technicat",
+          "relationship" : {
+
+          },
+          "is_admin" : false,
+          "hide_favorites" : true,
+          "favicon" : "https://universeodon.com/favicon.ico",
+          "background_image" : null
+        },
+        "last_status_at" : "2024-08-17",
+        "akkoma" : {
+          "status_ttl_days" : null,
+          "instance" : {
+            "name" : "universeodon.com",
+            "favicon" : "https://universeodon.com/favicon.ico",
+            "nodeinfo" : {
+              "openRegistrations" : true,
+              "services" : {
+                "inbound" : [
+
+                ],
+                "outbound" : [
+
+                ]
+              },
+              "protocols" : [
+                "activitypub"
+              ],
+              "software" : {
+                "name" : "mastodon",
+                "version" : "4.2.10"
+              },
+              "usage" : {
+                "users" : {
+                  "total" : 80702,
+                  "activeMonth" : 5157,
+                  "activeHalfyear" : 13404
+                },
+                "localPosts" : 3501887
+              },
+              "metadata" : {
+
+              },
+              "version" : "2.0"
+            }
+          },
+          "permit_followback" : false
+        },
+        "id" : "AT7ECsy5VceFhhmhyy",
+        "header_static" : "https://media.universeodon.com/accounts/headers/109/821/003/814/913/641/original/3cee018b0d5d51f8.jpg",
+        "followers_count" : 374,
+        "fqn" : "technicat@universeodon.com",
+        "header" : "https://media.universeodon.com/accounts/headers/109/821/003/814/913/641/original/3cee018b0d5d51f8.jpg",
+        "note" : "<p>This is my talk (and block) about anything account. I’ve got other accounts all over the <a href=\"https://universeodon.com/tags/fediverse\" rel=\"tag\">#<span>fediverse</span></a>.</p>",
+        "display_name" : "technicat",
+        "avatar" : "https://media.universeodon.com/accounts/avatars/109/821/003/814/913/641/original/10f40864ae456570.jpeg",
+        "created_at" : "2023-02-27T20:15:53.000Z",
+        "fields" : [
+          {
+            "name" : "Codeberg",
+            "value" : "<a href=\"https://codeberg.org/technicat\">https://codeberg.org/technicat</a>"
+          },
+          {
+            "name" : "Phil Chu",
+            "value" : "<a href=\"https://philipchu.com\">https://philipchu.com</a>"
+          },
+          {
+            "name" : "Résumé",
+            "value" : "<a href=\"https://philipchu.com/resume\">https://philipchu.com/resume</a>"
+          },
+          {
+            "name" : "Technicat LLC",
+            "value" : "<a href=\"https://technicat.com/\">https://technicat.com/</a>"
+          }
+        ],
+        "username" : "technicat"
+      },
+      "reblogs_count" : 0,
+      "edited_at" : null,
+      "in_reply_to_id" : null,
+      "emoji_reactions" : [
+
+      ],
+      "replies_count" : 1,
+      "reblogged" : false,
+      "application" : null,
+      "muted" : false,
+      "bookmarked" : false,
+      "akkoma" : {
+        "source" : null
+      },
+      "mentions" : [
+
+      ],
+      "spoiler_text" : "",
+      "tags" : [
+
+      ],
+      "content" : "<p>got a flu shot and fruit tea</p>",
+      "poll" : null,
+      "favourited" : false,
+      "quote" : null,
+      "favourites_count" : 0,
+      "visibility" : "public",
+      "uri" : "https://universeodon.com/users/technicat/statuses/112973737736509814",
+      "language" : "en"
+    },
+    "favourites_count" : 0,
+    "visibility" : "public",
+    "uri" : "https://miraiverse.xyz/objects/37125e6c-e5ac-4151-98a4-257d04791e43",
+    "language" : "en"
+  }


### PR DESCRIPTION
This fixes the issue @technicat pointed out in #355 where post parsing would fail for Akkoma quote posts. Now if parsing as a `Quote` fails, it tries to parse it as a `Post` as a fallback, then packages it as a TootSDK `Quote` struct.

Breaking because `Quote.state` is now optional (left as `nil` for Akkoma and other flavors that put a `Post` directly in the `Quote` property).

For the test json, I used the example that @technicat linked to: https://codeberg.org/technicat/fedicat/src/branch/main/Tests/TootSDKTests/Resources/post_akkoma_quote.json