### PR TITLE
Support block quotes in attributed string renderer

### DIFF
--- a/Examples/TootSDKExample/TootSDKExample.xcodeproj/project.pbxproj
+++ b/Examples/TootSDKExample/TootSDKExample.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B5362EB92E54C1790075BBD2 /* TootSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B5362EB82E54C1790075BBD2 /* TootSDK */; };
+		B51DCC1C2F9A761D00AFB55B /* TootSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B51DCC1B2F9A761D00AFB55B /* TootSDK */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,7 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B5362EB92E54C1790075BBD2 /* TootSDK in Frameworks */,
+				B51DCC1C2F9A761D00AFB55B /* TootSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,7 +130,7 @@
 			);
 			name = TootSDKExample;
 			packageProductDependencies = (
-				B5362EB82E54C1790075BBD2 /* TootSDK */,
+				B51DCC1B2F9A761D00AFB55B /* TootSDK */,
 			);
 			productName = TootSDKExample;
 			productReference = B5362E8B2E54C12F0075BBD2 /* TootSDKExample.app */;
@@ -215,7 +215,7 @@
 			mainGroup = B5362E822E54C12F0075BBD2;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */,
+				B51DCC1A2F9A761D00AFB55B /* XCLocalSwiftPackageReference "../../../TootSDK" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B5362E8C2E54C12F0075BBD2 /* Products */;
@@ -666,21 +666,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/TootSDK/TootSDK";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 18.2.0;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		B51DCC1A2F9A761D00AFB55B /* XCLocalSwiftPackageReference "../../../TootSDK" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../TootSDK;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B5362EB82E54C1790075BBD2 /* TootSDK */ = {
+		B51DCC1B2F9A761D00AFB55B /* TootSDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B5362EB72E54C1790075BBD2 /* XCRemoteSwiftPackageReference "TootSDK" */;
 			productName = TootSDK;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Examples/TootSDKExample/TootSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/TootSDKExample/TootSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "32950d79a4cf067a2070db1e8fea477d9c783330a61845f5c868a25232c29394",
