### PR TITLE
Fix unable to connect to services that do not support v2 instance info

### DIFF
--- a/Sources/TootSDK/Models/TootSDKError.swift
+++ b/Sources/TootSDK/Models/TootSDKError.swift
@@ -87,4 +87,15 @@ public enum TootSDKError: Error, LocalizedError, Equatable {
             return "The remote instance doesn't support nodeinfo endpoint."
         }
     }
+
+    var isUnsupportedEndpoint: Bool {
+        switch self {
+        case .unsupportedFeature, .unsupportedFlavour:
+            return true
+        case .invalidStatusCode(data: _, let response):
+            return [400, 404, 501].contains(response.statusCode)
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/TootSDK/TootClient/TootClient+Instance.swift
+++ b/Sources/TootSDK/TootClient/TootClient+Instance.swift
@@ -34,8 +34,8 @@ extension TootClient {
                 rawBody: response.rawBody
             )
             // This function might be called before flavour is known, causing feature check to work incorrectly.
-            // Attempt to fetch v1 instance info if call for v2 instance info fails with http error.
-        } catch TootSDKError.unsupportedFlavour, TootSDKError.invalidStatusCode {
+            // Attempt to fetch v1 instance info if call for v2 instance info fails with matching error.
+        } catch let error as TootSDKError where error.isUnsupportedEndpoint {
             let response = try await getInstanceInfoV1Raw()
             return TootResponse(
                 data: response.data as any Instance,


### PR DESCRIPTION
The function to fetch instance info is called from connect initializer before flavour info is known. For that reason feature check for support of v2 instance succeeds because it thinks we are connecting to Mastodon.

To work around the issue also attempt to fetch v1 instance info if call to v2 endpoint fails with a http error.

___

This could be potentially further extended by setting flavour as soon as possible in the connect method but I decided to go for simplest fix for now.