### PR TITLE
Added an example of a TootSDK graphical client using SharingGRDB

### DIFF
--- a/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.pbxproj
+++ b/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.pbxproj
@@ -1,0 +1,437 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1C85806B2E585D4700443C22 /* SharingGRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 1C85806A2E585D4700443C22 /* SharingGRDB */; };
+		1C85806D2E585D4700443C22 /* StructuredQueriesGRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 1C85806C2E585D4700443C22 /* StructuredQueriesGRDB */; };
+		B5362EB92E54C1790075BBD2 /* TootSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B5362EB82E54C1790075BBD2 /* TootSDK */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B5362E8B2E54C12F0075BBD2 /* SharingGRDBExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SharingGRDBExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		B5362E8D2E54C12F0075BBD2 /* SharingGRDBExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SharingGRDBExample;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B5362E882E54C12F0075BBD2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C85806D2E585D4700443C22 /* StructuredQueriesGRDB in Frameworks */,
+				1C85806B2E585D4700443C22 /* SharingGRDB in Frameworks */,
+				B5362EB92E54C1790075BBD2 /* TootSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B5362E822E54C12F0075BBD2 = {
+			isa = PBXGroup;
+			children = (
+				B5362E8D2E54C12F0075BBD2 /* SharingGRDBExample */,
+				B5362E8C2E54C12F0075BBD2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B5362E8C2E54C12F0075BBD2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B5362E8B2E54C12F0075BBD2 /* SharingGRDBExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B5362E8A2E54C12F0075BBD2 /* SharingGRDBExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B5362EAE2E54C1300075BBD2 /* Build configuration list for PBXNativeTarget "SharingGRDBExample" */;
+			buildPhases = (
+				B5362E872E54C12F0075BBD2 /* Sources */,
+				B5362E882E54C12F0075BBD2 /* Frameworks */,
+				B5362E892E54C12F0075BBD2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				B5362E8D2E54C12F0075BBD2 /* SharingGRDBExample */,
+			);
+			name = SharingGRDBExample;
+			packageProductDependencies = (
+				B5362EB82E54C1790075BBD2 /* TootSDK */,
+				1C85806A2E585D4700443C22 /* SharingGRDB */,
+				1C85806C2E585D4700443C22 /* StructuredQueriesGRDB */,
+			);
+			productName = TootSDKExample;
+			productReference = B5362E8B2E54C12F0075BBD2 /* SharingGRDBExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B5362E832E54C12F0075BBD2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					B5362E8A2E54C12F0075BBD2 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+				};
+			};
+			buildConfigurationList = B5362E862E54C12F0075BBD2 /* Build configuration list for PBXProject "SharingGRDBExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B5362E822E54C12F0075BBD2;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */,
+				1C8580692E585D4700443C22 /* XCRemoteSwiftPackageReference "sharing-grdb" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = B5362E8C2E54C12F0075BBD2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B5362E8A2E54C12F0075BBD2 /* SharingGRDBExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B5362E892E54C12F0075BBD2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B5362E872E54C12F0075BBD2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B5362EAC2E54C1300075BBD2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = MS6MBBXCFJ;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B5362EAD2E54C1300075BBD2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = MS6MBBXCFJ;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		B5362EAF2E54C1300075BBD2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2L7TR9QPY4;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SharingGRDBExample/Info.plist;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = eu.iamkonstantin.apps.TootSDKExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Debug;
+		};
+		B5362EB02E54C1300075BBD2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2L7TR9QPY4;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SharingGRDBExample/Info.plist;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = eu.iamkonstantin.apps.TootSDKExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B5362E862E54C12F0075BBD2 /* Build configuration list for PBXProject "SharingGRDBExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5362EAC2E54C1300075BBD2 /* Debug */,
+				B5362EAD2E54C1300075BBD2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B5362EAE2E54C1300075BBD2 /* Build configuration list for PBXNativeTarget "SharingGRDBExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5362EAF2E54C1300075BBD2 /* Debug */,
+				B5362EB02E54C1300075BBD2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		1C8580692E585D4700443C22 /* XCRemoteSwiftPackageReference "sharing-grdb" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/sharing-grdb.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.6.0;
+			};
+		};
+		B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/TootSDK/TootSDK";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 18.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		1C85806A2E585D4700443C22 /* SharingGRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1C8580692E585D4700443C22 /* XCRemoteSwiftPackageReference "sharing-grdb" */;
+			productName = SharingGRDB;
+		};
+		1C85806C2E585D4700443C22 /* StructuredQueriesGRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1C8580692E585D4700443C22 /* XCRemoteSwiftPackageReference "sharing-grdb" */;
+			productName = StructuredQueriesGRDB;
+		};
+		B5362EB82E54C1790075BBD2 /* TootSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */;
+			productName = TootSDK;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = B5362E832E54C12F0075BBD2 /* Project object */;
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,222 @@
+{
+  "originHash" : "6b4003ccd6ee9525f3cbf9df77f3043dbc2b55bcc7b0269c0d1b1d5a9110ef17",
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "8ba1bc9a96afc731a000fd4136dd13a5a46297bd",
+        "version" : "7.6.1"
+      }
+    },
+    {
+      "identity" : "sharing-grdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/sharing-grdb.git",
+      "state" : {
+        "revision" : "46f8561d442cd49d0f8f42234f0d97da33544dda",
+        "version" : "0.6.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "334e682869394ee239a57dbe9262bff3cd9495bd",
+        "version" : "3.14.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
+        "version" : "1.9.4"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "7d3509c7f4de78ad3eb3d804e036fb62e3585141",
+        "version" : "2.0.5"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "530c98ac2c3e393615616bd6d8fc604600c99f6f",
+        "version" : "2.7.2"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "d7e40607dcd6bc26543f5d9433103f06e0b28f8f",
+        "version" : "1.18.6"
+      }
+    },
+    {
+      "identity" : "swift-structured-queries",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-structured-queries",
+      "state" : {
+        "revision" : "b5b5a9ed9ff321f43a02f07394f2831eba5e11f2",
+        "version" : "0.13.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
+        "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "swift-url",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/karwa/swift-url.git",
+      "state" : {
+        "revision" : "9306a962396a50d7d88e924afcd7ec67226763db",
+        "version" : "0.4.2"
+      }
+    },
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "3a439f9eccc391b264d54516ce640251552eb0c4",
+        "version" : "2.10.3"
+      }
+    },
+    {
+      "identity" : "tootsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TootSDK/TootSDK",
+      "state" : {
+        "revision" : "3e090a30f3cb3ae4e0a863135842a01bd2e38c91",
+        "version" : "18.2.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/xcshareddata/xcschemes/TootSDKExample.xcscheme
+++ b/Examples/SharingGRDBExample/SharingGRDBExample.xcodeproj/xcshareddata/xcschemes/TootSDKExample.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5362E8A2E54C12F0075BBD2"
+               BuildableName = "SharingGRDBExample.app"
+               BlueprintName = "SharingGRDBExample"
+               ReferencedContainer = "container:SharingGRDBExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5362E992E54C1300075BBD2"
+               BuildableName = "TootSDKExampleTests.xctest"
+               BlueprintName = "TootSDKExampleTests"
+               ReferencedContainer = "container:SharingGRDBExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5362EA32E54C1300075BBD2"
+               BuildableName = "TootSDKExampleUITests.xctest"
+               BlueprintName = "TootSDKExampleUITests"
+               ReferencedContainer = "container:SharingGRDBExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5362E8A2E54C12F0075BBD2"
+            BuildableName = "SharingGRDBExample.app"
+            BlueprintName = "SharingGRDBExample"
+            ReferencedContainer = "container:SharingGRDBExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5362E8A2E54C12F0075BBD2"
+            BuildableName = "SharingGRDBExample.app"
+            BlueprintName = "SharingGRDBExample"
+            ReferencedContainer = "container:SharingGRDBExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,85 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/Contents.json
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Info.plist
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tootsdk-example</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Models/Schema.swift
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Models/Schema.swift
@@ -1,0 +1,106 @@
+//
+//  Schema.swift
+//  TootSDKExample
+//
+//  Created by Tim De Jong on 22/08/2025.
+//
+import Foundation
+import SharingGRDB
+import OSLog
+
+private let logger = Logger(subsystem: "SharingGRDBExample", category: "Database")
+
+@Table
+struct DisplayPost: Identifiable {
+  
+    let id: String
+    let authorName: String
+    let authorUsername: String
+    let content: String
+    let createdAt: Date
+    let url: String
+}
+
+@Table
+struct ServerCredential
+{
+    let host: String
+    let accessToken: String
+}
+
+func appDatabase() throws -> any DatabaseWriter
+{
+    let database: any DatabaseWriter
+    
+    @Dependency(\.context) var context
+    
+    var configuration = Configuration()
+    configuration.prepareDatabase { db in
+        #if DEBUG
+        db.trace(options: .profile) {
+            if context == .preview
+            {
+                print($0.expandedDescription)
+            }
+            else
+            {
+                logger.debug("\($0.expandedDescription)")
+            }
+        }
+        #endif
+    }
+    
+    switch context
+    {
+    case .live:
+        let path = URL.documentsDirectory.appendingPathComponent("bubbles.sqlite").path()
+        logger.info("open \(path)")
+        database = try DatabasePool(path: path, configuration: configuration)
+    case .preview, .test:
+        database = try DatabaseQueue(configuration: configuration)
+    }
+    
+    var migrator = DatabaseMigrator()
+    migrator.registerMigration("Create tables") { db in
+        try #sql(
+            """
+            CREATE TABLE "serverCredentials" (
+                "host" TEXT NOT NULL,
+                "accessToken" TEXT NOT NULL
+            )
+            """
+        )
+        .execute(db)
+        
+        let id: String
+        let authorName: String
+        let authorUsername: String
+        let content: String
+        let createdAt: Date
+        let url: String
+        
+        try #sql(
+            """
+            CREATE TABLE "displayPosts" (
+                "id" TEXT PRIMARY KEY,
+                "authorName" TEXT NOT NULL,
+                "authorUsername" TEXT NOT NULL,
+                "content" TEXT NOT NULL,
+                "createdAt" TEXT NOT NULL,
+                "url" TEXT NOT NULL
+            )
+            """
+        )
+        .execute(db)
+    }
+    
+    #if DEBUG
+    migrator.eraseDatabaseOnSchemaChange = true
+    #endif
+    
+    try migrator.migrate(database)
+    
+    
+    return database
+}
+

