### PR TITLE
[BREAKING] Allow caching and restoring TootClient without calling connect()

### DIFF
--- a/Examples/swiftyadmin/Package.resolved
+++ b/Examples/swiftyadmin/Package.resolved
@@ -71,6 +71,15 @@
         "revision" : "aa85ee96017a730031bafe411cde24a08a17a9c9",
         "version" : "2.8.8"
       }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version.git",
+      "state" : {
+        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
+        "version" : "2.2.0"
+      }
     }
   ],
   "version" : 2

--- a/Examples/swiftyadmin/Sources/swiftyadmin/OauthApps/DeleteOauthApp.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/OauthApps/DeleteOauthApp.swift
@@ -16,7 +16,6 @@ struct DeleteOauthApp: AsyncParsableCommand {
     mutating func run() async throws {
         print("Deleting app id \(id):")
         let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
-        client.flavour = .pleroma
         let _ = try await client.adminDeleteOauthApp(appId: id)
     }
 }

--- a/Examples/swiftyadmin/Sources/swiftyadmin/OauthApps/ListOauthApps.swift
+++ b/Examples/swiftyadmin/Sources/swiftyadmin/OauthApps/ListOauthApps.swift
@@ -22,7 +22,6 @@ struct ListOauthApps: AsyncParsableCommand {
     mutating func run() async throws {
         print("Listing OAuth apps:")
         let client = TootClient(instanceURL: URL(string: url)!, accessToken: token)
-        client.flavour = .pleroma
 
         let params = ListOauthAppsParams(
             name: name != "" ? name : nil, clientId: clientId != "" ? clientId : nil,

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ let feature = TootFeature(requirements: [
 // This works on any server that reports Mastodon API compatibility,
 // even if it's not a Mastodon server:
 // - Akkoma server with { "mastodon": 6 } ✓ Supported
-// - Pleroma server with { "mastodon": 4 } ✓ Supported  
+// - Pleroma server with { "mastodon": 4 } ✓ Supported
 // - Firefish server with { "mastodon": 3 } ✗ Not supported
 ```
 
@@ -452,6 +452,31 @@ let selectiveFeature = TootFeature(
 if client.supportsFeature(customFeature) {
     // Use the feature
 }
+```
+
+</details>
+
+<details>
+<summary>Saving and Restoring Server Configuration</summary>
+
+In some situations, it may be helpful for your app to cache `TootClient` and restore it without having to repeatedly call `connect()`:
+
+```swift
+// Save server configuration e.g. encoding it as JSON:
+
+let config = client.serverConfiguration
+let data = try JSONEncoder().encode(config)
+
+// Store data in UserDefaults, Keychain, etc.
+// ⚠️ serverConfiguration does NOT include secrets, only version and flavour information of the server
+
+// Restore server configuration
+let savedConfig = try JSONDecoder().decode(ServerConfiguration.self, from: data)
+let client = TootClient(
+    instanceURL: instanceURL,
+    accessToken: accessToken,
+    serverConfiguration: savedConfig
+)
 ```
 
 </details>

--- a/Sources/TootSDK/Models/ServerConfiguration.swift
+++ b/Sources/TootSDK/Models/ServerConfiguration.swift
@@ -1,0 +1,94 @@
+// ABOUTME: Encapsulates server state information for TootClient including flavour, version, and API details.
+// ABOUTME: This struct makes it easier to cache and restore TootClient instances with pre-configured server state.
+
+import Foundation
+import Version
+
+/// Encapsulates the server configuration state for a TootClient instance.
+/// This includes information about the server's flavour, version, and supported API versions.
+public struct ServerConfiguration: Sendable, Codable, Hashable {
+    /// The detected fediverse server flavour (e.g., Mastodon, Pleroma, etc.)
+    public let flavour: TootSDKFlavour
+    
+    /// The parsed semantic version of the server (used for feature detection)
+    public let version: Version?
+    
+    /// The raw version string from the server (for debugging/display purposes)
+    public let versionString: String?
+    
+    /// The API versions supported by the server (from InstanceV2 response)
+    public let apiVersions: InstanceV2.APIVersions?
+    
+    /// Creates a new ServerConfiguration instance.
+    /// - Parameters:
+    ///   - flavour: The server flavour
+    ///   - version: The parsed semantic version
+    ///   - versionString: The raw version string
+    ///   - apiVersions: The supported API versions
+    public init(
+        flavour: TootSDKFlavour = .mastodon,
+        version: Version? = nil,
+        versionString: String? = nil,
+        apiVersions: InstanceV2.APIVersions? = nil
+    ) {
+        self.flavour = flavour
+        self.version = version
+        self.versionString = versionString
+        self.apiVersions = apiVersions
+    }
+    
+    // MARK: - Codable
+    
+    private enum CodingKeys: String, CodingKey {
+        case flavour
+        case version
+        case versionString
+        case apiVersions
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.flavour = try container.decode(TootSDKFlavour.self, forKey: .flavour)
+        
+        // Decode Version as a string and parse it
+        if let versionString = try container.decodeIfPresent(String.self, forKey: .version) {
+            self.version = Version(versionString)
+        } else {
+            self.version = nil
+        }
+        
+        self.versionString = try container.decodeIfPresent(String.self, forKey: .versionString)
+        self.apiVersions = try container.decodeIfPresent(InstanceV2.APIVersions.self, forKey: .apiVersions)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(flavour, forKey: .flavour)
+        
+        // Encode Version as a string
+        if let version = version {
+            try container.encode(version.description, forKey: .version)
+        }
+        
+        try container.encodeIfPresent(versionString, forKey: .versionString)
+        try container.encodeIfPresent(apiVersions, forKey: .apiVersions)
+    }
+    
+    // MARK: - Hashable
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(flavour)
+        if let version = version {
+            hasher.combine(version.description)
+        }
+        hasher.combine(versionString)
+        hasher.combine(apiVersions)
+    }
+    
+    public static func == (lhs: ServerConfiguration, rhs: ServerConfiguration) -> Bool {
+        return lhs.flavour == rhs.flavour &&
+               lhs.version?.description == rhs.version?.description &&
+               lhs.versionString == rhs.versionString &&
+               lhs.apiVersions == rhs.apiVersions
+    }
+}

--- a/Sources/TootSDK/Models/ServerConfiguration.swift
+++ b/Sources/TootSDK/Models/ServerConfiguration.swift
@@ -9,16 +9,16 @@ import Version
 public struct ServerConfiguration: Sendable, Codable, Hashable {
     /// The detected fediverse server flavour (e.g., Mastodon, Pleroma, etc.)
     public let flavour: TootSDKFlavour
-    
+
     /// The parsed semantic version of the server (used for feature detection)
     public let version: Version?
-    
+
     /// The raw version string from the server (for debugging/display purposes)
     public let versionString: String?
-    
+
     /// The API versions supported by the server (from InstanceV2 response)
     public let apiVersions: InstanceV2.APIVersions?
-    
+
     /// Creates a new ServerConfiguration instance.
     /// - Parameters:
     ///   - flavour: The server flavour
@@ -36,46 +36,46 @@ public struct ServerConfiguration: Sendable, Codable, Hashable {
         self.versionString = versionString
         self.apiVersions = apiVersions
     }
-    
+
     // MARK: - Codable
-    
+
     private enum CodingKeys: String, CodingKey {
         case flavour
         case version
         case versionString
         case apiVersions
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.flavour = try container.decode(TootSDKFlavour.self, forKey: .flavour)
-        
+
         // Decode Version as a string and parse it
         if let versionString = try container.decodeIfPresent(String.self, forKey: .version) {
             self.version = Version(versionString)
         } else {
             self.version = nil
         }
-        
+
         self.versionString = try container.decodeIfPresent(String.self, forKey: .versionString)
         self.apiVersions = try container.decodeIfPresent(InstanceV2.APIVersions.self, forKey: .apiVersions)
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(flavour, forKey: .flavour)
-        
+
         // Encode Version as a string
         if let version = version {
             try container.encode(version.description, forKey: .version)
         }
-        
+
         try container.encodeIfPresent(versionString, forKey: .versionString)
         try container.encodeIfPresent(apiVersions, forKey: .apiVersions)
     }
-    
+
     // MARK: - Hashable
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(flavour)
         if let version = version {
@@ -84,11 +84,9 @@ public struct ServerConfiguration: Sendable, Codable, Hashable {
         hasher.combine(versionString)
         hasher.combine(apiVersions)
     }
-    
+
     public static func == (lhs: ServerConfiguration, rhs: ServerConfiguration) -> Bool {
-        return lhs.flavour == rhs.flavour &&
-               lhs.version?.description == rhs.version?.description &&
-               lhs.versionString == rhs.versionString &&
-               lhs.apiVersions == rhs.apiVersions
+        return lhs.flavour == rhs.flavour && lhs.version?.description == rhs.version?.description && lhs.versionString == rhs.versionString
+            && lhs.apiVersions == rhs.apiVersions
     }
 }

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -24,22 +24,22 @@ public class TootClient: @unchecked Sendable {
     public var debugInstance: Bool = false
     /// The server configuration containing flavour, version, and API information
     public private(set) var serverConfiguration: ServerConfiguration = ServerConfiguration()
-    
+
     /// The preferred fediverse server flavour to use for API calls
     public var flavour: TootSDKFlavour {
         serverConfiguration.flavour
     }
-    
+
     /// The parsed version of the instance we're connected to (used for feature detection)
     public var version: Version? {
         serverConfiguration.version
     }
-    
+
     /// The raw version string from the instance (for debugging/display purposes)
     public var versionString: String? {
         serverConfiguration.versionString
     }
-    
+
     /// The API versions supported by the instance (from InstanceV2 response)
     public var apiVersions: InstanceV2.APIVersions? {
         serverConfiguration.apiVersions
@@ -109,7 +109,7 @@ public class TootClient: @unchecked Sendable {
         self.clientWebsite = clientWebsite
         self.httpUserAgent = httpUserAgent ?? clientName
     }
-    
+
     /// Initialize a new instance of `TootClient` with a pre-configured server configuration.
     ///
     /// This initializer is useful when caching TootClient instances or when you already know the server configuration
@@ -140,7 +140,7 @@ public class TootClient: @unchecked Sendable {
         self.clientWebsite = clientWebsite
         self.httpUserAgent = httpUserAgent ?? clientName
         self.serverConfiguration = serverConfiguration
-        
+
         // Set the encoder userInfo with the configured flavour
         self.encoder.userInfo[.tootSDKFlavour] = serverConfiguration.flavour
     }

--- a/Sources/TootSDK/TootClient/TootClient.swift
+++ b/Sources/TootSDK/TootClient/TootClient.swift
@@ -22,14 +22,28 @@ public class TootClient: @unchecked Sendable {
     public var debugResponses: Bool = false
     /// Set this to `true` to see a `print()` for instance information.
     public var debugInstance: Bool = false
+    /// The server configuration containing flavour, version, and API information
+    public private(set) var serverConfiguration: ServerConfiguration = ServerConfiguration()
+    
     /// The preferred fediverse server flavour to use for API calls
-    public var flavour: TootSDKFlavour = .mastodon
+    public var flavour: TootSDKFlavour {
+        serverConfiguration.flavour
+    }
+    
     /// The parsed version of the instance we're connected to (used for feature detection)
-    public var version: Version?
+    public var version: Version? {
+        serverConfiguration.version
+    }
+    
     /// The raw version string from the instance (for debugging/display purposes)
-    public var versionString: String?
+    public var versionString: String? {
+        serverConfiguration.versionString
+    }
+    
     /// The API versions supported by the instance (from InstanceV2 response)
-    public var apiVersions: InstanceV2.APIVersions?
+    public var apiVersions: InstanceV2.APIVersions? {
+        serverConfiguration.apiVersions
+    }
     /// The authorization scopes the client was initialized with
     public let scopes: [String]
     /// Data streams that the client can subscribe to
@@ -94,6 +108,41 @@ public class TootClient: @unchecked Sendable {
         self.clientName = clientName
         self.clientWebsite = clientWebsite
         self.httpUserAgent = httpUserAgent ?? clientName
+    }
+    
+    /// Initialize a new instance of `TootClient` with a pre-configured server configuration.
+    ///
+    /// This initializer is useful when caching TootClient instances or when you already know the server configuration
+    /// and don't need to call ``TootClient/connect()``.
+    /// - Parameters:
+    ///   - clientName: Name of the client to be used in outgoing HTTP requests. Defaults to `TootSDK`
+    ///   - clientWebsite: A URL to the homepage of your client. Defaults to an empty string.
+    ///   - session: the URLSession being used internally, defaults to shared
+    ///   - instanceURL: the instance you are connecting to
+    ///   - accessToken: the existing access token; if you already have one
+    ///   - scopes: An array of authentication scopes, defaults to `"read", "write", "follow", "push"`
+    ///   - serverConfiguration: The pre-configured server configuration containing flavour, version, and API information
+    public init(
+        clientName: String = "TootSDK",
+        clientWebsite: String? = nil,
+        session: URLSession = URLSession.shared,
+        instanceURL: URL,
+        accessToken: String? = nil,
+        scopes: [String] = ["read", "write", "follow", "push"],
+        httpUserAgent: String? = nil,
+        serverConfiguration: ServerConfiguration
+    ) {
+        self.session = session
+        self.instanceURL = instanceURL
+        self.accessToken = accessToken
+        self.scopes = scopes
+        self.clientName = clientName
+        self.clientWebsite = clientWebsite
+        self.httpUserAgent = httpUserAgent ?? clientName
+        self.serverConfiguration = serverConfiguration
+        
+        // Set the encoder userInfo with the configured flavour
+        self.encoder.userInfo[.tootSDKFlavour] = serverConfiguration.flavour
     }
 
     /// Initialize and connect a new instance of `TootClient`.
@@ -465,13 +514,14 @@ extension TootClient {
     public func connect() async throws {
         // Try to get InstanceV2 first as it has API version information
         let instance = try await getInstanceInfo()
-        self.flavour = instance.flavour
-        self.versionString = instance.version
-        self.version = TootFeature.parseVersion(from: instance.version)
+        var detectedFlavour = instance.flavour
+        var detectedVersionString = instance.version
+        var detectedVersion = TootFeature.parseVersion(from: instance.version)
+        var detectedApiVersions: InstanceV2.APIVersions? = nil
 
         // Store API versions if this is an InstanceV2
         if let instanceV2 = instance as? InstanceV2 {
-            self.apiVersions = instanceV2.apiVersions
+            detectedApiVersions = instanceV2.apiVersions
             if debugInstance {
                 print("🎨 Detected fediverse instance flavour: \(instance.flavour), version: \(instance.version)")
                 if let apiVersions = instanceV2.apiVersions {
@@ -481,9 +531,9 @@ extension TootClient {
         } else {
             // Fall back to NodeInfo if InstanceV2 is not available
             if let nodeInfo = await getNodeInfoIfAvailable() {
-                self.flavour = nodeInfo.flavour
-                self.versionString = nodeInfo.software.version
-                self.version = TootFeature.parseVersion(from: nodeInfo.software.version)
+                detectedFlavour = nodeInfo.flavour
+                detectedVersionString = nodeInfo.software.version
+                detectedVersion = TootFeature.parseVersion(from: nodeInfo.software.version)
                 if debugInstance {
                     print("🎨 Detected fediverse instance flavour: \(nodeInfo.flavour), version: \(nodeInfo.software.version)")
                 }
@@ -495,8 +545,16 @@ extension TootClient {
             }
         }
 
+        // Create the new server configuration
+        self.serverConfiguration = ServerConfiguration(
+            flavour: detectedFlavour,
+            version: detectedVersion,
+            versionString: detectedVersionString,
+            apiVersions: detectedApiVersions
+        )
+
         // Set the encoder userInfo after flavour has been determined
-        encoder.userInfo[.tootSDKFlavour] = flavour
+        encoder.userInfo[.tootSDKFlavour] = serverConfiguration.flavour
     }
 
     private func getNodeInfoIfAvailable() async -> NodeInfo? {

--- a/Tests/TootSDKTests/EncodingTests.swift
+++ b/Tests/TootSDKTests/EncodingTests.swift
@@ -12,18 +12,20 @@ import Testing
 
 struct EncodingTests {
 
-    private let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-
     @Test func generalEncodingOfNotificationType() throws {
-        client.flavour = .mastodon
-        client.encoder.userInfo[.tootSDKFlavour] = client.flavour
+        let client = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: .mastodon)
+        )
         let encoded = try client.encoder.encode(TootNotification.NotificationType.emojiReaction)
         #expect(encoded == Data(#""emoji_reaction""#.utf8))
     }
 
     @Test func flavorSpecificEncodingOfNotificationType() throws {
-        client.flavour = .pleroma
-        client.encoder.userInfo[.tootSDKFlavour] = client.flavour
+        let client = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: .pleroma)
+        )
         let encoded = try client.encoder.encode(TootNotification.NotificationType.emojiReaction)
         #expect(encoded == Data(#""pleroma:emoji_reaction""#.utf8))
     }

--- a/Tests/TootSDKTests/FeatureTests.swift
+++ b/Tests/TootSDKTests/FeatureTests.swift
@@ -5,14 +5,18 @@ import XCTest
 final class FeatureTests: XCTestCase {
 
     func testFeatureChecks() throws {
-        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+        let mastodonClient = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: .mastodon)
+        )
+        XCTAssertTrue(mastodonClient.supportsFeature(.featuredTags))
+        XCTAssertNoThrow(try mastodonClient.requireFeature(.featuredTags))
 
-        client.flavour = .mastodon
-        XCTAssertTrue(client.supportsFeature(.featuredTags))
-        XCTAssertNoThrow(try client.requireFeature(.featuredTags))
-
-        client.flavour = .akkoma
-        XCTAssertFalse(client.supportsFeature(.featuredTags))
-        XCTAssertThrowsError(try client.requireFeature(.featuredTags))
+        let akkomaClient = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: .akkoma)
+        )
+        XCTAssertFalse(akkomaClient.supportsFeature(.featuredTags))
+        XCTAssertThrowsError(try akkomaClient.requireFeature(.featuredTags))
     }
 }

--- a/Tests/TootSDKTests/ServerConfigurationTests.swift
+++ b/Tests/TootSDKTests/ServerConfigurationTests.swift
@@ -1,10 +1,10 @@
-import XCTest
 import Version
+import XCTest
 
 @testable import TootSDK
 
 final class ServerConfigurationTests: XCTestCase {
-    
+
     func testServerConfigurationInitialization() throws {
         // Test default initialization
         let defaultConfig = ServerConfiguration()
@@ -12,7 +12,7 @@ final class ServerConfigurationTests: XCTestCase {
         XCTAssertNil(defaultConfig.version)
         XCTAssertNil(defaultConfig.versionString)
         XCTAssertNil(defaultConfig.apiVersions)
-        
+
         // Test custom initialization
         let customConfig = ServerConfiguration(
             flavour: .pleroma,
@@ -25,7 +25,7 @@ final class ServerConfigurationTests: XCTestCase {
         XCTAssertEqual(customConfig.versionString, "4.0.0")
         XCTAssertEqual(customConfig.apiVersions?.mastodon, 1)
     }
-    
+
     func testTootClientInitializationWithServerConfiguration() throws {
         let serverConfig = ServerConfiguration(
             flavour: .akkoma,
@@ -33,22 +33,22 @@ final class ServerConfigurationTests: XCTestCase {
             versionString: "3.10.3 (Akkoma)",
             apiVersions: nil
         )
-        
+
         let client = TootClient(
             instanceURL: URL(string: "https://example.com")!,
             serverConfiguration: serverConfig
         )
-        
+
         // Verify the server configuration is properly set
         XCTAssertEqual(client.flavour, .akkoma)
         XCTAssertEqual(client.version, Version(3, 10, 3))
         XCTAssertEqual(client.versionString, "3.10.3 (Akkoma)")
         XCTAssertNil(client.apiVersions)
-        
+
         // Verify the encoder is configured with the flavour
         XCTAssertEqual(client.encoder.userInfo[.tootSDKFlavour] as? TootSDKFlavour, .akkoma)
     }
-    
+
     func testServerConfigurationCodable() throws {
         let originalConfig = ServerConfiguration(
             flavour: .mastodon,
@@ -56,22 +56,22 @@ final class ServerConfigurationTests: XCTestCase {
             versionString: "4.2.0",
             apiVersions: InstanceV2.APIVersions(mastodon: 1)
         )
-        
+
         // Encode
         let encoder = JSONEncoder()
         let data = try encoder.encode(originalConfig)
-        
+
         // Decode
         let decoder = JSONDecoder()
         let decodedConfig = try decoder.decode(ServerConfiguration.self, from: data)
-        
+
         // Verify
         XCTAssertEqual(decodedConfig.flavour, originalConfig.flavour)
         XCTAssertEqual(decodedConfig.version?.description, originalConfig.version?.description)
         XCTAssertEqual(decodedConfig.versionString, originalConfig.versionString)
         XCTAssertEqual(decodedConfig.apiVersions, originalConfig.apiVersions)
     }
-    
+
     func testServerConfigurationEquality() throws {
         let config1 = ServerConfiguration(
             flavour: .mastodon,
@@ -79,29 +79,29 @@ final class ServerConfigurationTests: XCTestCase {
             versionString: "4.0.0",
             apiVersions: InstanceV2.APIVersions(mastodon: 1)
         )
-        
+
         let config2 = ServerConfiguration(
             flavour: .mastodon,
             version: Version(4, 0, 0),
             versionString: "4.0.0",
             apiVersions: InstanceV2.APIVersions(mastodon: 1)
         )
-        
+
         let config3 = ServerConfiguration(
             flavour: .pleroma,
             version: Version(4, 0, 0),
             versionString: "4.0.0",
             apiVersions: InstanceV2.APIVersions(mastodon: 1)
         )
-        
+
         XCTAssertEqual(config1, config2)
         XCTAssertNotEqual(config1, config3)
     }
-    
+
     func testBackwardCompatibility() throws {
         // Test that existing code still works with the default TootClient initializer
         let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-        
+
         // The default configuration should be Mastodon
         XCTAssertEqual(client.flavour, .mastodon)
         XCTAssertNil(client.version)

--- a/Tests/TootSDKTests/ServerConfigurationTests.swift
+++ b/Tests/TootSDKTests/ServerConfigurationTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+import Version
+
+@testable import TootSDK
+
+final class ServerConfigurationTests: XCTestCase {
+    
+    func testServerConfigurationInitialization() throws {
+        // Test default initialization
+        let defaultConfig = ServerConfiguration()
+        XCTAssertEqual(defaultConfig.flavour, .mastodon)
+        XCTAssertNil(defaultConfig.version)
+        XCTAssertNil(defaultConfig.versionString)
+        XCTAssertNil(defaultConfig.apiVersions)
+        
+        // Test custom initialization
+        let customConfig = ServerConfiguration(
+            flavour: .pleroma,
+            version: Version(4, 0, 0),
+            versionString: "4.0.0",
+            apiVersions: InstanceV2.APIVersions(mastodon: 1)
+        )
+        XCTAssertEqual(customConfig.flavour, .pleroma)
+        XCTAssertEqual(customConfig.version, Version(4, 0, 0))
+        XCTAssertEqual(customConfig.versionString, "4.0.0")
+        XCTAssertEqual(customConfig.apiVersions?.mastodon, 1)
+    }
+    
+    func testTootClientInitializationWithServerConfiguration() throws {
+        let serverConfig = ServerConfiguration(
+            flavour: .akkoma,
+            version: Version(3, 10, 3),
+            versionString: "3.10.3 (Akkoma)",
+            apiVersions: nil
+        )
+        
+        let client = TootClient(
+            instanceURL: URL(string: "https://example.com")!,
+            serverConfiguration: serverConfig
+        )
+        
+        // Verify the server configuration is properly set
+        XCTAssertEqual(client.flavour, .akkoma)
+        XCTAssertEqual(client.version, Version(3, 10, 3))
+        XCTAssertEqual(client.versionString, "3.10.3 (Akkoma)")
+        XCTAssertNil(client.apiVersions)
+        
+        // Verify the encoder is configured with the flavour
+        XCTAssertEqual(client.encoder.userInfo[.tootSDKFlavour] as? TootSDKFlavour, .akkoma)
+    }
+    
+    func testServerConfigurationCodable() throws {
+        let originalConfig = ServerConfiguration(
+            flavour: .mastodon,
+            version: Version(4, 2, 0),
+            versionString: "4.2.0",
+            apiVersions: InstanceV2.APIVersions(mastodon: 1)
+        )
+        
+        // Encode
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(originalConfig)
+        
+        // Decode
+        let decoder = JSONDecoder()
+        let decodedConfig = try decoder.decode(ServerConfiguration.self, from: data)
+        
+        // Verify
+        XCTAssertEqual(decodedConfig.flavour, originalConfig.flavour)
+        XCTAssertEqual(decodedConfig.version?.description, originalConfig.version?.description)
+        XCTAssertEqual(decodedConfig.versionString, originalConfig.versionString)
+        XCTAssertEqual(decodedConfig.apiVersions, originalConfig.apiVersions)
+    }
+    
+    func testServerConfigurationEquality() throws {
+        let config1 = ServerConfiguration(
+            flavour: .mastodon,
+            version: Version(4, 0, 0),
+            versionString: "4.0.0",
+            apiVersions: InstanceV2.APIVersions(mastodon: 1)
+        )
+        
+        let config2 = ServerConfiguration(
+            flavour: .mastodon,
+            version: Version(4, 0, 0),
+            versionString: "4.0.0",
+            apiVersions: InstanceV2.APIVersions(mastodon: 1)
+        )
+        
+        let config3 = ServerConfiguration(
+            flavour: .pleroma,
+            version: Version(4, 0, 0),
+            versionString: "4.0.0",
+            apiVersions: InstanceV2.APIVersions(mastodon: 1)
+        )
+        
+        XCTAssertEqual(config1, config2)
+        XCTAssertNotEqual(config1, config3)
+    }
+    
+    func testBackwardCompatibility() throws {
+        // Test that existing code still works with the default TootClient initializer
+        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
+        
+        // The default configuration should be Mastodon
+        XCTAssertEqual(client.flavour, .mastodon)
+        XCTAssertNil(client.version)
+        XCTAssertNil(client.versionString)
+        XCTAssertNil(client.apiVersions)
+    }
+}

--- a/Tests/TootSDKTests/TootNotificationParamsTests.swift
+++ b/Tests/TootSDKTests/TootNotificationParamsTests.swift
@@ -89,8 +89,10 @@ import Testing
 
     @Test func friendicaQueryParams() throws {
         let flavour = TootSDKFlavour.friendica
-        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-        client.flavour = flavour
+        let client = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: flavour)
+        )
 
         let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
         let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
@@ -105,8 +107,10 @@ import Testing
 
     @Test func sharkeyQueryParams() throws {
         let flavour = TootSDKFlavour.sharkey
-        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-        client.flavour = flavour
+        let client = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: flavour)
+        )
 
         let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
         let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
@@ -128,8 +132,10 @@ import Testing
 
     @Test func pleromaAkkomaQueryParams() throws {
         for flavour in [TootSDKFlavour.pleroma, .akkoma] {
-            let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-            client.flavour = flavour
+            let client = TootClient(
+                instanceURL: URL(string: "https://mastodon.social")!,
+                serverConfiguration: ServerConfiguration(flavour: flavour)
+            )
 
             let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
             let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
@@ -142,8 +148,10 @@ import Testing
     }
 
     @Test func mastodonQueryParams() throws {
-        let client = TootClient(instanceURL: URL(string: "https://mastodon.social")!)
-        client.flavour = .mastodon
+        let client = TootClient(
+            instanceURL: URL(string: "https://mastodon.social")!,
+            serverConfiguration: ServerConfiguration(flavour: .mastodon)
+        )
 
         let params = TootNotificationParams(excludeTypes: [.mention], types: [.favourite])
         let query = client.createQuery(from: params).sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }


### PR DESCRIPTION
This PR fixes #365 by allowing apps to cache (and restore) TootClient without having to call `connect()` (cf. also mentioned in https://github.com/TootSDK/TootSDK/pull/361#discussion_r2265223662)

- [x] Created ServerConfiguration struct to group flavour, version, versionString, and apiVersions
- [x] Updated TootClient to use ServerConfiguration with computed properties: it is no longer possible to "set" the server configuration by hand
- [x] Added new TootClient initializer that accepts pre-configured ServerConfiguration - this is what apps can use to restore TootClient.
- [x] Updated tests

Example
```swift
// Save configuration
let config = client.serverConfiguration
let data = try JSONEncoder().encode(config)

// Restore later
let savedConfig = try JSONDecoder().decode(ServerConfiguration.self, from: data)
let restoredClient = TootClient(
    instanceURL: url,
    serverConfiguration: savedConfig
)
```