### PR TITLE
Mark push notifications as supported by GoToSocial

### DIFF
--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -152,10 +152,10 @@ extension TootClient {
 
 extension TootFeature {
     /// Ability to create Web Push API subscriptions to receive notifications.
-    public static let pushSubscriptions = TootFeature(supportedFlavours: [.mastodon, .akkoma, .friendica, .pleroma])
+    public static let pushSubscriptions = TootFeature(supportedFlavours: [.mastodon, .akkoma, .friendica, .pleroma, .goToSocial])
 
     /// Ability to specify policy for push notifications.
-    public static let pushSubscriptionsPolicy = TootFeature(supportedFlavours: [.mastodon])
+    public static let pushSubscriptionsPolicy = TootFeature(supportedFlavours: [.mastodon, .goToSocial])
 }
 
 extension TootClient {


### PR DESCRIPTION
Implemented in version 0.18.0 of GoToSocial: https://github.com/superseriousbusiness/gotosocial/releases/tag/v0.18.0