--- a/Examples/SharingGRDBExample/SharingGRDBExample/TootSDKExampleApp.swift
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/TootSDKExampleApp.swift
@@ -1,0 +1,27 @@
+//
+//  TootSDKExampleApp.swift
+//  TootSDKExample
+//
+//  Created by Konstantin Gerry on 19/08/2025.
+//
+
+import SwiftUI
+import Dependencies
+import SharingGRDB
+
+@main
+struct TootSDKExampleApp: App {
+    
+    init()
+    {
+        prepareDependencies {
+            $0.defaultDatabase = try! appDatabase()
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }        
+    }
+}

--- a/Examples/SharingGRDBExample/SharingGRDBExample/Views/RootView.swift
+++ b/Examples/SharingGRDBExample/SharingGRDBExample/Views/RootView.swift
@@ -1,0 +1,240 @@
+//
+//  RootView.swift
+//  TootSDKExample
+//
+//  Created by Konstantin Gerry on 19/08/2025.
+//
+
+import AuthenticationServices
+import SharingGRDB
+import SwiftUI
+import TootSDK
+
+struct RootView: View {
+   
+    @FetchOne
+    private var currentCredential: ServerCredential?
+    
+    @FetchAll
+    private var posts: [DisplayPost]
+
+    @State private var serverURL = "https://mastodon.social"
+    @State private var isLoading = false
+    @State private var client: TootClient?
+    @State private var showingAuthSession = false
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                if let _ = currentCredential {
+                    // Authenticated view showing posts
+                    authenticatedView
+                } else {
+                    // Login view for entering server URL
+                    loginView
+                }
+            }
+            .navigationTitle("TootSDK Example")
+            .toolbar {
+                if let _ = currentCredential {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Sign Out") {
+                            signOut()
+                        }
+                    }
+                }
+            }
+        }
+        .task {
+            // If you already have a credential, use it to create a TootClient
+            if let credential = currentCredential {
+                await connectWithCredential(credential)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var loginView: some View {
+        VStack(spacing: 20) {
+            Text("Connect to Mastodon")
+                .font(.largeTitle)
+
+            Text("Enter your Mastodon server URL")
+                .font(.subheadline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("https://mastodon.social", text: $serverURL)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+            }
+            .padding(.horizontal)
+
+            Button(action: {
+                Task {
+                    await startAuthentication()
+                }
+            }) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                } else {
+                    Text("Sign In")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(serverURL.isEmpty || isLoading)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var authenticatedView: some View {
+        if posts.isEmpty {
+            VStack(spacing: 20) {
+                ProgressView()
+                Text("Loading posts...")
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(posts) { post in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(post.authorName)
+                        .font(.headline)
+                    Text(post.content)
+                        .font(.body)
+                        .lineLimit(5)
+                    Text(post.createdAt, style: .relative)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private func startAuthentication() async {
+
+        guard let url = URL(string: self.serverURL) else {
+            print("Invalid server URL")
+            return
+        }
+
+        do {
+            // Let's create a TootClient which will execute the authentication
+            let newClient = try await TootClient(
+                connect: url,
+                clientName: "TootSDK SharingGRDB Example",
+                scopes: ["read"]
+            )
+
+            self.client = newClient
+
+            // Present authentication session
+            let accessToken = try await newClient.presentSignIn(
+                callbackURI: "tootsdk-example://oauth",
+                prefersEphemeralWebBrowserSession: false
+            )
+
+            // Save credential so it can be re-used later
+            let credential = ServerCredential(
+                host: url.absoluteString,
+                accessToken: accessToken
+            )
+           
+            @Dependency(\.defaultDatabase) var database
+            try await database.write { db in
+                try ServerCredential.insert {
+                    credential
+                }
+                .execute(db)
+            }
+            await fetchPosts()
+            
+        } catch ASWebAuthenticationSessionError.canceledLogin {
+            print("User cancelled, no error message needed")
+            return
+        } catch {
+            print("Authentication failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func connectWithCredential(_ credential: ServerCredential) async {
+        guard let url = URL(string: credential.host) else { return }
+
+        do {
+            let newClient = try await TootClient(
+                connect: url,
+                clientName: "TootSDK Example",
+                accessToken: credential.accessToken
+            )
+            self.client = newClient
+
+            // Verify credentials are still valid and fetch posts
+            _ = try await newClient.verifyCredentials()
+            await fetchPosts()
+        } catch {
+            // Token might be invalid, clear credentials
+            print(error.localizedDescription)
+            signOut()
+        }
+    }
+
+    private func fetchPosts() async {
+        guard let client else { return }
+
+        do {
+            // Fetch home timeline
+            let timeline = try await client.getTimeline(.home)
+
+            // Convert to DisplayPost objects
+            let newPosts = timeline.result.compactMap { post in
+                // TootSDK provides renderers to handle post formatting
+                // You can make your own renderer for custom handling!
+                let renderedPost: String = AttributedStringRenderer().render(html: post.content ?? "").plainString
+
+                return DisplayPost(
+                    id: post.id,
+                    authorName: post.account.displayName ?? post.account.username ?? "",
+                    authorUsername: post.account.acct,
+                    content: renderedPost,
+                    createdAt: post.createdAt,
+                    url: post.url ?? post.uri
+                )
+            }
+ 
+            @Dependency(\.defaultDatabase) var database
+            try await database.write { db in
+                try DisplayPost.delete().execute(db)
+                
+                try DisplayPost.upsert {
+                    newPosts
+                }
+                .execute(db)
+            }
+        } catch {
+            print("Failed to fetch posts: \(error)")
+        }
+    }
+
+    private func signOut() {
+        do
+        {
+            // Clear all credentials and posts
+            @Dependency(\.defaultDatabase) var database
+            try database.write { db in
+                try ServerCredential.delete().execute(db)
+                try DisplayPost.delete().execute(db)
+            }
+            // Reset state
+            client = nil
+            serverURL = ""
+        }
+        catch
+        {
+            print("Error signing out: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
This adds a basic example of a macOS gui app using `PointFree's SharingGRDB`. These are the changes:
- Removed all `SwiftData` related code
- Added [SharingGRDB](https://github.com/pointfreeco/sharing-grdb) framework to the package dependencies
- Reduced the macOS target to 15.0 (not on the latest version yet ;))
- Added `Models/Schema.swift` with the code to create the necessary tables & the database connection
- Adapted `Views/RootView.swift` to use `SharingGRDB` instead.
- Renamed some targets to reflect the new name.

All the code is in the `Examples/SharingGRDBExample` directory. Let me know if you have questions or if I need to change anything!