### PR TITLE
Add dedicated parameters for rescheduling posts

### DIFF
--- a/Sources/TootSDK/Models/ReschedulePostParams.swift
+++ b/Sources/TootSDK/Models/ReschedulePostParams.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Parameters to update a scheduled post's publication date.
+public struct ReschedulePostParams: Sendable {
+
+    /// Date and time at which the post will be published.
+    public let scheduledAt: Date
+
+    /// Creates parameters to update a scheduled post's publication date.
+    ///
+    /// - Parameter scheduledAt: Date and time at which the post will be published. Must be at least five minutes in the future.
+    public init(scheduledAt: Date) {
+        self.scheduledAt = scheduledAt
+    }
+}
+
+extension ReschedulePostParams {
+    func queryItems() throws -> [URLQueryItem] {
+        if scheduledAt < Date().addingTimeInterval(TimeInterval(5.0 * 60.0)) {
+            throw TootSDKError.invalidParameter(
+                parameterName: "scheduledAt",
+                reason: "The scheduled date must be at least 5 minutes into the future."
+            )
+        }
+
+        return [URLQueryItem(name: "scheduled_at", value: TootEncoder.dateFormatter.string(from: scheduledAt))]
+    }
+}

--- a/Sources/TootSDK/TootClient/TootClient+ScheduledPost.swift
+++ b/Sources/TootSDK/TootClient/TootClient+ScheduledPost.swift
@@ -82,20 +82,44 @@ extension TootClient {
         return try await fetch(ScheduledPost.self, req)
     }
 
-    /// Edit a given post to change its text, sensitivity, media attachments, or poll. Note that editing a poll’s options will reset the votes.
-    /// - Parameter id: the ID of the post to be changed
-    /// - Parameter params: the updated content of the post to be posted
-    /// - Returns: the post after the update
-    public func updateScheduledPostDate(id: String, _ params: ScheduledPostParams) async throws -> ScheduledPost? {
+    /// Update a scheduled post's publication date.
+    /// - Parameters:
+    ///   - id: The ID of the scheduled post to update.
+    ///   - params: Parameters containing the new publication date.
+    /// - Returns: The scheduled post after the update.
+    public func updateScheduledPostDate(id: String, _ params: ReschedulePostParams) async throws -> ScheduledPost? {
+        let response = try await updateScheduledPostDateRaw(id: id, params)
+        return response.data
+    }
+
+    /// Update a scheduled post's publication date with HTTP response metadata.
+    /// - Parameters:
+    ///   - id: The ID of the scheduled post to update.
+    ///   - params: Parameters containing the new publication date.
+    /// - Returns: TootResponse containing the scheduled post after the update and HTTP metadata.
+    public func updateScheduledPostDateRaw(id: String, _ params: ReschedulePostParams) async throws -> TootResponse<ScheduledPost?> {
         try requireFeature(.scheduledPost)
-        let requestParams = try ScheduledPostRequest(from: params)
         let req = try HTTPRequestBuilder {
             $0.url = getURL(["api", "v1", "scheduled_statuses", id])
             $0.method = .put
-            $0.body = try .multipart(requestParams, boundary: UUID().uuidString)
+            $0.body = try .form(queryItems: params.queryItems())
         }
 
-        return try await fetch(ScheduledPost.self, req)
+        return try await fetchRaw(ScheduledPost?.self, req)
+    }
+
+    /// Update a scheduled post's publication date.
+    /// - Parameters:
+    ///   - id: The ID of the scheduled post to update.
+    ///   - params: The scheduled post parameters containing the new publication date.
+    /// - Returns: The scheduled post after the update.
+    @available(*, deprecated, message: "Use updateScheduledPostDate(id:_:) with ReschedulePostParams instead.")
+    public func updateScheduledPostDate(id: String, _ params: ScheduledPostParams) async throws -> ScheduledPost? {
+        guard let scheduledAt = params.scheduledAt else {
+            throw TootSDKError.missingParameter(parameterName: "scheduledAt")
+        }
+
+        return try await updateScheduledPostDate(id: id, ReschedulePostParams(scheduledAt: scheduledAt))
     }
 
     /// Deletes a single scheduled post

--- a/Tests/TootSDKTests/ScheduledPostTests.swift
+++ b/Tests/TootSDKTests/ScheduledPostTests.swift
@@ -6,6 +6,30 @@ import XCTest
 @testable import TootSDK
 
 final class ScheduledPostTests: XCTestCase {
+    func testReschedulePostCreatesScheduledAtQueryItem() throws {
+        // arrange
+        let date = Date().addingTimeInterval(TimeInterval(60.0 * 60.0))
+        let params = ReschedulePostParams(scheduledAt: date)
+
+        // act
+        let queryItems = try params.queryItems()
+
+        // assert
+        XCTAssertEqual(queryItems, [URLQueryItem(name: "scheduled_at", value: TootEncoder.dateFormatter.string(from: date))])
+    }
+
+    func testReschedulePostValidatesScheduledAtTooSoon() throws {
+        // arrange
+        let params = ReschedulePostParams(scheduledAt: Date().addingTimeInterval(TimeInterval(4.5 * 60.0)))
+
+        // act
+        XCTAssertThrowsError(try params.queryItems()) { error in
+            XCTAssertEqual(
+                error as? TootSDKError,
+                TootSDKError.invalidParameter(parameterName: "scheduledAt", reason: "The scheduled date must be at least 5 minutes into the future."))
+        }
+    }
+
     func testScheduledPostValidatesScheduledAtRequired() throws {
         // arrange
         let params = ScheduledPostParams(mediaIds: [], visibility: .public)


### PR DESCRIPTION
This closes #267

`updateScheduledPostDate` currently accepts `ScheduledPostParams` which includes unrelated parameters like visibility even though the endpoint only needs `scheduled_at`

This PR adds a smaller `ReschedulePostParams` type containing only `scheduledAt` and updates the method to use URL-form encoding

- preserved existing five-minute date validation
- adds `updateScheduledPostDateRaw`
- deprecates the existing overload without breaking current callers
- adds tests for form encoding and date validation