### PR TITLE
Make TootResponse Sendable when its decoded data is sendable

### DIFF
--- a/Sources/TootSDK/Models/TootResponse.swift
+++ b/Sources/TootSDK/Models/TootResponse.swift
@@ -16,7 +16,7 @@ import Foundation
 /// let rateLimit = response.rateLimitRemaining
 /// let linkHeader = response.linkHeader
 /// ```
-public struct TootResponse<T> {
+public struct TootResponse<T>: Sendable where T: Sendable {
     /// The decoded response data (original return type)
     public let data: T
 

--- a/Sources/TootSDK/Models/TrendingLink.swift
+++ b/Sources/TootSDK/Models/TrendingLink.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TrendingLink: Codable, Hashable {
+public struct TrendingLink: Codable, Hashable, Sendable {
     public init(
         url: String,
         title: String,


### PR DESCRIPTION
This makes the Raw methods more usable with concurrency. Also marked TrendingLink as Sendable.