### PR TITLE
add public init for PagedResult for better testability

### DIFF
--- a/Sources/TootSDK/HTTP/PagedResult.swift
+++ b/Sources/TootSDK/HTTP/PagedResult.swift
@@ -12,7 +12,9 @@ public struct PagedResult<T: Decodable>: Decodable {
 
     /// Returns pagination object for the previous page of results if one is available.  A previous page contains results older than the current page.
     public let previousPage: PagedInfo?
-	
+
+    /// Creates a new `PagedResult` with a given `result` and its `PageInfo`.
+    /// Use `nextPage` and `previousPage` as fit.
     public init(result: T, info: PagedInfo, nextPage: PagedInfo?, previousPage: PagedInfo?) {
         self.result = result
         self.info = info

--- a/Sources/TootSDK/HTTP/PagedResult.swift
+++ b/Sources/TootSDK/HTTP/PagedResult.swift
@@ -12,6 +12,14 @@ public struct PagedResult<T: Decodable>: Decodable {
 
     /// Returns pagination object for the previous page of results if one is available.  A previous page contains results older than the current page.
     public let previousPage: PagedInfo?
+	
+    public init(result: T, info: PagedInfo, nextPage: PagedInfo?, previousPage: PagedInfo?) {
+        self.result = result
+        self.info = info
+        self.nextPage = nextPage
+        self.previousPage = previousPage
+		}
+
 }
 
 extension PagedResult {


### PR DESCRIPTION
As I was adding pagination tests to my current project, I wanted to use `PagedResult` directly.
Sadly there was no public init for it, so swiftc was complaining.

- this adds the missing public init for `PagedResult` only
- no new test were added as this make the structure public only, no feature was changed
- existing tests all passed