+  "originHash" : "afb16287533c48638048ef415a918ca37714a59f5fef6dee04e938f856ed7ba5",
   "pins" : [
     {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
-        "version" : "1.4.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {
@@ -33,8 +33,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "334e682869394ee239a57dbe9262bff3cd9495bd",
-        "version" : "3.14.0"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -42,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
-        "version" : "2.86.0"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
-        "version" : "1.6.2"
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {
@@ -69,17 +78,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "3a439f9eccc391b264d54516ce640251552eb0c4",
-        "version" : "2.10.3"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     },
     {
-      "identity" : "tootsdk",
+      "identity" : "version",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/TootSDK/TootSDK",
+      "location" : "https://github.com/mxcl/Version.git",
       "state" : {
-        "revision" : "3e090a30f3cb3ae4e0a863135842a01bd2e38c91",
-        "version" : "18.2.0"
+        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
+        "version" : "2.2.0"
       }
     }
   ],

--- a/Examples/TootSDKExample/TootSDKExample/Models/DisplayPost.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Models/DisplayPost.swift
@@ -9,18 +9,26 @@ import Foundation
 import SwiftData
 
 @Model
-// A model of a post as used in the UI of the app
 final class DisplayPost {
+    enum Kind: String, Codable {
+        case home
+        case mention
+    }
+
     @Attribute(.unique)
+    var storageID: String
     var id: String
+    var kind: String
     var authorName: String
     var authorUsername: String
     var content: String
     var createdAt: Date
     var url: String
 
-    init(id: String, authorName: String, authorUsername: String, content: String, createdAt: Date, url: String) {
+    init(kind: Kind, id: String, authorName: String, authorUsername: String, content: String, createdAt: Date, url: String) {
+        self.storageID = "\(kind.rawValue):\(id)"
         self.id = id
+        self.kind = kind.rawValue
         self.authorName = authorName
         self.authorUsername = authorUsername
         self.content = content

--- a/Examples/TootSDKExample/TootSDKExample/TootSDKExampleApp.swift
+++ b/Examples/TootSDKExample/TootSDKExample/TootSDKExampleApp.swift
@@ -16,8 +16,7 @@ struct TootSDKExampleApp: App {
             ServerCredential.self,
         ])
 
-        // in-memory store because this is a demo and we don't need anything saved, the app will reset when restarted
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {
             return try ModelContainer(for: schema, configurations: [modelConfiguration])

--- a/Examples/TootSDKExample/TootSDKExample/Views/HomeTimelineView.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/HomeTimelineView.swift
@@ -1,0 +1,71 @@
+//
+//  HomeTimelineView.swift
+//  TootSDKExample
+//
+//  Created by Konstantin Gerry on 19/08/2025.
+//
+
+import SwiftData
+import SwiftUI
+import TootSDK
+
+struct HomeTimelineView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(
+        filter: #Predicate<DisplayPost> { $0.kind == "home" },
+        sort: \DisplayPost.createdAt,
+        order: .reverse
+    )
+    private var posts: [DisplayPost]
+
+    let client: TootClient
+
+    var body: some View {
+        Group {
+            if posts.isEmpty {
+                VStack(spacing: 20) {
+                    ProgressView()
+                    Text("Loading posts...")
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(posts) { post in
+                    PostRow(post: post)
+                }
+            }
+        }
+        .task {
+            await fetchPosts()
+        }
+        .refreshable {
+            await fetchPosts()
+        }
+    }
+
+    private func fetchPosts() async {
+        do {
+            let timeline = try await client.getTimeline(.home)
+            let newPosts = timeline.result.compactMap { post -> DisplayPost? in
+                let rendered = AttributedStringRenderer().render(html: post.content ?? "").plainString
+                return DisplayPost(
+                    kind: .home,
+                    id: post.id,
+                    authorName: post.account.displayName ?? post.account.username ?? "",
+                    authorUsername: post.account.acct,
+                    content: rendered,
+                    createdAt: post.createdAt,
+                    url: post.url ?? post.uri
+                )
+            }
+            for post in posts {
+                modelContext.delete(post)
+            }
+            for post in newPosts {
+                modelContext.insert(post)
+            }
+            try? modelContext.save()
+        } catch {
+            print("Failed to fetch home timeline: \(error)")
+        }
+    }
+}

--- a/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
@@ -43,12 +43,25 @@ struct MentionsTimelineView: View {
     }
 
     private func fetchMentions() async {
+        var marks = AttributeContainer()
+        marks.swiftUI.font = .system(size: 32, weight: .bold)
+        marks.swiftUI.foregroundColor = .pink
+        
+        var body = AttributeContainer()
+        body.swiftUI.font = .body
+        
+        let style = BlockQuoteStyle(
+            locale: Locale(identifier: "en_US"),
+            markAttributes: marks,
+            contentAttributes: body
+        )
+        
         do {
             let params = TootNotificationParams(types: [.mention])
             let page = try await client.getNotifications(params: params)
             let newPosts = page.result.compactMap { notif -> DisplayPost? in
                 guard let post = notif.post else { return nil }
-                let rendered = AttributedStringRenderer().render(html: post.content ?? "").plainString
+                let rendered = AttributedStringRenderer().render(html: post.content ?? "", blockQuoteStyle: style).plainString
                 return DisplayPost(
                     kind: .mention,
                     id: post.id,

--- a/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
@@ -1,0 +1,73 @@
+//
+//  MentionsTimelineView.swift
+//  TootSDKExample
+//
+//  Created by Konstantin Gerry on 19/08/2025.
+//
+
+import SwiftData
+import SwiftUI
+import TootSDK
+
+struct MentionsTimelineView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(
+        filter: #Predicate<DisplayPost> { $0.kind == "mention" },
+        sort: \DisplayPost.createdAt,
+        order: .reverse
+    )
+    private var posts: [DisplayPost]
+
+    let client: TootClient
+
+    var body: some View {
+        Group {
+            if posts.isEmpty {
+                VStack(spacing: 20) {
+                    ProgressView()
+                    Text("Loading mentions...")
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(posts) { post in
+                    PostRow(post: post)
+                }
+            }
+        }
+        .task {
+            await fetchMentions()
+        }
+        .refreshable {
+            await fetchMentions()
+        }
+    }
+
+    private func fetchMentions() async {
+        do {
+            let params = TootNotificationParams(types: [.mention])
+            let page = try await client.getNotifications(params: params)
+            let newPosts = page.result.compactMap { notif -> DisplayPost? in
+                guard let post = notif.post else { return nil }
+                let rendered = AttributedStringRenderer().render(html: post.content ?? "").plainString
+                return DisplayPost(
+                    kind: .mention,
+                    id: post.id,
+                    authorName: post.account.displayName ?? post.account.username ?? "",
+                    authorUsername: post.account.acct,
+                    content: rendered,
+                    createdAt: post.createdAt,
+                    url: post.url ?? post.uri
+                )
+            }
+            for post in posts {
+                modelContext.delete(post)
+            }
+            for post in newPosts {
+                modelContext.insert(post)
+            }
+            try? modelContext.save()
+        } catch {
+            print("Failed to fetch mentions: \(error)")
+        }
+    }
+}

--- a/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/MentionsTimelineView.swift
@@ -20,6 +20,21 @@ struct MentionsTimelineView: View {
 
     let client: TootClient
 
+    private static let blockQuoteStyle: BlockQuoteStyle = {
+        var marks = AttributeContainer()
+        marks.swiftUI.font = .system(size: 32, weight: .bold)
+        marks.swiftUI.foregroundColor = .green
+
+        var body = AttributeContainer()
+        body.swiftUI.font = .body
+
+        return BlockQuoteStyle(
+            locale: Locale(identifier: "en_US"),
+            markAttributes: marks,
+            contentAttributes: body
+        )
+    }()
+
     var body: some View {
         Group {
             if posts.isEmpty {
@@ -30,7 +45,7 @@ struct MentionsTimelineView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(posts) { post in
-                    PostRow(post: post)
+                    MentionRow(post: post, blockQuoteStyle: Self.blockQuoteStyle)
                 }
             }
         }
@@ -43,31 +58,17 @@ struct MentionsTimelineView: View {
     }
 
     private func fetchMentions() async {
-        var marks = AttributeContainer()
-        marks.swiftUI.font = .system(size: 32, weight: .bold)
-        marks.swiftUI.foregroundColor = .pink
-        
-        var body = AttributeContainer()
-        body.swiftUI.font = .body
-        
-        let style = BlockQuoteStyle(
-            locale: Locale(identifier: "en_US"),
-            markAttributes: marks,
-            contentAttributes: body
-        )
-        
         do {
             let params = TootNotificationParams(types: [.mention])
             let page = try await client.getNotifications(params: params)
             let newPosts = page.result.compactMap { notif -> DisplayPost? in
                 guard let post = notif.post else { return nil }
-                let rendered = AttributedStringRenderer().render(html: post.content ?? "", blockQuoteStyle: style).plainString
                 return DisplayPost(
                     kind: .mention,
                     id: post.id,
                     authorName: post.account.displayName ?? post.account.username ?? "",
                     authorUsername: post.account.acct,
-                    content: rendered,
+                    content: post.content ?? "",
                     createdAt: post.createdAt,
                     url: post.url ?? post.uri
                 )
@@ -82,5 +83,22 @@ struct MentionsTimelineView: View {
         } catch {
             print("Failed to fetch mentions: \(error)")
         }
+    }
+}
+
+private struct MentionRow: View {
+    let post: DisplayPost
+    let blockQuoteStyle: BlockQuoteStyle
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(post.authorName)
+                .font(.headline)
+            Text(AttributedStringRenderer.shared.render(html: post.content, blockQuoteStyle: blockQuoteStyle).attributedString)
+                .lineLimit(5)
+            Text(post.createdAt, style: .relative)
+                .font(.caption)
+        }
+        .padding(.vertical, 4)
     }
 }

--- a/Examples/TootSDKExample/TootSDKExample/Views/PostRow.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/PostRow.swift
@@ -1,0 +1,25 @@
+//
+//  PostRow.swift
+//  TootSDKExample
+//
+//  Created by Konstantin Gerry on 19/08/2025.
+//
+
+import SwiftUI
+
+struct PostRow: View {
+    let post: DisplayPost
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(post.authorName)
+                .font(.headline)
+            Text(post.content)
+                .font(.body)
+                .lineLimit(5)
+            Text(post.createdAt, style: .relative)
+                .font(.caption)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Examples/TootSDKExample/TootSDKExample/Views/RootView.swift
+++ b/Examples/TootSDKExample/TootSDKExample/Views/RootView.swift
@@ -13,12 +13,10 @@ import TootSDK
 struct RootView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var credentials: [ServerCredential]
-    @Query private var posts: [DisplayPost]
 
-    @State private var serverURL = "https://mastodon.social"
+    @AppStorage("lastEnteredServerURL") private var serverURL: String = "https://mastodon.social"
     @State private var isLoading = false
     @State private var client: TootClient?
-    @State private var showingAuthSession = false
 
     private var hasCredentials: Bool {
         !credentials.isEmpty
@@ -31,11 +29,14 @@ struct RootView: View {
     var body: some View {
         NavigationStack {
             VStack {
-                if hasCredentials {
-                    // Authenticated view showing posts
-                    authenticatedView
+                if let client, hasCredentials {
+                    TabView {
+                        HomeTimelineView(client: client)
+                            .tabItem { Label("Home", systemImage: "house") }
+                        MentionsTimelineView(client: client)
+                            .tabItem { Label("Mentions", systemImage: "at") }
+                    }
                 } else {
-                    // Login view for entering server URL
                     loginView
                 }
             }
@@ -51,7 +52,6 @@ struct RootView: View {
             }
         }
         .task {
-            // If you already have a credential, use it to create a TootClient
             if let credential = currentCredential {
                 await connectWithCredential(credential)
             }
@@ -94,41 +94,13 @@ struct RootView: View {
         .padding()
     }
 
-    @ViewBuilder
-    private var authenticatedView: some View {
-        if posts.isEmpty {
-            VStack(spacing: 20) {
-                ProgressView()
-                Text("Loading posts...")
-                    .foregroundColor(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            List(posts) { post in
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(post.authorName)
-                        .font(.headline)
-                    Text(post.content)
-                        .font(.body)
-                        .lineLimit(5)
-                    Text(post.createdAt, style: .relative)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.vertical, 4)
-            }
-        }
-    }
-
     private func startAuthentication() async {
-
         guard let url = URL(string: self.serverURL) else {
             print("Invalid server URL")
             return
         }
 
         do {
-            // Let's create a TootClient which will execute the authentication
             let newClient = try await TootClient(
                 connect: url,
                 clientName: "TootSDK Example",
@@ -137,22 +109,17 @@ struct RootView: View {
 
             self.client = newClient
 
-            // Present authentication session
             let accessToken = try await newClient.presentSignIn(
                 callbackURI: "tootsdk-example://oauth",
                 prefersEphemeralWebBrowserSession: false
             )
 
-            // Save credential so it can be re-used later
             let credential = ServerCredential(
                 host: url.absoluteString,
                 accessToken: accessToken
             )
             modelContext.insert(credential)
             try modelContext.save()
-
-            // Fetch initial posts
-            await fetchPosts()
 
         } catch ASWebAuthenticationSessionError.canceledLogin {
             print("User cancelled, no error message needed")
@@ -172,67 +139,18 @@ struct RootView: View {
                 accessToken: credential.accessToken
             )
             self.client = newClient
-
-            // Verify credentials are still valid and fetch posts
             _ = try await newClient.verifyCredentials()
-            await fetchPosts()
         } catch {
-            // Token might be invalid, clear credentials
             print(error.localizedDescription)
             signOut()
         }
     }
 
-    private func fetchPosts() async {
-        guard let client else { return }
-
-        do {
-            // Fetch home timeline
-            let timeline = try await client.getTimeline(.home)
-
-            // Convert to DisplayPost objects
-            let newPosts = timeline.result.compactMap { post in
-                // TootSDK provides renderers to handle post formatting
-                // You can make your own renderer for custom handling!
-                let renderedPost: String = AttributedStringRenderer().render(html: post.content ?? "").plainString
-
-                return DisplayPost(
-                    id: post.id,
-                    authorName: post.account.displayName ?? post.account.username ?? "",
-                    authorUsername: post.account.acct,
-                    content: renderedPost,
-                    createdAt: post.createdAt,
-                    url: post.url ?? post.uri
-                )
-            }
-
-            // Clear existing posts and add new ones
-            for post in posts {
-                modelContext.delete(post)
-            }
-
-            for post in newPosts {
-                modelContext.insert(post)
-            }
-
-            try? modelContext.save()
-        } catch {
-            print("Failed to fetch posts: \(error)")
-        }
-    }
-
     private func signOut() {
-        // Clear all credentials and posts
         for credential in credentials {
             modelContext.delete(credential)
         }
-        for post in posts {
-            modelContext.delete(post)
-        }
         try? modelContext.save()
-
-        // Reset state
         client = nil
-        serverURL = ""
     }
 }

--- a/Sources/MultipartKitTootSDK/MultipartParser.swift
+++ b/Sources/MultipartKitTootSDK/MultipartParser.swift
@@ -263,7 +263,7 @@ extension UInt8 {
 
     /*
      See https://tools.ietf.org/html/rfc1341#page-6 and https://tools.ietf.org/html/rfc822#section-3.2
-    
+
         field-name  = token
         token       = 1*<any CHAR except CTLs or tspecials>
         CTL         = <any US-ASCII control character (octets 0 - 31) and DEL (127)>

--- a/Sources/TootSDK/HTMLRendering/AttributedString+Quotation.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedString+Quotation.swift
@@ -1,0 +1,62 @@
+//
+//  AttributedString+Quotation.swift
+//  TootSDK
+//
+
+import Foundation
+
+/// Returns the opening and closing quotation mark strings for the given nesting level and locale.
+///
+/// - Even levels use the locale's primary delimiter pair; odd levels use the alternate pair.
+/// - French (`fr`) appends a non-breaking space (U+00A0) inside each mark; Swiss variants
+///   are intentionally excluded by checking the language code only.
+/// - Falls back to `"` / `'` when the locale provides no delimiter for a given pair.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+func quotationDelimiters(level: Int, locale: Locale) -> (open: String, close: String) {
+    let langCode = locale.identifier.components(separatedBy: CharacterSet(charactersIn: "_-")).first ?? ""
+    let isFrench = langCode == "fr"
+    let nbsp = "\u{00A0}"
+
+    let open: String
+    let close: String
+
+    if level % 2 == 0 {
+        open = locale.quotationBeginDelimiter ?? "\u{201C}"
+        close = locale.quotationEndDelimiter ?? "\u{201D}"
+    } else {
+        open = locale.alternateQuotationBeginDelimiter ?? "\u{2018}"
+        close = locale.alternateQuotationEndDelimiter ?? "\u{2019}"
+    }
+
+    if isFrench {
+        return (open + nbsp, nbsp + close)
+    }
+    return (open, close)
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString {
+    /// Wraps `content` in locale-correct quotation marks for the given nesting level.
+    ///
+    /// Inner text is not smartened; use a dedicated typography pass for that.
+    public static func inlineQuotation(
+        _ content: AttributedString,
+        level: Int = 0,
+        locale: Locale = .current
+    ) -> AttributedString {
+        let (open, close) = quotationDelimiters(level: level, locale: locale)
+        return AttributedString(open) + content + AttributedString(close)
+    }
+
+    /// Wraps `content` in locale-correct quotation marks for the given nesting level.
+    ///
+    /// Inner text is not smartened; use a dedicated typography pass for that.
+    public static func inlineQuotation(
+        _ content: String,
+        level: Int = 0,
+        locale: Locale = .current
+    ) -> AttributedString {
+        let (open, close) = quotationDelimiters(level: level, locale: locale)
+        return AttributedString(open + content + close)
+    }
+}

--- a/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedString+Util.swift
@@ -56,6 +56,20 @@
             self = AttributedString(self[startIndex..<endIndex])
         }
 
+        mutating func trimNewlines() {
+            var startIndex = startIndex
+            while startIndex < endIndex && characters[startIndex].isNewline {
+                startIndex = index(afterCharacter: startIndex)
+            }
+
+            var endIndex = endIndex
+            while endIndex > startIndex && characters[index(beforeCharacter: endIndex)].isNewline {
+                endIndex = index(beforeCharacter: endIndex)
+            }
+
+            self = AttributedString(self[startIndex..<endIndex])
+        }
+
         var endsWithNewline: Bool {
             characters.last?.isNewline == true
         }

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -45,6 +45,16 @@
             ]
         }
 
+        private struct Context {
+            var blockQuoteLevel: Int = 0
+
+            var isInBlockQuote: Bool { blockQuoteLevel > 0 }
+
+            var blockQuotePrefix: AttributedString {
+                AttributedString(String(repeating: "┃\t", count: blockQuoteLevel))
+            }
+        }
+
         public init() {}
 
         /// Converts an HTML fragment into a `ParsedContent` structure.
@@ -63,7 +73,7 @@
                 return ParsedContent(rawString: html, plainString: plainText, attributedString: .init(plainText))
             }
 
-            var attributedString = renderHTMLNode(body, options: options)
+            var attributedString = renderHTMLNode(body, options: options, context: Context())
             attributedString.trimWhitespaceAndNewlines()
             return ParsedContent(
                 rawString: html,
@@ -72,18 +82,18 @@
             )
         }
 
-        private func renderHTMLNode(_ node: Node, options: Options) -> AttributedString {
+        private func renderHTMLNode(_ node: Node, options: Options, context: Context) -> AttributedString {
             switch node {
             case let node as TextNode:
                 return AttributedString(node.getWholeText())
             case let node as Element:
-                return renderHTMLElement(node, options: options)
+                return renderHTMLElement(node, options: options, context: context)
             default:
                 return ""
             }
         }
 
-        private func renderHTMLElement(_ element: Element, options: Options) -> AttributedString {
+        private func renderHTMLElement(_ element: Element, options: Options, context: Context) -> AttributedString {
             var attributedString = AttributedString()
 
             if element.hasClass("quote-inline") && options.contains(.skipInlineQuotes) {
@@ -94,11 +104,18 @@
             }
 
             for child in element.getChildNodes() {
+                if child.isInsignificantWhitespace {
+                    continue
+                }
                 if child.isBlockElement && child.previousSibling() != nil && !attributedString.endsWithNewline {
                     // Each block element (including ones following inline elements) should start on new line
                     attributedString += "\n"
                 }
-                attributedString += renderHTMLNode(child, options: options)
+                var childContext = context
+                if element.tagName() == "blockquote" {
+                    childContext.blockQuoteLevel += 1
+                }
+                attributedString += renderHTMLNode(child, options: options, context: childContext)
             }
 
             if element.hasClass("ellipsis") && options.contains(.renderEllipsis) {
@@ -106,8 +123,18 @@
             }
 
             switch element.tagName() {
-            case "br", "p", "pre":
+            case "br":
                 attributedString += "\n"
+                if context.isInBlockQuote {
+                    attributedString += context.blockQuotePrefix
+                }
+            case "p", "pre":
+                if context.isInBlockQuote {
+                    attributedString.insertInlinePresentationIntent(.emphasized)
+                    attributedString = context.blockQuotePrefix + attributedString
+                } else {
+                    attributedString += "\n"
+                }
             case "a":
                 applyLink(from: element, to: &attributedString)
             case "em", "i":
@@ -118,6 +145,10 @@
                 attributedString.insertInlinePresentationIntent(.strikethrough)
             case "li":
                 applyList(from: element, to: &attributedString)
+                if context.isInBlockQuote {
+                    attributedString.insertInlinePresentationIntent(.emphasized)
+                    attributedString = context.blockQuotePrefix + attributedString
+                }
             case "code":
                 attributedString.insertInlinePresentationIntent(.code)
 
@@ -134,8 +165,8 @@
                 break
             }
 
-            if element.isBlockElement && !attributedString.endsWithDoubleNewline {
-                // Insert up to 2 new lines after block elements
+            if element.isBlockElement && !attributedString.endsWithDoubleNewline && !context.isInBlockQuote {
+                // Insert up to 2 new lines after block elements other than blockquotes
                 attributedString += "\n"
             }
 
@@ -164,7 +195,7 @@
                 let index = (try? element.elementSiblingIndex()) ?? 0
                 bullet = AttributedString("\(index + 1).\t")
             case "ul":
-                bullet = AttributedString("\u{2022}\t")
+                bullet = AttributedString(" \u{2022}\t")
             default:
                 bullet = AttributedString()
             }
@@ -180,6 +211,17 @@
                 return false
             }
             return element.isBlock() && element.tagName() != "del"
+        }
+
+        /// Returns `true` when this node is a whitespace-only text node whose only purpose is
+        /// to pretty-print the HTML source. Such nodes sit between block-level siblings and carry
+        /// no semantic content, so they can safely be skipped during rendering.
+        var isInsignificantWhitespace: Bool {
+            guard let textNode = self as? TextNode,
+                  textNode.getWholeText().allSatisfy({ $0.isWhitespace || $0.isNewline })
+            else { return false }
+            return previousSibling()?.isBlockElement == true
+                || nextSibling()?.isBlockElement == true
         }
     }
 #endif

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -218,7 +218,7 @@
         /// no semantic content, so they can safely be skipped during rendering.
         var isInsignificantWhitespace: Bool {
             guard let textNode = self as? TextNode,
-                  textNode.getWholeText().allSatisfy({ $0.isWhitespace || $0.isNewline })
+                textNode.getWholeText().allSatisfy({ $0.isWhitespace || $0.isNewline })
             else { return false }
             return previousSibling()?.isBlockElement == true
                 || nextSibling()?.isBlockElement == true

--- a/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
+++ b/Sources/TootSDK/HTMLRendering/AttributedStringRenderer.swift
@@ -47,12 +47,7 @@
 
         private struct Context {
             var blockQuoteLevel: Int = 0
-
-            var isInBlockQuote: Bool { blockQuoteLevel > 0 }
-
-            var blockQuotePrefix: AttributedString {
-                AttributedString(String(repeating: "┃\t", count: blockQuoteLevel))
-            }
+            var blockQuoteStyle: BlockQuoteStyle = .default
         }
 
         public init() {}
@@ -62,9 +57,14 @@
         /// - Parameters:
         ///   - html: A raw HTML string to render.
         ///   - options: Rendering options affecting output behavior.
+        ///   - blockQuoteStyle: Style configuration for blockquote rendering.
         /// - Returns: A parsed result containing the original HTML, plain text,
         ///   and attributed string representation.
-        public func render(html: String, options: Options = []) -> ParsedContent {
+        public func render(
+            html: String,
+            options: Options = [],
+            blockQuoteStyle: BlockQuoteStyle = .default
+        ) -> ParsedContent {
             guard
                 let document = try? SwiftSoup.parseBodyFragment(html),
                 let body = document.body()
@@ -73,7 +73,9 @@
                 return ParsedContent(rawString: html, plainString: plainText, attributedString: .init(plainText))
             }
 
-            var attributedString = renderHTMLNode(body, options: options, context: Context())
+            var context = Context()
+            context.blockQuoteStyle = blockQuoteStyle
+            var attributedString = renderHTMLNode(body, options: options, context: context)
             attributedString.trimWhitespaceAndNewlines()
             return ParsedContent(
                 rawString: html,
@@ -103,6 +105,11 @@
                 return attributedString
             }
 
+            var childContext = context
+            if element.tagName() == "blockquote" {
+                childContext.blockQuoteLevel += 1
+            }
+
             for child in element.getChildNodes() {
                 if child.isInsignificantWhitespace {
                     continue
@@ -110,10 +117,6 @@
                 if child.isBlockElement && child.previousSibling() != nil && !attributedString.endsWithNewline {
                     // Each block element (including ones following inline elements) should start on new line
                     attributedString += "\n"
-                }
-                var childContext = context
-                if element.tagName() == "blockquote" {
-                    childContext.blockQuoteLevel += 1
                 }
                 attributedString += renderHTMLNode(child, options: options, context: childContext)
             }
@@ -125,16 +128,8 @@
             switch element.tagName() {
             case "br":
                 attributedString += "\n"
-                if context.isInBlockQuote {
-                    attributedString += context.blockQuotePrefix
-                }
             case "p", "pre":
-                if context.isInBlockQuote {
-                    attributedString.insertInlinePresentationIntent(.emphasized)
-                    attributedString = context.blockQuotePrefix + attributedString
-                } else {
-                    attributedString += "\n"
-                }
+                attributedString += "\n"
             case "a":
                 applyLink(from: element, to: &attributedString)
             case "em", "i":
@@ -145,12 +140,14 @@
                 attributedString.insertInlinePresentationIntent(.strikethrough)
             case "li":
                 applyList(from: element, to: &attributedString)
-                if context.isInBlockQuote {
-                    attributedString.insertInlinePresentationIntent(.emphasized)
-                    attributedString = context.blockQuotePrefix + attributedString
-                }
             case "code":
                 attributedString.insertInlinePresentationIntent(.code)
+            case "blockquote":
+                attributedString = renderBlockQuote(
+                    body: attributedString,
+                    level: context.blockQuoteLevel,
+                    style: context.blockQuoteStyle
+                )
 
             #if canImport(UIKit) || canImport(AppKit)
                 case "h1":
@@ -165,12 +162,57 @@
                 break
             }
 
-            if element.isBlockElement && !attributedString.endsWithDoubleNewline && !context.isInBlockQuote {
-                // Insert up to 2 new lines after block elements other than blockquotes
+            if element.isBlockElement && element.tagName() != "blockquote" && !attributedString.endsWithDoubleNewline {
                 attributedString += "\n"
             }
 
             return attributedString
+        }
+
+        private func renderBlockQuote(body: AttributedString, level: Int, style: BlockQuoteStyle) -> AttributedString {
+            guard !body.characters.isEmpty else { return body }
+
+            var trimmed = body
+            trimmed.trimNewlines()
+            guard !trimmed.characters.isEmpty else { return AttributedString() }
+
+            // Collapse consecutive newlines (paragraph spacing) to a single newline per boundary.
+            var normalized = AttributedString()
+            var lastWasNewline = false
+            for run in trimmed.runs {
+                let runAttributes = run.attributes
+                let text = String(trimmed[run.range].characters)
+                var segment = ""
+                for ch in text {
+                    if ch == "\n" {
+                        if !lastWasNewline {
+                            segment.append(ch)
+                        }
+                        lastWasNewline = true
+                    } else {
+                        lastWasNewline = false
+                        segment.append(ch)
+                    }
+                }
+                if !segment.isEmpty {
+                    var segmentAS = AttributedString(segment)
+                    segmentAS.setAttributes(runAttributes)
+                    normalized += segmentAS
+                }
+            }
+
+            for run in normalized.runs {
+                normalized[run.range].mergeAttributes(style.contentAttributes, mergePolicy: .keepCurrent)
+            }
+
+            let (openStr, closeStr) = quotationDelimiters(level: level, locale: style.locale)
+
+            var openAS = AttributedString(openStr)
+            openAS.mergeAttributes(style.markAttributes)
+            var closeAS = AttributedString(closeStr)
+            closeAS.mergeAttributes(style.markAttributes)
+
+            return openAS + normalized + closeAS + AttributedString("\n")
         }
 
         private func applyLink(from element: Element, to attributedString: inout AttributedString) {

--- a/Sources/TootSDK/HTMLRendering/BlockQuoteStyle.swift
+++ b/Sources/TootSDK/HTMLRendering/BlockQuoteStyle.swift
@@ -1,0 +1,30 @@
+//
+//  BlockQuoteStyle.swift
+//  TootSDK
+//
+
+import Foundation
+
+/// Controls how blockquote elements are rendered by `AttributedStringRenderer`.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct BlockQuoteStyle: Sendable {
+    /// The locale used to determine quotation mark characters.
+    public var locale: Locale
+    /// Attributes applied to the opening and closing quotation mark glyphs only.
+    public var markAttributes: AttributeContainer
+    /// Attributes merged into every run of body text, with inner element attributes taking precedence.
+    public var contentAttributes: AttributeContainer
+
+    public init(
+        locale: Locale = .current,
+        markAttributes: AttributeContainer = .init(),
+        contentAttributes: AttributeContainer = .init()
+    ) {
+        self.locale = locale
+        self.markAttributes = markAttributes
+        self.contentAttributes = contentAttributes
+    }
+
+    /// Bare locale-aware quotation marks with no additional styling.
+    public static let `default` = BlockQuoteStyle()
+}

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -395,9 +395,9 @@
             let html = "<blockquote><p>Body text</p></blockquote>"
             var markAttrs = AttributeContainer()
             #if canImport(UIKit)
-            markAttrs.uiKit.foregroundColor = _TestColor.red
+                markAttrs.uiKit.foregroundColor = _TestColor.red
             #elseif canImport(AppKit)
-            markAttrs.appKit.foregroundColor = _TestColor.red
+                markAttrs.appKit.foregroundColor = _TestColor.red
             #endif
             let style = BlockQuoteStyle(
                 locale: Locale(identifier: "en_US"),
@@ -416,13 +416,13 @@
             })
 
             #if canImport(UIKit)
-            #expect(openRun?.uiKit.foregroundColor == _TestColor.red)
-            #expect(closeRun?.uiKit.foregroundColor == _TestColor.red)
-            #expect(bodyRun?.uiKit.foregroundColor != _TestColor.red)
+                #expect(openRun?.uiKit.foregroundColor == _TestColor.red)
+                #expect(closeRun?.uiKit.foregroundColor == _TestColor.red)
+                #expect(bodyRun?.uiKit.foregroundColor != _TestColor.red)
             #elseif canImport(AppKit)
-            #expect(openRun?.appKit.foregroundColor == _TestColor.red)
-            #expect(closeRun?.appKit.foregroundColor == _TestColor.red)
-            #expect(bodyRun?.appKit.foregroundColor != _TestColor.red)
+                #expect(openRun?.appKit.foregroundColor == _TestColor.red)
+                #expect(closeRun?.appKit.foregroundColor == _TestColor.red)
+                #expect(bodyRun?.appKit.foregroundColor != _TestColor.red)
             #endif
         }
 
@@ -433,9 +433,9 @@
             let bodyFont = _TestFont.systemFont(ofSize: 14)
             var contentAttrs = AttributeContainer()
             #if canImport(UIKit)
-            contentAttrs.uiKit.font = bodyFont
+                contentAttrs.uiKit.font = bodyFont
             #elseif canImport(AppKit)
-            contentAttrs.appKit.font = bodyFont
+                contentAttrs.appKit.font = bodyFont
             #endif
             let style = BlockQuoteStyle(
                 locale: Locale(identifier: "en_US"),
@@ -451,9 +451,9 @@
             })
 
             #if canImport(UIKit)
-            #expect(normalRun?.uiKit.font == bodyFont)
+                #expect(normalRun?.uiKit.font == bodyFont)
             #elseif canImport(AppKit)
-            #expect(normalRun?.appKit.font == bodyFont)
+                #expect(normalRun?.appKit.font == bodyFont)
             #endif
             #expect(boldRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
         }

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -89,6 +89,7 @@
             #"<p class="quote-inline">RE: <a href="https://example.com/post/1234" rel="nofollow noopener" translate="no" target="_blank"><span class="invisible">https://</span><span class="ellipsis">example.com/post/1</span><span class="invisible">234</span></a></p><p>Hello world</p>"#
 
         @Test func htmlWithInlineQuoteSkipped() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .skipInlineQuotes)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
@@ -97,10 +98,15 @@
         }
 
         @Test func htmlWithInlineQuotePreserved() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == "RE: https://example.com/post/1234\n\nHello world")
+            #expect(renderedDefault.plainString == """
+                RE: https://example.com/post/1234
+
+                Hello world
+                """)
             let attributedString = try AttributedString(
                 markdown: "RE: [https://example.com/post/1234](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -109,10 +115,15 @@
         }
 
         @Test func htmlWithInvisiblesSkipped() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .skipInvisibles)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == "RE: example.com/post/1\n\nHello world")
+            #expect(renderedDefault.plainString == """
+                RE: example.com/post/1
+
+                Hello world
+                """)
             let attributedString = try AttributedString(
                 markdown: "RE: [example.com/post/1](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -121,10 +132,15 @@
         }
 
         @Test func htmlWithEllipsisRendered() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .renderEllipsis)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == "RE: https://example.com/post/1…234\n\nHello world")
+            #expect(renderedDefault.plainString == """
+                RE: https://example.com/post/1…234
+
+                Hello world
+                """)
             let attributedString = try AttributedString(
                 markdown: "RE: [https://example.com/post/1…234](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -133,15 +149,209 @@
         }
 
         @Test func htmlWithShortenedLinks() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .shortenLinks)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == "RE: example.com/post/1…\n\nHello world")
+            #expect(renderedDefault.plainString == """
+                RE: example.com/post/1…
+
+                Hello world
+                """)
             let attributedString = try AttributedString(
                 markdown: "RE: [example.com/post/1…](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
             )
             #expect(renderedDefault.attributedString == attributedString)
+        }
+
+        @Test func htmlWithSingleLevelBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = """
+                <blockquote>
+                    <p>Single level</p>
+                    <p>Second paragraph</p>
+                </blockquote>
+                <p>Regular text</p>
+                """
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Single level
+                ┃	Second paragraph
+                Regular text
+                """)
+        }
+
+        @Test func htmlWithBlockQuoteBasicRendering() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Quoted text</p></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == "┃\tQuoted text")
+            // All text content inside a blockquote is emphasised; the ┃ prefix gutter is not.
+            let quotedRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Quoted text")
+            })
+            #expect(quotedRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+        }
+
+        @Test func htmlWithMultipleParagraphsInBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>First</p><p>Second</p><p>Third</p></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	First
+                ┃	Second
+                ┃	Third
+                """)
+        }
+
+        @Test func htmlWithNestedBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html =
+                "<blockquote><p>Level one</p><blockquote><p>Level two</p></blockquote></blockquote><p>Regular text</p>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Level one
+                ┃	┃	Level two
+                Regular text
+                """)
+        }
+
+        @Test func htmlWithTriplyNestedBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html =
+                "<blockquote><p>Level one</p><blockquote><p>Level two</p><blockquote><p>Level three</p></blockquote></blockquote></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Level one
+                ┃	┃	Level two
+                ┃	┃	┃	Level three
+                """)
+        }
+
+        @Test func htmlWithBlockQuoteContainingEmphasis() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p><em>Emphasized text</em></p></blockquote><p>Regular</p>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Emphasized text
+                Regular
+                """)
+            let emphasizedRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Emphasized text")
+            })
+            #expect(emphasizedRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+        }
+
+        @Test func htmlWithBlockQuoteContainingBold() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p><strong>Bold text</strong></p></blockquote><p>Regular</p>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Bold text
+                Regular
+                """)
+            let boldRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Bold text")
+            })
+            // Blockquote adds .emphasized; <strong> adds .stronglyEmphasized on top.
+            #expect(boldRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+            #expect(boldRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+        }
+
+        @Test func htmlWithBlockQuoteContainingList() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html =
+                "<blockquote><ul><li>Item one</li><li>Item two</li></ul></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	 •	Item one
+                ┃	 •	Item two
+                """)
+        }
+
+        @Test func htmlWithBrOutsideBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<p>Line one<br>Line two</p>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                Line one
+                Line two
+                """)
+        }
+
+        @Test func htmlWithBrInBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Line one<br>Line two</p></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	Line one
+                ┃	Line two
+                """)
+        }
+
+        @Test func htmlWithMultipleBrInBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>First<br>Second<br>Third</p></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	First
+                ┃	Second
+                ┃	Third
+                """)
+        }
+
+        @Test func htmlWithBrInNestedBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><blockquote><p>Line one<br>Line two</p></blockquote></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == """
+                ┃	┃	Line one
+                ┃	┃	Line two
+                """)
+        }
+
+        @Test func htmlWithBlockQuoteContainingPartialEmphasis() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            // Only the middle word is wrapped in <em>, but blockquote emphasises all content uniformly.
+            let html = "<blockquote><p>Normal <em>italic</em> text</p></blockquote>"
+            let rendered = renderer.render(html: html)
+            #expect(rendered.rawString == html)
+            // Every content run — not just the <em> span — carries .emphasized.
+            #expect(rendered.plainString == "┃\tNormal italic text")
+            let normalRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Normal")
+            })
+            let italicRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("italic")
+            })
+            #expect(normalRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+            #expect(italicRun?.inlinePresentationIntent?.contains(.emphasized) == true)
         }
     }
 #endif

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -102,11 +102,12 @@
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == """
-                RE: https://example.com/post/1234
+            #expect(
+                renderedDefault.plainString == """
+                    RE: https://example.com/post/1234
 
-                Hello world
-                """)
+                    Hello world
+                    """)
             let attributedString = try AttributedString(
                 markdown: "RE: [https://example.com/post/1234](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -119,11 +120,12 @@
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .skipInvisibles)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == """
-                RE: example.com/post/1
+            #expect(
+                renderedDefault.plainString == """
+                    RE: example.com/post/1
 
-                Hello world
-                """)
+                    Hello world
+                    """)
             let attributedString = try AttributedString(
                 markdown: "RE: [example.com/post/1](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -136,11 +138,12 @@
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .renderEllipsis)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == """
-                RE: https://example.com/post/1…234
+            #expect(
+                renderedDefault.plainString == """
+                    RE: https://example.com/post/1…234
 
-                Hello world
-                """)
+                    Hello world
+                    """)
             let attributedString = try AttributedString(
                 markdown: "RE: [https://example.com/post/1…234](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -153,11 +156,12 @@
             let renderer = AttributedStringRenderer()
             let renderedDefault = renderer.render(html: htmlWithSpecialMarkup, options: .shortenLinks)
             #expect(renderedDefault.rawString == htmlWithSpecialMarkup)
-            #expect(renderedDefault.plainString == """
-                RE: example.com/post/1…
+            #expect(
+                renderedDefault.plainString == """
+                    RE: example.com/post/1…
 
-                Hello world
-                """)
+                    Hello world
+                    """)
             let attributedString = try AttributedString(
                 markdown: "RE: [example.com/post/1…](https://example.com/post/1234)\n\nHello world",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -177,11 +181,12 @@
                 """
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Single level
-                ┃	Second paragraph
-                Regular text
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Single level
+                    ┃	Second paragraph
+                    Regular text
+                    """)
         }
 
         @Test func htmlWithBlockQuoteBasicRendering() async throws {
@@ -204,11 +209,12 @@
             let html = "<blockquote><p>First</p><p>Second</p><p>Third</p></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	First
-                ┃	Second
-                ┃	Third
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	First
+                    ┃	Second
+                    ┃	Third
+                    """)
         }
 
         @Test func htmlWithNestedBlockQuote() async throws {
@@ -218,11 +224,12 @@
                 "<blockquote><p>Level one</p><blockquote><p>Level two</p></blockquote></blockquote><p>Regular text</p>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Level one
-                ┃	┃	Level two
-                Regular text
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Level one
+                    ┃	┃	Level two
+                    Regular text
+                    """)
         }
 
         @Test func htmlWithTriplyNestedBlockQuote() async throws {
@@ -232,11 +239,12 @@
                 "<blockquote><p>Level one</p><blockquote><p>Level two</p><blockquote><p>Level three</p></blockquote></blockquote></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Level one
-                ┃	┃	Level two
-                ┃	┃	┃	Level three
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Level one
+                    ┃	┃	Level two
+                    ┃	┃	┃	Level three
+                    """)
         }
 
         @Test func htmlWithBlockQuoteContainingEmphasis() async throws {
@@ -245,10 +253,11 @@
             let html = "<blockquote><p><em>Emphasized text</em></p></blockquote><p>Regular</p>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Emphasized text
-                Regular
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Emphasized text
+                    Regular
+                    """)
             let emphasizedRun = rendered.attributedString.runs.first(where: {
                 String(rendered.attributedString[$0.range].characters).contains("Emphasized text")
             })
@@ -261,10 +270,11 @@
             let html = "<blockquote><p><strong>Bold text</strong></p></blockquote><p>Regular</p>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Bold text
-                Regular
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Bold text
+                    Regular
+                    """)
             let boldRun = rendered.attributedString.runs.first(where: {
                 String(rendered.attributedString[$0.range].characters).contains("Bold text")
             })
@@ -280,10 +290,11 @@
                 "<blockquote><ul><li>Item one</li><li>Item two</li></ul></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	 •	Item one
-                ┃	 •	Item two
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	 •	Item one
+                    ┃	 •	Item two
+                    """)
         }
 
         @Test func htmlWithBrOutsideBlockQuote() async throws {
@@ -292,10 +303,11 @@
             let html = "<p>Line one<br>Line two</p>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                Line one
-                Line two
-                """)
+            #expect(
+                rendered.plainString == """
+                    Line one
+                    Line two
+                    """)
         }
 
         @Test func htmlWithBrInBlockQuote() async throws {
@@ -304,10 +316,11 @@
             let html = "<blockquote><p>Line one<br>Line two</p></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	Line one
-                ┃	Line two
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	Line one
+                    ┃	Line two
+                    """)
         }
 
         @Test func htmlWithMultipleBrInBlockQuote() async throws {
@@ -316,11 +329,12 @@
             let html = "<blockquote><p>First<br>Second<br>Third</p></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	First
-                ┃	Second
-                ┃	Third
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	First
+                    ┃	Second
+                    ┃	Third
+                    """)
         }
 
         @Test func htmlWithBrInNestedBlockQuote() async throws {
@@ -329,10 +343,11 @@
             let html = "<blockquote><blockquote><p>Line one<br>Line two</p></blockquote></blockquote>"
             let rendered = renderer.render(html: html)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == """
-                ┃	┃	Line one
-                ┃	┃	Line two
-                """)
+            #expect(
+                rendered.plainString == """
+                    ┃	┃	Line one
+                    ┃	┃	Line two
+                    """)
         }
 
         @Test func htmlWithBlockQuoteContainingPartialEmphasis() async throws {

--- a/Tests/TootSDKTests/AttributedStringRendererTests.swift
+++ b/Tests/TootSDKTests/AttributedStringRendererTests.swift
@@ -10,6 +10,18 @@
     import Testing
     import TootSDK
 
+    #if canImport(UIKit)
+        import UIKit
+
+        typealias _TestFont = UIFont
+        typealias _TestColor = UIColor
+    #elseif canImport(AppKit)
+        import AppKit
+
+        typealias _TestFont = NSFont
+        typealias _TestColor = NSColor
+    #endif
+
     @Suite struct AttributedStringRendererTests {
 
         @Test func testRendersPostWithoutEmojis() async throws {
@@ -20,7 +32,7 @@
 
                 As some of you may know, @konstantin and @davidgarywood have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
 
-                The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
+                The main purpose of TootSDK is to take care of the \u{201C}boring\u{201D} and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
                 """
             let attributedString = try AttributedString(
                 markdown: """
@@ -28,7 +40,7 @@
 
                     As some of you may know, [@konstantin](https://m.iamkonstantin.eu/users/konstantin) and [@davidgarywood](https://social.davidgarywood.com/@davidgarywood) have been working on an open-source swift package library designed to help other devs make apps that interact with the fediverse (like Mastodon, Pleroma, Pixelfed etc). We call it TootSDK ✨!
 
-                    The main purpose of TootSDK is to take care of the “boring” and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
+                    The main purpose of TootSDK is to take care of the \u{201C}boring\u{201D} and complicated parts of the Mastodon API, so you can focus on crafting the actual app experience.
                     """,
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
             )
@@ -169,6 +181,8 @@
             #expect(renderedDefault.attributedString == attributedString)
         }
 
+        private let enUS = BlockQuoteStyle(locale: Locale(identifier: "en_US"))
+
         @Test func htmlWithSingleLevelBlockQuote() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
@@ -179,42 +193,28 @@
                 </blockquote>
                 <p>Regular text</p>
                 """
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
             #expect(
-                rendered.plainString == """
-                    ┃	Single level
-                    ┃	Second paragraph
-                    Regular text
-                    """)
+                rendered.plainString == "\u{201C}Single level\nSecond paragraph\u{201D}\nRegular text")
         }
 
         @Test func htmlWithBlockQuoteBasicRendering() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p>Quoted text</p></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(rendered.plainString == "┃\tQuoted text")
-            // All text content inside a blockquote is emphasised; the ┃ prefix gutter is not.
-            let quotedRun = rendered.attributedString.runs.first(where: {
-                String(rendered.attributedString[$0.range].characters).contains("Quoted text")
-            })
-            #expect(quotedRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+            #expect(rendered.plainString == "\u{201C}Quoted text\u{201D}")
         }
 
         @Test func htmlWithMultipleParagraphsInBlockQuote() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p>First</p><p>Second</p><p>Third</p></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	First
-                    ┃	Second
-                    ┃	Third
-                    """)
+            #expect(rendered.plainString == "\u{201C}First\nSecond\nThird\u{201D}")
         }
 
         @Test func htmlWithNestedBlockQuote() async throws {
@@ -222,14 +222,10 @@
             let renderer = AttributedStringRenderer()
             let html =
                 "<blockquote><p>Level one</p><blockquote><p>Level two</p></blockquote></blockquote><p>Regular text</p>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
             #expect(
-                rendered.plainString == """
-                    ┃	Level one
-                    ┃	┃	Level two
-                    Regular text
-                    """)
+                rendered.plainString == "\u{201C}Level one\n\u{2018}Level two\u{2019}\u{201D}\nRegular text")
         }
 
         @Test func htmlWithTriplyNestedBlockQuote() async throws {
@@ -237,27 +233,20 @@
             let renderer = AttributedStringRenderer()
             let html =
                 "<blockquote><p>Level one</p><blockquote><p>Level two</p><blockquote><p>Level three</p></blockquote></blockquote></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
             #expect(
-                rendered.plainString == """
-                    ┃	Level one
-                    ┃	┃	Level two
-                    ┃	┃	┃	Level three
-                    """)
+                rendered.plainString
+                    == "\u{201C}Level one\n\u{2018}Level two\n\u{201C}Level three\u{201D}\u{2019}\u{201D}")
         }
 
         @Test func htmlWithBlockQuoteContainingEmphasis() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p><em>Emphasized text</em></p></blockquote><p>Regular</p>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	Emphasized text
-                    Regular
-                    """)
+            #expect(rendered.plainString == "\u{201C}Emphasized text\u{201D}\nRegular")
             let emphasizedRun = rendered.attributedString.runs.first(where: {
                 String(rendered.attributedString[$0.range].characters).contains("Emphasized text")
             })
@@ -268,18 +257,12 @@
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p><strong>Bold text</strong></p></blockquote><p>Regular</p>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	Bold text
-                    Regular
-                    """)
+            #expect(rendered.plainString == "\u{201C}Bold text\u{201D}\nRegular")
             let boldRun = rendered.attributedString.runs.first(where: {
                 String(rendered.attributedString[$0.range].characters).contains("Bold text")
             })
-            // Blockquote adds .emphasized; <strong> adds .stronglyEmphasized on top.
-            #expect(boldRun?.inlinePresentationIntent?.contains(.emphasized) == true)
             #expect(boldRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
         }
 
@@ -288,13 +271,9 @@
             let renderer = AttributedStringRenderer()
             let html =
                 "<blockquote><ul><li>Item one</li><li>Item two</li></ul></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	 •	Item one
-                    ┃	 •	Item two
-                    """)
+            #expect(rendered.plainString == "\u{201C} \u{2022}\tItem one\n \u{2022}\tItem two\u{201D}")
         }
 
         @Test func htmlWithBrOutsideBlockQuote() async throws {
@@ -314,59 +293,207 @@
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p>Line one<br>Line two</p></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	Line one
-                    ┃	Line two
-                    """)
+            #expect(rendered.plainString == "\u{201C}Line one\nLine two\u{201D}")
         }
 
         @Test func htmlWithMultipleBrInBlockQuote() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><p>First<br>Second<br>Third</p></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	First
-                    ┃	Second
-                    ┃	Third
-                    """)
+            #expect(rendered.plainString == "\u{201C}First\nSecond\nThird\u{201D}")
         }
 
         @Test func htmlWithBrInNestedBlockQuote() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
             let html = "<blockquote><blockquote><p>Line one<br>Line two</p></blockquote></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            #expect(
-                rendered.plainString == """
-                    ┃	┃	Line one
-                    ┃	┃	Line two
-                    """)
+            #expect(rendered.plainString == "\u{201C}\u{2018}Line one\nLine two\u{2019}\u{201D}")
         }
 
         @Test func htmlWithBlockQuoteContainingPartialEmphasis() async throws {
             guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
             let renderer = AttributedStringRenderer()
-            // Only the middle word is wrapped in <em>, but blockquote emphasises all content uniformly.
             let html = "<blockquote><p>Normal <em>italic</em> text</p></blockquote>"
-            let rendered = renderer.render(html: html)
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
             #expect(rendered.rawString == html)
-            // Every content run — not just the <em> span — carries .emphasized.
-            #expect(rendered.plainString == "┃\tNormal italic text")
-            let normalRun = rendered.attributedString.runs.first(where: {
-                String(rendered.attributedString[$0.range].characters).contains("Normal")
-            })
+            #expect(rendered.plainString == "\u{201C}Normal italic text\u{201D}")
             let italicRun = rendered.attributedString.runs.first(where: {
                 String(rendered.attributedString[$0.range].characters).contains("italic")
             })
-            #expect(normalRun?.inlinePresentationIntent?.contains(.emphasized) == true)
             #expect(italicRun?.inlinePresentationIntent?.contains(.emphasized) == true)
+        }
+
+        @Test func htmlWithEmptyBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote></blockquote>"
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
+            #expect(rendered.rawString == html)
+            #expect(rendered.plainString == "")
+        }
+
+        // MARK: - Locale tests
+
+        @Test func htmlWithFrenchBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Bonjour</p></blockquote>"
+            let style = BlockQuoteStyle(locale: Locale(identifier: "fr_FR"))
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+            #expect(rendered.plainString == "\u{AB}\u{00A0}Bonjour\u{00A0}\u{BB}")
+        }
+
+        @Test func htmlWithGermanBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Hallo</p></blockquote>"
+            let style = BlockQuoteStyle(locale: Locale(identifier: "de_DE"))
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+            #expect(rendered.plainString == "\u{201E}Hallo\u{201C}")
+        }
+
+        @Test func htmlWithJapaneseBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>こんにちは</p></blockquote>"
+            let style = BlockQuoteStyle(locale: Locale(identifier: "ja_JP"))
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+            #expect(rendered.plainString == "\u{300C}こんにちは\u{300D}")
+        }
+
+        @Test func htmlWithArabicBlockQuote() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>مرحبا</p></blockquote>"
+            let style = BlockQuoteStyle(locale: Locale(identifier: "ar_SA"))
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+            let plain = rendered.plainString
+            #expect(plain.contains("مرحبا"))
+            let hasQuoteMarks = !plain.hasPrefix("مرحبا")
+            #expect(hasQuoteMarks)
+        }
+
+        @Test func htmlWithNestedBlockQuoteAlternation() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><blockquote><p>inner</p></blockquote></blockquote>"
+            let rendered = renderer.render(html: html, blockQuoteStyle: enUS)
+            #expect(rendered.plainString == "\u{201C}\u{2018}inner\u{2019}\u{201D}")
+        }
+
+        // MARK: - BlockQuoteStyle attribute tests
+
+        @Test func htmlWithMarkAttributesAppliedToGlyphsOnly() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Body text</p></blockquote>"
+            var markAttrs = AttributeContainer()
+            #if canImport(UIKit)
+            markAttrs.uiKit.foregroundColor = _TestColor.red
+            #elseif canImport(AppKit)
+            markAttrs.appKit.foregroundColor = _TestColor.red
+            #endif
+            let style = BlockQuoteStyle(
+                locale: Locale(identifier: "en_US"),
+                markAttributes: markAttrs
+            )
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+
+            let openRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters) == "\u{201C}"
+            })
+            let closeRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters) == "\u{201D}"
+            })
+            let bodyRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Body text")
+            })
+
+            #if canImport(UIKit)
+            #expect(openRun?.uiKit.foregroundColor == _TestColor.red)
+            #expect(closeRun?.uiKit.foregroundColor == _TestColor.red)
+            #expect(bodyRun?.uiKit.foregroundColor != _TestColor.red)
+            #elseif canImport(AppKit)
+            #expect(openRun?.appKit.foregroundColor == _TestColor.red)
+            #expect(closeRun?.appKit.foregroundColor == _TestColor.red)
+            #expect(bodyRun?.appKit.foregroundColor != _TestColor.red)
+            #endif
+        }
+
+        @Test func htmlWithContentAttributesFontAppliedToBody() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let renderer = AttributedStringRenderer()
+            let html = "<blockquote><p>Normal <strong>bold</strong> text</p></blockquote>"
+            let bodyFont = _TestFont.systemFont(ofSize: 14)
+            var contentAttrs = AttributeContainer()
+            #if canImport(UIKit)
+            contentAttrs.uiKit.font = bodyFont
+            #elseif canImport(AppKit)
+            contentAttrs.appKit.font = bodyFont
+            #endif
+            let style = BlockQuoteStyle(
+                locale: Locale(identifier: "en_US"),
+                contentAttributes: contentAttrs
+            )
+            let rendered = renderer.render(html: html, blockQuoteStyle: style)
+
+            let normalRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("Normal")
+            })
+            let boldRun = rendered.attributedString.runs.first(where: {
+                String(rendered.attributedString[$0.range].characters).contains("bold")
+            })
+
+            #if canImport(UIKit)
+            #expect(normalRun?.uiKit.font == bodyFont)
+            #elseif canImport(AppKit)
+            #expect(normalRun?.appKit.font == bodyFont)
+            #endif
+            #expect(boldRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+        }
+
+        // MARK: - inlineQuotation helper tests
+
+        @Test func inlineQuotationEnglishDefault() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let result = AttributedString.inlineQuotation("hello", locale: Locale(identifier: "en_US"))
+            #expect(String(result.characters) == "\u{201C}hello\u{201D}")
+        }
+
+        @Test func inlineQuotationLevel1Alternation() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let result = AttributedString.inlineQuotation("hello", level: 1, locale: Locale(identifier: "en_US"))
+            #expect(String(result.characters) == "\u{2018}hello\u{2019}")
+        }
+
+        @Test func inlineQuotationFrenchNBSP() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let result = AttributedString.inlineQuotation("bonjour", locale: Locale(identifier: "fr_FR"))
+            #expect(String(result.characters) == "\u{AB}\u{00A0}bonjour\u{00A0}\u{BB}")
+        }
+
+        @Test func inlineQuotationAttributedStringOverload() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            var content = AttributedString("hello")
+            content.inlinePresentationIntent = .emphasized
+            let result = AttributedString.inlineQuotation(content, locale: Locale(identifier: "en_US"))
+            #expect(String(result.characters) == "\u{201C}hello\u{201D}")
+            let run = result.runs.first(where: {
+                String(result[$0.range].characters) == "hello"
+            })
+            #expect(run?.inlinePresentationIntent?.contains(.emphasized) == true)
+        }
+
+        @Test func inlineQuotationStringOverload() async throws {
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+            let result = AttributedString.inlineQuotation("world", locale: Locale(identifier: "en_US"))
+            #expect(String(result.characters) == "\u{201C}world\u{201D}")
         }
     }
 #endif


### PR DESCRIPTION
This pull request adds support for block quotes by rendering them with┃character prefix and in italics. Not 100% sure if this character is a good choice but I didn't find anything better. **I'm open for better suggestions.**

Additional small change is to prefix bullet points with a single space. It's a minor change but somehow without it the lists felt odd to me.

Example from my app how block quotes look like with this pull request
<img height="580" alt="Simulator Screenshot - iPhone 17 - 2026-04-22 at 20 01 24" src="https://github.com/user-attachments/assets/9dcb33a5-6756-4f3b-a23e-95ecaff26706" />
