### PR TITLE
AES-128-GCM encoding support for webpush messages

### DIFF
--- a/Sources/TootSDK/Models/PushSubscriptionParams.swift
+++ b/Sources/TootSDK/Models/PushSubscriptionParams.swift
@@ -11,14 +11,17 @@ public struct PushSubscriptionParams: Codable, Sendable {
     public var data: SubscriptionData?
 
     public struct Subscription: Codable, Sendable {
-        public init(endpoint: String, keys: PushSubscriptionParams.Keys) {
+        public init(endpoint: String, keys: PushSubscriptionParams.Keys, standard: Bool? = nil) {
             self.endpoint = endpoint
             self.keys = keys
+            self.standard = standard
         }
 
         /// The endpoint URL that is called when a notification event occurs.
         public var endpoint: String
         public var keys: PushSubscriptionParams.Keys
+        /// Follow standardized webpush (RFC8030+RFC8291+RFC8292) ? Else follow legacy webpush (unpublished version, 4th draft of RFC8291 and 1st draft of RFC8292).
+        public var standard: Bool?
     }
 
     /// Encryption related data of push subscription.

--- a/Sources/TootSDK/TootClient/TootClient+Notifications.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Notifications.swift
@@ -156,6 +156,9 @@ extension TootFeature {
 
     /// Ability to specify policy for push notifications.
     public static let pushSubscriptionsPolicy = TootFeature(supportedFlavours: [.mastodon, .goToSocial])
+
+    /// Ability to specify whether to use standardized webpush (RFC8030+RFC8291+RFC8292) or legacy webpush (unpublished version, 4th draft of RFC8291 and 1st draft of RFC8292).
+    public static let pushSubscriptionsStandard = TootFeature(requirements: [.from(.mastodon, displayVersion: "4.4.0")])
 }
 
 extension TootClient {
@@ -185,6 +188,9 @@ extension TootClient {
         queryParameters.append(.init(name: "subscription[endpoint]", value: params.subscription.endpoint))
         queryParameters.append(.init(name: "subscription[keys][p256dh]", value: params.subscription.keys.p256dh))
         queryParameters.append(.init(name: "subscription[keys][auth]", value: params.subscription.keys.auth))
+        if let standard = params.subscription.standard {
+            queryParameters.append(.init(name: "subscription[standard]", value: String(standard).lowercased()))
+        }
         queryParameters.append(contentsOf: createQuery(from: params.data))
         return queryParameters
     }

--- a/Sources/TootSDK/WebPushEncryption/WebPushMessageEncryption.swift
+++ b/Sources/TootSDK/WebPushEncryption/WebPushMessageEncryption.swift
@@ -1,6 +1,7 @@
 //
 //  WebPushMessageEncryption.swift
 //
+//  Provides encryption and decryption helpers for Web Push messages.
 //
 //  Created by Łukasz Rutkowski on 30/12/2023.
 //
@@ -10,45 +11,99 @@ import Foundation
 
 /// Helper for Web Push message handling.
 public enum WebPushMessageEncryption {
+    /// Supported Web Push content encodings as defined in the Web Push specifications.
+    public enum ContentEncoding: String {
+        /// AES-GCM encoding (RFC 8291 4th draft). https://datatracker.ietf.org/doc/html/draft-ietf-webpush-encryption-04
+        case aesgcm
+        /// AES-128-GCM encoding (RFC 8291). https://datatracker.ietf.org/doc/html/rfc8291
+        case aes128gcm
+    }
 
     /// Decrypts and decodes a push notification.
     ///
     /// - Parameters:
     ///   - encryptedMessage: The encrypted message data received in push.
     ///   - privateKey: The private key corresponding to a public key used when registering push subscription.
-    ///   - serverPublicKey: The public key of a server received in push  as "dh" parameter of "Crypto-Key" HTTP header
+    ///   - serverPublicKey: The server's public key received in push as the "dh" parameter of the "Crypto-Key" HTTP header.
     ///   - auth: The authentication secret used when registering push subscription.
-    ///   - salt: The salt received from server in push  as "salt" parameter of "Encryption" HTTP header.
+    ///   - salt: The salt received from the server in push as the "salt" parameter of the "Encryption" HTTP header.
+    ///   - encoding: The content encoding algorithm to use.
     /// - Returns: Push notification.
     public static func decryptAndDecodePush(
         _ encryptedMessage: Data,
         privateKey: P256.KeyAgreement.PrivateKey,
-        serverPublicKey: P256.KeyAgreement.PublicKey,
+        serverPublicKey: P256.KeyAgreement.PublicKey?,
         auth: Data,
-        salt: Data
+        salt: Data?,
+        encoding: ContentEncoding,
     ) throws -> PushNotification {
         let decryptedMessageData = try decrypt(
             encryptedMessage,
             privateKey: privateKey,
             serverPublicKey: serverPublicKey,
             auth: auth,
-            salt: salt
+            salt: salt,
+            encoding: encoding
         )
         return try TootDecoder().decode(PushNotification.self, from: decryptedMessageData)
     }
 
     /// Decrypts a message encrypted by server according to Web Push standard.
     ///
-    /// - Reference:
-    ///   - [Message Encryption for Web Push](https://datatracker.ietf.org/doc/html/draft-ietf-webpush-encryption-04)
-    ///   - [ecec](https://github.com/web-push-libs/ecec?tab=readme-ov-file#ecec)
+    /// - Parameters:
+    ///   - encryptedMessage: The encrypted message data received in push.
+    ///   - privateKey: The private key corresponding to a public key used when registering push subscription.
+    ///   - serverPublicKey: The server's public key received in push as the "dh" parameter of the "Crypto-Key" HTTP header. Used for `aesgcm` encoding only.
+    ///   - auth: The authentication secret used when registering push subscription.
+    ///   - salt: The salt received from the server in push as the "salt" parameter of the "Encryption" HTTP header.  Used for `aesgcm` encoding only.
+    ///   - encoding: The content encoding algorithm to use.
+    /// - Returns: Decrypted message data.
+    public static func decrypt(
+        _ encryptedMessage: Data,
+        privateKey: P256.KeyAgreement.PrivateKey,
+        serverPublicKey: P256.KeyAgreement.PublicKey?,
+        auth: Data,
+        salt: Data?,
+        encoding: ContentEncoding,
+    ) throws -> Data {
+        switch encoding {
+        case .aesgcm:
+            guard let serverPublicKey else {
+                throw TootSDKError.invalidParameter(
+                    parameterName: "serverPublicKey",
+                    reason: "Public key is required when decrypting AES-GCM encrypted messages."
+                )
+            }
+            guard let salt else {
+                throw TootSDKError.invalidParameter(parameterName: "salt", reason: "Salt is required when decrypting AES-GCM encrypted messages.")
+            }
+            return try decrypt(
+                encryptedMessage,
+                privateKey: privateKey,
+                serverPublicKey: serverPublicKey,
+                auth: auth,
+                salt: salt
+            )
+
+        case .aes128gcm:
+            return try decrypt(
+                encryptedMessage,
+                privateKey: privateKey,
+                auth: auth
+            )
+        }
+    }
+
+    // MARK: AES-GCM
+
+    /// Decrypts a message encrypted by server according to Web Push standard using AES-GCM encoding (RFC 8291 4th draft).
     ///
     /// - Parameters:
     ///   - encryptedMessage: The encrypted message data received in push.
     ///   - privateKey: The private key corresponding to a public key used when registering push subscription.
-    ///   - serverPublicKey: The public key of a server received in push  as "dh" parameter of "Crypto-Key" HTTP header
+    ///   - serverPublicKey: The server's public key received in push as the "dh" parameter of the "Crypto-Key" HTTP header.
     ///   - auth: The authentication secret used when registering push subscription.
-    ///   - salt: The salt received from server in push  as "salt" parameter of "Encryption" HTTP header.
+    ///   - salt: The salt received from the server in push as the "salt" parameter of the "Encryption" HTTP header.
     /// - Returns: Decrypted message data.
     public static func decrypt(
         _ encryptedMessage: Data,
@@ -96,17 +151,110 @@ public enum WebPushMessageEncryption {
 
         let sealedBox = try AES.GCM.SealedBox(combined: nonceData + encryptedMessage)
         let plaintext = try AES.GCM.open(sealedBox, using: key)
+        return try removeLeadingPadding(plaintext)
+    }
 
-        let paddingLength = Int(plaintext[0]) * 256 + Int(plaintext[1])
-        guard plaintext.count >= 2 + paddingLength else {
+    private static func removeLeadingPadding(_ data: Data) throws -> Data {
+        let paddingLength = Int(data[0]) * 256 + Int(data[1])
+        guard data.count >= 2 + paddingLength else {
             throw TootSDKError.unexpectedError("Malformed encoded message. Padding should not be longer than message.")
         }
-        let unpadded = plaintext.suffix(from: paddingLength + 2)
-
+        let unpadded = data.suffix(from: paddingLength + 2)
         return Data(unpadded)
     }
 
-    private static func info(_ name: String, context: [UInt8]) -> [UInt8] {
-        return Array("Content-Encoding: \(name)\0".utf8) + context
+    private static func info(_ name: String, context: [UInt8]?) -> [UInt8] {
+        let bytes = Array("Content-Encoding: \(name)\0".utf8)
+        if let context {
+            return bytes + context
+        }
+        return bytes
     }
+
+    // - MARK: AES-128-GCM
+
+    /// Decrypts a message encrypted by server according to Web Push standard using AES-128-GCM encoding (RFC 8291).
+    ///
+    /// - Parameters:
+    ///   - encryptedMessageWithHeader: The encrypted message data received in push.
+    ///   - privateKey: The private key corresponding to a public key used when registering push subscription.
+    ///   - auth: The authentication secret used when registering push subscription.
+    /// - Returns: Decrypted message data.
+    public static func decrypt(
+        _ encryptedMessageWithHeader: Data,
+        privateKey: P256.KeyAgreement.PrivateKey,
+        auth: Data
+    ) throws -> Data {
+        guard encryptedMessageWithHeader.count > headerKeyIDLengthEnd else {
+            throw TootSDKError.unexpectedError("Encrypted message is too short.")
+        }
+
+        let salt = encryptedMessageWithHeader[headerSaltStart..<headerSaltEnd]
+
+        let recordSize: UInt32 = encryptedMessageWithHeader[headerSaltEnd..<headerRecordSizeEnd]
+            .withUnsafeBytes { $0.load(as: UInt32.self).bigEndian }
+        guard recordSize >= 18 else {
+            throw TootSDKError.unexpectedError("Invalid record size")
+        }
+
+        let keyIDLength: UInt8 = encryptedMessageWithHeader[headerKeyIDLengthStart]
+        let headerKeyIDEnd = Int(keyIDLength) + headerKeyIDStart
+        let serverPublicKeyData = encryptedMessageWithHeader[headerKeyIDStart..<headerKeyIDEnd]
+        let encryptedMessage = encryptedMessageWithHeader[headerKeyIDEnd...]
+
+        let serverPublicKey = try P256.KeyAgreement.PublicKey(x963Representation: serverPublicKeyData)
+        let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: serverPublicKey)
+
+        var keyInfo = Array("WebPush: info\0".utf8)
+        keyInfo.append(contentsOf: privateKey.publicKey.x963Representation)
+        keyInfo.append(contentsOf: serverPublicKey.x963Representation)
+
+        let pseudoRandomKey = sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: auth,
+            sharedInfo: keyInfo,
+            outputByteCount: 32
+        )
+        let key = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: pseudoRandomKey,
+            salt: salt,
+            info: info("aes128gcm", context: nil),
+            outputByteCount: 16
+        )
+        let nonce = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: pseudoRandomKey,
+            salt: salt,
+            info: info("nonce", context: nil),
+            outputByteCount: 12
+        )
+        let nonceData = nonce.withUnsafeBytes(Array.init)
+
+        let sealedBox = try AES.GCM.SealedBox(combined: nonceData + encryptedMessage)
+        let plaintext = try AES.GCM.open(sealedBox, using: key)
+        return try removeTrailingPadding(plaintext)
+    }
+
+    private static func removeTrailingPadding(_ data: Data) throws -> Data {
+        var byteIndex = data.count - 1
+        while byteIndex >= 0 && data[byteIndex] == 0 {
+            byteIndex -= 1
+        }
+        guard
+            byteIndex >= 0,
+            data[byteIndex] == lastRecordPaddingDelimiter
+        else {
+            throw TootSDKError.unexpectedError("Invalid padding")
+        }
+        let unpadded = data.prefix(byteIndex)
+        return Data(unpadded)
+    }
+
+    private static let headerSaltStart = 0
+    private static let headerSaltEnd = 16 + headerSaltStart
+    private static let headerRecordSizeStart = headerSaltEnd
+    private static let headerRecordSizeEnd = 4 + headerRecordSizeStart
+    private static let headerKeyIDLengthStart = headerRecordSizeEnd
+    private static let headerKeyIDLengthEnd = 1 + headerKeyIDLengthStart
+    private static let headerKeyIDStart = headerKeyIDLengthEnd
+    private static let lastRecordPaddingDelimiter = 2
 }

--- a/Tests/TootSDKTests/WebPushMessageEncryptionTests.swift
+++ b/Tests/TootSDKTests/WebPushMessageEncryptionTests.swift
@@ -25,7 +25,8 @@ final class WebPushMessageEncryptionTests: XCTestCase {
             privateKey: privateKey,
             serverPublicKey: serverPublicKey,
             auth: auth,
-            salt: salt
+            salt: salt,
+            encoding: .aesgcm
         )
         let decryptedMessage = try XCTUnwrap(String(data: decryptedMessageData, encoding: .utf8))
         XCTAssertEqual(decryptedMessage, "I am the walrus")
@@ -52,7 +53,8 @@ final class WebPushMessageEncryptionTests: XCTestCase {
             privateKey: privateKey,
             serverPublicKey: serverPublicKey,
             auth: auth,
-            salt: salt
+            salt: salt,
+            encoding: .aesgcm
         )
         XCTAssertEqual(pushNotification.accessToken, "c43ecb5528e95f52529ec5fcf03e02966bce3602ff0017bea98a83136df70485")
         XCTAssertEqual(pushNotification.body, "Test")
@@ -72,6 +74,24 @@ final class WebPushMessageEncryptionTests: XCTestCase {
         let keys = PushSubscriptionParams.Keys(encryptionKeys)
         XCTAssertEqual(keys.p256dh, "BCEkBjzL8Z3C-oi2Q7oE5t2Np-p7osjGLg93qUP0wvqRT21EEWyf0cQDQcakQMqz4hQKYOQ3il2nNZct4HgAUQU")
         XCTAssertEqual(keys.auth, urlSafeBase64EncodedAuth)
+    }
+
+    func testDecryptAES128GCM() throws {
+        let encryptedMessage = try decode("DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN")
+        let privateKeyData = try decode("q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94")
+        let privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateKeyData)
+        let auth = try decode("BTBZMqHH6r4Tts7J_aSIgg")
+
+        let decryptedMessageData = try WebPushMessageEncryption.decrypt(
+            encryptedMessage,
+            privateKey: privateKey,
+            serverPublicKey: nil,
+            auth: auth,
+            salt: nil,
+            encoding: .aes128gcm
+        )
+        let decryptedMessage = try XCTUnwrap(String(data: decryptedMessageData, encoding: .utf8))
+        XCTAssertEqual(decryptedMessage, "When I grow up, I want to be a watermelon")
     }
 
     private func decode(_ base64UrlEncoded: String) throws -> Data {


### PR DESCRIPTION
In order to correctly add support for GoToSocial push notifications we need a way to decode them using AES-128-GCM encoding which is what they are using. This pull request addresses that by updating the existing decrypt(andDecode) methods with a new `ContentEncoding` parameter. This is a breaking change.

Additionally Mastodon also implemented webpush using the same encoding but it is opt-in. A way to enable that is by passing `subscription[standard]` set to true when creating push subscription. I implemented that with a new optional parameter on `Subscription` struct and a feature telling whether it's available or not. 

Reference:
- https://github.com/feditext/feditext/commit/87b4075c58de319dd556223745a3069a686c2e27
- https://datatracker.ietf.org/doc/html/rfc8291#section-5
- https://codeberg.org/superseriousbusiness/gotosocial/pulls/3587
- https://docs.joinmastodon.org/methods/push/#form-data-parameters